### PR TITLE
add keep_most_recent to strategy

### DIFF
--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -62,6 +62,9 @@ class ModelProtocol(Protocol):
     def fit(self, train_x: torch.Tensor, train_y: torch.Tensor) -> None:
         pass
 
+    def update(self, train_x: torch.Tensor, train_y: torch.Tensor) -> None:
+        pass
+
 
 class AEPsychMixin:
     """Mixin class that provides AEPsych-specific utility methods."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,7 @@ class ConfigTestCase(unittest.TestCase):
         generator = OptimizeAcqfGenerator
         n_trials = 20
         min_post_range = 0.01
+        keep_most_recent = 10
 
         [MCLevelSetEstimation]
         beta = 3.98
@@ -94,9 +95,11 @@ class ConfigTestCase(unittest.TestCase):
 
         self.assertEqual(strat.strat_list[0].min_outcome_occurrences, 5)
         self.assertEqual(strat.strat_list[0].min_post_range, None)
+        self.assertEqual(strat.strat_list[0].keep_most_recent, None)
 
         self.assertEqual(strat.strat_list[1].min_outcome_occurrences, 1)
         self.assertEqual(strat.strat_list[1].min_post_range, 0.01)
+        self.assertEqual(strat.strat_list[1].keep_most_recent, 10)
 
     def test_missing_config_file(self):
         config_file = "../configs/does_not_exist.ini"


### PR DESCRIPTION
Summary: Adds an option to strategies to only keep data from the most recent X trials

Differential Revision: D36113490

