### PR TITLE
Minor fixes to max fit and gen time

### DIFF
--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -6,14 +6,14 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-from typing import Mapping, Optional, Tuple, Union, Protocol, List
+from typing import Any, List, Mapping, Optional, Protocol, Tuple, Union
 
 import numpy as np
 import torch
 from aepsych.utils import dim_grid, get_jnd_multid, make_scaled_sobol
+from botorch.models.approximate_gp import _select_inducing_points
 from scipy.cluster.vq import kmeans2
 from scipy.optimize import minimize
-from botorch.models.approximate_gp import _select_inducing_points
 
 
 torch.set_default_dtype(torch.double)  # TODO: find a better way to prevent type errors
@@ -59,10 +59,12 @@ class ModelProtocol(Protocol):
     def dim_grid(self, gridsize: int = 30) -> torch.Tensor:
         pass
 
-    def fit(self, train_x: torch.Tensor, train_y: torch.Tensor) -> None:
+    def fit(self, train_x: torch.Tensor, train_y: torch.Tensor, **kwargs: Any) -> None:
         pass
 
-    def update(self, train_x: torch.Tensor, train_y: torch.Tensor) -> None:
+    def update(
+        self, train_x: torch.Tensor, train_y: torch.Tensor, **kwargs: Any
+    ) -> None:
         pass
 
 
@@ -117,6 +119,7 @@ class AEPsychMixin:
         Returns:
             Tuple[float, np.ndarray]: Tuple containing the min and its location (argmin).
         """
+
         locked_dims = locked_dims or {}
 
         def signed_model(x, sign=1):

--- a/aepsych/models/gp_classification.py
+++ b/aepsych/models/gp_classification.py
@@ -86,7 +86,6 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP, GPyTorchModel):
         if likelihood is None:
             likelihood = BernoulliLikelihood()
 
-        self.max_fit_time = max_fit_time
         self.inducing_point_method = inducing_point_method
         # initialize to sobol before we have data
         inducing_points = self._select_inducing_points(method="sobol")
@@ -232,12 +231,14 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP, GPyTorchModel):
         mll = gpytorch.mlls.VariationalELBO(self.likelihood, self, n)
         self.train()
 
-        if self.max_fit_time is not None:
+        max_fit_time = kwargs.pop("max_fit_time", self.max_fit_time)
+
+        if max_fit_time is not None:
             # figure out how long evaluating a single samp
             starttime = time.time()
             _ = mll(self(train_x), train_y)
             single_eval_time = time.time() - starttime
-            n_eval = self.max_fit_time // single_eval_time
+            n_eval = max_fit_time // single_eval_time
             options = {"maxfun": n_eval}
             logger.info(f"fit maxfun is {n_eval}")
 

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -10,10 +10,9 @@ from typing import Callable, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
-from scipy.stats import norm
-
 from aepsych.strategy import Strategy
 from aepsych.utils import get_lse_contour, get_lse_interval
+from scipy.stats import norm
 
 
 def plot_strat(
@@ -246,6 +245,9 @@ def _plot_strat_2d(
     x, y = strat.x, strat.y
     assert x is not None and y is not None, "No data to plot!"
 
+    # make sure the model is fit well if we've been limiting fit time
+    strat.model.fit(train_x=x, train_y=y, max_fit_time=None)
+
     grid = strat.model.dim_grid(gridsize=gridsize)
     fmean, _ = strat.model.predict(grid)
     phimean = norm.cdf(fmean.reshape(gridsize, gridsize).detach().numpy()).T
@@ -270,7 +272,7 @@ def _plot_strat_2d(
     if logx:
         locs = np.arange(strat.lb[0], strat.ub[0])
         ax.set_xticks(ticks=locs)
-        ax.set_xticklabels(2.0 ** locs)
+        ax.set_xticklabels(2.0**locs)
 
     ax.plot(x[y == 0, 0], x[y == 0, 1], "ro", alpha=0.7, label=no_label)
     ax.plot(x[y == 1, 0], x[y == 1, 1], "bo", alpha=0.7, label=yes_label)


### PR DESCRIPTION
Summary: Removes hardcoded q=1 in `gen`. Makes max_fit_time a kwarg we can pass to fit so we can use small maxes with human in the loop and refit in the end with no limites.

Differential Revision: D36220338

