### PR TITLE
Objective inverse links and more numerically stable Gumbel

### DIFF
--- a/tests/acquisition/test_objective.py
+++ b/tests/acquisition/test_objective.py
@@ -39,3 +39,6 @@ class FloorLinkTests(unittest.TestCase):
         our_link = our_objective(floor=floor)
         our_answer = our_link(torch.Tensor(x).unsqueeze(-1))
         self.assertTrue(np.allclose(scipy_answer, our_answer.numpy()))
+
+        our_inverse = our_link.inverse(our_answer)
+        self.assertTrue(np.allclose(x, our_inverse.numpy()))


### PR DESCRIPTION
Summary: Inverse links are useful for e.g. threshold finding (we hardcode `norm.ppf` in a bunch of places and we shouldn't now that we have flexible links).

Differential Revision: D36292770

