### PR TITLE
n_trials backwards compatibility

### DIFF
--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -237,6 +237,14 @@ class Strategy(object):
     def can_fit(self):
         return self.has_model and self.x is not None and self.y is not None
 
+    @property
+    def n_trials(self):
+        warnings.warn(
+            "'n_trials' is deprecated and will be removed in a future release. Specify 'min_asks' instead.",
+            DeprecationWarning,
+        )
+        return self.min_asks
+
     def add_data(self, x, y):
         self.x, self.y, self.n = self.normalize_inputs(x, y)
         self._model_is_fresh = False
@@ -307,7 +315,8 @@ class Strategy(object):
         n_trials = config.getint(name, "n_trials", fallback=None)
         if n_trials is not None:
             warnings.warn(
-                "'n_trials' is deprecated and will be removed in a future release. Specify 'min_asks' instead."
+                "'n_trials' is deprecated and will be removed in a future release. Specify 'min_asks' instead.",
+                DeprecationWarning,
             )
             min_asks = n_trials
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -7,12 +7,12 @@
 
 import unittest
 from unittest.mock import MagicMock
-from aepsych.models.gp_classification import GPClassificationModel
 
 import numpy as np
 import torch
 from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
 from aepsych.generators import MonotonicRejectionGenerator, SobolGenerator
+from aepsych.models.gp_classification import GPClassificationModel
 from aepsych.models.monotonic_rejection_gp import MonotonicRejectionGP
 from aepsych.strategy import SequentialStrategy, Strategy
 
@@ -156,6 +156,22 @@ class TestSequenceGenerators(unittest.TestCase):
             self.assertTrue(
                 torch.equal(self.strat.model.train_inputs[0], data[lb : i + 1])
             )
+
+    def test_n_trials_deprecation(self):
+        seed = 1
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+        lb = [-1, -1]
+        ub = [1, 1]
+
+        self.strat = Strategy(
+            generator=SobolGenerator(lb=lb, ub=ub),
+            min_asks=50,
+            lb=lb,
+            ub=ub,
+        )
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(self.strat.n_trials, 50)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: This retains compatibility with other code that expects `n_trials` property, with a warning. We'll eventually deprecate but this warning will let us catch where this comes up. TODO should probably grep the codebase for `n_trials` and fix any that we want to fix.

Differential Revision: D36945423

