### PR TITLE
Support ragged no-op configs for benchmark

### DIFF
--- a/aepsych/benchmark/benchmark.py
+++ b/aepsych/benchmark/benchmark.py
@@ -137,7 +137,7 @@ class Benchmark:
         config_dict: Dict[str, Any],
         seed: int,
         rep: int,
-    ) -> Tuple[List[Dict[str, Any]], SequentialStrategy]:
+    ) -> Tuple[List[Dict[str, Any]], Union[SequentialStrategy, None]]:
         """Run one simulated experiment.
 
         Args:
@@ -156,6 +156,11 @@ class Benchmark:
         config_dict["common"]["ub"] = str(problem.ub.tolist())
         config_dict["problem"] = problem.metadata
         materialized_config = self.materialize_config(config_dict)
+
+        # no-op config
+        is_invalid = materialized_config["common"].get("invalid_config", False)
+        if is_invalid:
+            return [{}], None
 
         strat, flatconfig = self.make_strat_and_flatconfig(materialized_config)
 
@@ -212,7 +217,8 @@ class Benchmark:
         ):
             local_seed = i + self.seed
             results, _ = self.run_experiment(problem, config, seed=local_seed, rep=rep)
-            self._log.extend(results)
+            if results != [{}]:
+                self._log.extend(results)
 
     def flatten_config(self, config: Config) -> Dict[str, str]:
         """Flatten a config object for logging.

--- a/aepsych/benchmark/pathos_benchmark.py
+++ b/aepsych/benchmark/pathos_benchmark.py
@@ -77,7 +77,7 @@ class PathosBenchmark(Benchmark):
         config_dict: Dict[str, Any],
         seed: int,
         rep: int,
-    ) -> Tuple[List[Dict[str, Any]], SequentialStrategy]:
+    ) -> Tuple[List[Dict[str, Any]], Union[SequentialStrategy, None]]:
         """Run one simulated experiment.
 
         Args:
@@ -166,6 +166,8 @@ class PathosBenchmark(Benchmark):
             item = self.futures.pop()
             if wait or item.ready():
                 results = item.get()
+                # filter out empty results from invalid configs
+                results = [r for r in results if r != {}]
                 if isinstance(results, list):
                     self._log.extend(results)
             else:

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -66,7 +66,7 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
                     # if this thing is configured
                     if k in full_section.keys():
                         # if it's an object make it an object
-                        if full_section[k] in config.registered_names.keys():
+                        if full_section[k] in Config.registered_names.keys():
                             extra_acqf_args[k] = config.getobj(acqf_name, k)
                         else:
                             # otherwise try a float


### PR DESCRIPTION
Summary: This is useful when some benchmark configurations are invalid

Differential Revision: D36214512

