### PR TITLE
Make lookahead acquisition compatible with posterior transforms

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -176,7 +176,8 @@ class ConfigTestCase(unittest.TestCase):
         )
         self.assertTrue(strat.strat_list[1].generator.acqf is qNoisyExpectedImprovement)
         self.assertTrue(
-            set(strat.strat_list[1].generator.acqf_kwargs.keys()) == {"objective"}
+            set(strat.strat_list[1].generator.acqf_kwargs.keys())
+            == {"objective", "posterior_transform"}
         )
         self.assertTrue(
             isinstance(
@@ -528,6 +529,7 @@ class ConfigTestCase(unittest.TestCase):
 
         config_file = "../configs/pairwise_opt_example.ini"
         config_file = os.path.join(os.path.dirname(__file__), config_file)
+
         server.configure(config_fnames=[config_file])
         strat = server.strat
 
@@ -537,7 +539,8 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(isinstance(strat.strat_list[1].model, PairwiseProbitModel))
         self.assertTrue(strat.strat_list[1].generator.acqf is qNoisyExpectedImprovement)
         self.assertTrue(
-            set(strat.strat_list[1].generator.acqf_kwargs.keys()) == {"objective"}
+            set(strat.strat_list[1].generator.acqf_kwargs.keys())
+            == {"objective", "posterior_transform"}
         )
         self.assertTrue(
             isinstance(


### PR DESCRIPTION
Summary: More BoTorch API compatibility fixes, this time for lookahead LSE acquisition.

Differential Revision: D36333559

