### PR TITLE
make installation and starting the server easier

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -19,8 +19,8 @@ import numpy as np
 import pandas as pd
 import torch
 from aepsych.config import Config
-from aepsych.strategy import SequentialStrategy
 from aepsych.server.sockets import DummySocket, createSocket
+from aepsych.strategy import SequentialStrategy
 
 logger = utils_logging.getLogger(logging.INFO)
 
@@ -845,7 +845,7 @@ def start_server(server_class, args):
         raise RuntimeError(e)
 
 
-def main(server_class):
+def main(server_class=AEPsychServer):
     args = parse_argument()
     if args.logs:
         # overide logger path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,57 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from os import path
+import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, "Readme.md"), encoding="utf-8") as f:
-    long_description = f.read()
+root_dir = os.path.dirname(__file__)
+
+REQUIRES = [
+    "matplotlib",
+    "torch",
+    "pyzmq==19.0.2",
+    "scipy",
+    "sklearn",
+    "gpytorch>=1.4",
+    "botorch>=0.6.1",
+    "SQLAlchemy",
+    "dill",
+    "pandas",
+    "tqdm",
+    "pathos",
+]
+
+DEV_REQUIRES = [
+    "coverage",
+    "flake8",
+    "black",
+    "numpy>=1.20, " "sqlalchemy-stubs",  # for mypy stubs
+    "mypy",
+    "parameterized",
+]
+
+with open(os.path.join(root_dir, "README.md"), "r") as fh:
+    long_description = fh.read()
 
 setup(
     name="aepsych",
-    version="0.1",
+    version="0.1.0",
+    python_requires=">=3.8",
     packages=find_packages(),
+    description="Adaptive experimetation for psychophysics",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    install_requires=REQUIRES,
+    entry_points={
+        "console_scripts": [
+            "aepsych_server = aepsych.server.server:main",
+        ],
+    },
+)
+
+extras_require = (
+    {
+        "dev": DEV_REQUIRES,
+    },
 )


### PR DESCRIPTION
Summary: These changes will allow aepsych to be hosted on pypi and installed from pip; also allows a server to be started with a simple command

Differential Revision: D37176812

