### PR TITLE
Added Missing copyright header

### DIFF
--- a/tutorials/minimal_python_example.ipynb
+++ b/tutorials/minimal_python_example.ipynb
@@ -1,5 +1,3 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved
-
 {
     "cells": [
         {

--- a/website/static/js/cookie_consent.js
+++ b/website/static/js/cookie_consent.js
@@ -1,3 +1,5 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates. All Rights Reserved
+
 window.addEventListener('load', function() {
     const cookieConsentContainer = document.querySelector(".cookie-container");
     const cookieConsentBtn = document.querySelector(".cookie-btn");


### PR DESCRIPTION
Summary:
- added copy right header to cookie_consent event listener
- added the tutorials to the copyright header exemption as the header is not valid JSON and causes an error when building website.

Differential Revision: D37489815

