### PR TITLE
ShowOptimal Bug Fix

### DIFF
--- a/clients/unity/Packages/com.frl.aepsych/Runtime/Experiment.cs
+++ b/clients/unity/Packages/com.frl.aepsych/Runtime/Experiment.cs
@@ -537,11 +537,13 @@ namespace AEPsych
                 if (newStatus == AEPsychClient.ClientStatus.QuerySent)
                 {
                     SetState(ExperimentState.WaitingForQueryResponse);
-                    queryModel.QueryEnabled(false);
+                    if (useModelExploration)
+                        queryModel.QueryEnabled(false);
                 }
                 else
                 {
-                    queryModel.QueryEnabled(true);
+                    if (useModelExploration)
+                        queryModel.QueryEnabled(true);
                 }
             }
             else if (_experimentState == ExperimentState.WaitingForTellResponse)
@@ -848,7 +850,7 @@ namespace AEPsych
         }
 
         /// <summary>
-        /// Resumes a paused experiment by re-enabling the Client state change listener and 
+        /// Resumes a paused experiment by re-enabling the Client state change listener and
         /// starting a new trial. If the experiment is uninitialized, it will initialize it.
         ///
         /// </summary>


### PR DESCRIPTION
Summary: Fixes client crash when calling ShowOptimal without enabling Model Exploration

Reviewed By: tymmsc

Differential Revision: D37706864

