### PR TITLE
Async

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -83,8 +83,8 @@ class AEPsychServer(object):
 
 
     def handle_queue(self):
-        request = self.queue[0]
         if self.queue:
+            request = self.queue[0]
             try:
                 if "version" in request.keys():
                     result = self.versioned_handler(request)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -56,7 +56,6 @@ class ServerTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.s.cleanup()
-
         # cleanup the db
         if self.s.db is not None:
             self.s.db.delete_db()
@@ -300,7 +299,7 @@ class ServerTestCase(unittest.TestCase):
 
     def test_serve_versioned_handler(self):
         request = {"version": 0}
-        self.s.socket.receive = MagicMock(return_value=request)
+        self.s.queue.append(request)
         self.s.versioned_handler = MagicMock()
         self.s.unversioned_handler = MagicMock()
         self.s.exit_server_loop = True
@@ -310,7 +309,7 @@ class ServerTestCase(unittest.TestCase):
 
     def test_serve_unversioned_handler(self):
         request = {}
-        self.s.socket.receive = MagicMock(return_value=request)
+        self.s.queue.append(request)
         self.s.versioned_handler = MagicMock()
         self.s.unversioned_handler = MagicMock()
         self.s.exit_server_loop = True
@@ -562,7 +561,7 @@ class ServerTestCase(unittest.TestCase):
 
     def test_error_handling(self):
         request = {"bad request"}
-        self.s.socket.receive = MagicMock(return_value=request)
+        self.s.queue.append(request)
         self.s.socket.send = MagicMock()
         self.s.exit_server_loop = True
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
Added threading to the server. 

On server creation, there are now 2 more objects. 
The server creates a Thread Object, called self.receiverThread, and an attribute called self.queue, which is a list.

When the main server logic is spun up, it creates an instance of the receiverThread. The receiverThread, is listening on the socket, and adding messages to the self.queue object as messages come in from the user.

The server itself now has a handle_queue method. What this method does is constantly check to see the state of self.queue. If it is not empty, it will handle the requests in FIFO order. 

This is a threadsafe approach because only the main thread ever handles the input, and the main thread itself has a bottleneck. The handle_queue method is synchronous. 