### PR TITLE
Added AEPsych client link to repo

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -8,10 +8,10 @@ The modeling components of AEPsych are by necessity implemented in python, but w
 All clients connect to the server over regular unix sockets, and messages between the client and server are encoded in JSON. Experiments begin with a configuration message from the client to the server, and the proceed with alternating ask messages (which query the server for the next point to evaluate) and tell messages (which let the server know what the outcome of evaluating a stimulus configuration is).
 
 ## AEPsych Unity client
-The Unity client is written in C#, and supports interfacing AEPsych with stimulus display on regular screens or in VR. It additionally includes tooling for interactive model exploration and model querying, for developing fuller-featured adaptive experiments and prototypes using AEPsych.
+The [Unity client](https://github.com/facebookresearch/aepsych/tree/main/clients/unity) is written in C#, and supports interfacing AEPsych with stimulus display on regular screens or in VR. It additionally includes tooling for interactive model exploration and model querying, for developing fuller-featured adaptive experiments and prototypes using AEPsych.
 
 ## AEPsych MATLAB client
-The MATLAB client supports interfacing AEPsych with standard MATLAB stimulus display code (e.g. in psychtoolbox). It has fewer interactive components than the Unity client, but includes core configure-ask-tell functionality for running experiments.
+The [MATLAB client](https://github.com/facebookresearch/aepsych/tree/main/clients/matlab) supports interfacing AEPsych with standard MATLAB stimulus display code (e.g. in psychtoolbox). It has fewer interactive components than the Unity client, but includes core configure-ask-tell functionality for running experiments.
 
 ## AEPsych Python client
-The AEPsych python client has similar functionality to the MATLAB client, for supporting interfacing with tools such as PsychoPy / OpenSesame. It’s also possible for experiments in python to use the AEPsych machinery directly, not over a network socket, but there are advantages to using the server anyway (e.g. automated data logging and experiment replay functionality, asynchronous operation, etc).
+The AEPsych [python client](https://github.com/facebookresearch/aepsych/tree/main/clients/python) has similar functionality to the MATLAB client, for supporting interfacing with tools such as PsychoPy / OpenSesame. It’s also possible for experiments in python to use the AEPsych machinery directly, not over a network socket, but there are advantages to using the server anyway (e.g. automated data logging and experiment replay functionality, asynchronous operation, etc).

--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -29,3 +29,15 @@ echo "===== Publishing website to gh-pages ====="
     yarn run publish-gh-pages
     rm -rf build/
 echo "=========================================="
+
+
+echo "======== Cleanup for github ==============="
+  cd .. || exit
+  find . -type d -name __pycache__ -exec rm -r {} \+
+  pwd
+  cd website/ || exit
+  rm -rf node_modules/
+  cd ../
+  cd sphinx/ || exit
+  rm -rf build/ || exit
+echo "=========================================="


### PR DESCRIPTION
Summary: Added links for AEPsych clinets under Docs -> General -> AEPsych Clients for unity, matlab, and python.

Differential Revision: D37866186

