### PR TITLE
fix bug when updating configs

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -659,10 +659,11 @@ class AEPsychServer(object):
         if version < __version__:
             try:
                 config.convert_to_latest()
+                self.db.perform_updates()
                 logger.warning(
                     f"Config version {version} is less than AEPsych version {__version__}. The config was automatically modified to be compatible. Check the config table in the db to see the changes."
                 )
-            except:
+            except RuntimeError:
                 logger.warning(
                     f"Config version {version} is less than AEPsych version {__version__}, but couldn't automatically update the config! Trying to configure the server anyway..."
                 )
@@ -695,8 +696,8 @@ class AEPsychServer(object):
 def startServerAndRun(
     server_class, socket=None, database_path=None, config_path=None, uuid_of_replay=None
 ):
+    server = server_class(socket=socket, database_path=database_path)
     try:
-        server = server_class(socket=socket, database_path=database_path)
         if config_path is not None:
             with open(config_path) as f:
                 config_str = f.read()


### PR DESCRIPTION
Summary: The server would automatically try to update old configs from setup messages, but it would also write the old config message to the replay table, causing bugs during replay. This fixes the issue by having the db update itself when the config is updated.

Differential Revision: D38722893

