### PR TITLE
fix pairwise shape bug

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -617,9 +617,9 @@ class AEPsychServer(object):
 
         # handle config elements being either scalars or length-1 lists
         if isinstance(unpacked[0], list):
-            x = np.stack(unpacked, axis=1)
+            x = torch.tensor(np.stack(unpacked, axis=0)).squeeze(-1)
         else:
-            x = np.stack(unpacked)
+            x = torch.tensor(np.stack(unpacked))
         return x
 
     def tell(self, outcome, config):

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -156,7 +156,7 @@ class Strategy(object):
             n (int): number of observations
         """
         assert (
-            x.shape[-self.stimuli_per_trial :] == self.event_shape
+            x.shape == self.event_shape or x.shape[1:] == self.event_shape
         ), f"x shape should be {self.event_shape} or batch x {self.event_shape}, instead got {x.shape}"
 
         if x.shape == self.event_shape:

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -94,7 +94,7 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
                 ub=ub,
                 generator=PairwiseSobolGenerator(lb=lb, ub=ub, seed=seed),
                 min_asks=n_init,
-                stimuli_per_trial=1,
+                stimuli_per_trial=2,
                 outcome_types=["binary"],
             ),
             Strategy(


### PR DESCRIPTION
Summary: server._config_to_tensor was returning the wrong shape, breaking pairwise. This fixes that.

Differential Revision: D38760762

