### PR TITLE
add model_data argument to server.tell

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -622,7 +622,7 @@ class AEPsychServer(object):
             x = torch.tensor(np.stack(unpacked))
         return x
 
-    def tell(self, outcome, config):
+    def tell(self, outcome, config, model_data=True):
         """tell the model which input was run and what the outcome was
 
         Arguments:
@@ -632,9 +632,10 @@ class AEPsychServer(object):
             TODO better types
         """
 
-        x = self._config_to_tensor(config)
-        y = outcome
-        self.strat.add_data(x, y)
+        if model_data:
+            x = self._config_to_tensor(config)
+            y = outcome
+            self.strat.add_data(x, y)
 
     def _configure(self, config):
         self.parnames = config._str_to_list(

--- a/clients/python/aepsych_client/client.py
+++ b/clients/python/aepsych_client/client.py
@@ -61,7 +61,11 @@ class AEPsychClient:
         return response
 
     def tell(
-        self, config: Dict[str, List[Any]], outcome: int, **metadata: Dict[str, Any]
+        self,
+        config: Dict[str, List[Any]],
+        outcome: int,
+        model_data: bool = True,
+        **metadata: Dict[str, Any],
     ) -> None:
         """Update the server on a configuration that was executed.
 
@@ -69,6 +73,8 @@ class AEPsychClient:
             config (Dict[str, str]): Config that was evaluated.
             outcome (int): Outcome that was obtained.
             metadata (optional kwargs) is passed to the extra_info field on the server.
+            model_data (bool): If True, the data will be recorded in the db and included in the server's model. If False,
+                the data will be recorded in the db, but will not be used by the model. Defaults to True.
 
         Raises:
             AssertionError if server failed to acknowledge the tell.
@@ -76,7 +82,7 @@ class AEPsychClient:
 
         request = {
             "type": "tell",
-            "message": {"config": config, "outcome": outcome},
+            "message": {"config": config, "outcome": outcome, "model_data": model_data},
             "extra_info": metadata,
         }
         self._send_recv(request)

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -78,6 +78,10 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(self.s._strats[0].x, tensor([[0.0]]))
         self.assertEqual(self.s._strats[0].y, tensor([[1.0]]))
 
+        self.client.tell(config={"x": [0]}, outcome=1, model_data=False)
+        self.assertEqual(self.s._strats[0].x, tensor([[0.0]]))
+        self.assertEqual(self.s._strats[0].y, tensor([[1.0]]))
+
         response = self.client.ask()
         self.assertTrue(response["is_finished"])
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -592,6 +592,29 @@ class ServerTestCase(unittest.TestCase):
                 torch.equal(tensor, torch.tensor([[0.0, 2.0], [1.0, 1.0], [2.0, 0.0]]))
             )
 
+    def test_tell(self):
+        setup_request = {
+            "type": "setup",
+            "message": {"config_str": dummy_config},
+        }
+
+        tell_request = {
+            "type": "tell",
+            "message": {"config": {"x": [0.5]}, "outcome": 1},
+        }
+
+        self.s.db.record_message = MagicMock()
+
+        self.s.unversioned_handler(setup_request)
+        self.s.unversioned_handler(tell_request)
+        self.assertEqual(self.s.db.record_message.call_count, 2)
+        self.assertEqual(len(self.s.strat.x), 1)
+
+        tell_request["message"]["model_data"] = False
+        self.s.unversioned_handler(tell_request)
+        self.assertEqual(self.s.db.record_message.call_count, 3)
+        self.assertEqual(len(self.s.strat.x), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: Sometimes you run trials and you want the data to be recorded, but you don't necessarily want that data to be included in the model (e.g., practice trials). By including "model_data": False in your tell message, you can tell the server to record data in the db, but not add it to the model.

Differential Revision: D38795185

