### PR TITLE
add strategy_name and next_strategy messages

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -414,6 +414,8 @@ class AEPsychServer(object):
             "can_model": self.handle_can_model,
             "exit": self.handle_exit,
             "get_config": self.handle_get_config,
+            "finish_strategy": self.handle_finish_strategy,
+            "strategy_name": self.handle_strategy_name,
         }
 
         if "type" not in request.keys():
@@ -612,6 +614,12 @@ class AEPsychServer(object):
 
         # If both section and property are specified, return only the relevant value from the config
         return self.config.to_dict(deduplicate=False)[section][prop]
+    def handle_finish_strategy(self, request):
+        self.strat.finish()
+        return f"finished strategy {self.strat.name}"
+
+    def handle_strategy_name(self, request):
+        return self.strat.name
 
     ### Properties that are set on a per-strat basis
     @property

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -681,7 +681,7 @@ class AEPsychServer(object):
             x = torch.tensor(np.stack(unpacked))
         return x
 
-    def tell(self, outcome, config):
+    def tell(self, outcome, config, model_data=True):
         """tell the model which input was run and what the outcome was
 
         Arguments:
@@ -691,9 +691,10 @@ class AEPsychServer(object):
             TODO better types
         """
 
-        x = self._config_to_tensor(config)
-        y = outcome
-        self.strat.add_data(x, y)
+        if model_data:
+            x = self._config_to_tensor(config)
+            y = outcome
+            self.strat.add_data(x, y)
 
     def _configure(self, config):
         self.parnames = config._str_to_list(

--- a/clients/python/aepsych_client/client.py
+++ b/clients/python/aepsych_client/client.py
@@ -61,7 +61,11 @@ class AEPsychClient:
         return response
 
     def tell(
-        self, config: Dict[str, List[Any]], outcome: int, **metadata: Dict[str, Any]
+        self,
+        config: Dict[str, List[Any]],
+        outcome: int,
+        model_data: bool = True,
+        **metadata: Dict[str, Any],
     ) -> None:
         """Update the server on a configuration that was executed.
 
@@ -69,6 +73,8 @@ class AEPsychClient:
             config (Dict[str, str]): Config that was evaluated.
             outcome (int): Outcome that was obtained.
             metadata (optional kwargs) is passed to the extra_info field on the server.
+            model_data (bool): If True, the data will be recorded in the db and included in the server's model. If False,
+                the data will be recorded in the db, but will not be used by the model. Defaults to True.
 
         Raises:
             AssertionError if server failed to acknowledge the tell.
@@ -76,7 +82,7 @@ class AEPsychClient:
 
         request = {
             "type": "tell",
-            "message": {"config": config, "outcome": outcome},
+            "message": {"config": config, "outcome": outcome, "model_data": model_data},
             "extra_info": metadata,
         }
         self._send_recv(request)

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -78,6 +78,10 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(self.s._strats[0].x, tensor([[0.0]]))
         self.assertEqual(self.s._strats[0].y, tensor([[1.0]]))
 
+        self.client.tell(config={"x": [0]}, outcome=1, model_data=False)
+        self.assertEqual(self.s._strats[0].x, tensor([[0.0]]))
+        self.assertEqual(self.s._strats[0].y, tensor([[1.0]]))
+
         response = self.client.ask()
         self.assertTrue(response["is_finished"])
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -758,6 +758,49 @@ class ConfigTestCase(unittest.TestCase):
         with self.assertRaises(AssertionError):
             SequentialStrategy.from_config(config3)
 
+    def test_strat_names(self):
+        good_str = """
+            [common]
+            lb = [0, 0]
+            ub = [1, 1]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+            parnames = [par1, par2]
+            strategy_names = [init_strat, opt_strat]
+
+            [init_strat]
+            generator = SobolGenerator
+            model = GPClassificationModel
+
+            [opt_strat]
+            generator = OptimizeAcqfGenerator
+            model = GPClassificationModel
+            """
+
+        bad_str = """
+            [common]
+            lb = [0, 0]
+            ub = [1, 1]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+            parnames = [par1, par2]
+            strategy_names = [init_strat, init_strat]
+
+            [init_strat]
+            generator = SobolGenerator
+            model = GPClassificationModel
+            """
+
+        good_config = Config(config_str=good_str)
+        bad_config = Config(config_str=bad_str)
+
+        # this should work
+        SequentialStrategy.from_config(good_config)
+
+        # this should fail
+        with self.assertRaises(AssertionError):
+            SequentialStrategy.from_config(bad_config)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -648,6 +648,38 @@ class ServerTestCase(unittest.TestCase):
         self.assertEqual(self.s.db.record_message.call_count, 3)
         self.assertEqual(len(self.s.strat.x), 1)
 
+    def test_handle_finish_strategy(self):
+        setup_request = {
+            "type": "setup",
+            "message": {"config_str": dummy_config},
+        }
+
+        tell_request = {
+            "type": "tell",
+            "message": {"config": {"x": [0.5]}, "outcome": 1},
+        }
+
+        ask_request = {"type": "ask", "message": ""}
+
+        strat_name_request = {"type": "strategy_name"}
+        finish_strat_request = {"type": "finish_strategy"}
+
+        self.s.unversioned_handler(setup_request)
+        strat_name = self.s.unversioned_handler(strat_name_request)
+        self.assertEqual(strat_name, "init_strat")
+
+        # model-based strategies require data
+        self.s.unversioned_handler(tell_request)
+
+        msg = self.s.unversioned_handler(finish_strat_request)
+        self.assertEqual(msg, "finished strategy init_strat")
+
+        # need to gen another trial to move to next strategy
+        self.s.unversioned_handler(ask_request)
+
+        strat_name = self.s.unversioned_handler(strat_name_request)
+        self.assertEqual(strat_name, "opt_strat")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -625,6 +625,29 @@ class ServerTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             response = self.s.versioned_handler(get_config_request)
 
+    def test_tell(self):
+        setup_request = {
+            "type": "setup",
+            "message": {"config_str": dummy_config},
+        }
+
+        tell_request = {
+            "type": "tell",
+            "message": {"config": {"x": [0.5]}, "outcome": 1},
+        }
+
+        self.s.db.record_message = MagicMock()
+
+        self.s.unversioned_handler(setup_request)
+        self.s.unversioned_handler(tell_request)
+        self.assertEqual(self.s.db.record_message.call_count, 2)
+        self.assertEqual(len(self.s.strat.x), 1)
+
+        tell_request["message"]["model_data"] = False
+        self.s.unversioned_handler(tell_request)
+        self.assertEqual(self.s.db.record_message.call_count, 3)
+        self.assertEqual(len(self.s.strat.x), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -167,6 +167,29 @@ class TestSequenceGenerators(unittest.TestCase):
                 torch.equal(self.strat.model.train_inputs[0], data[lb : i + 1])
             )
 
+    def test_run_indefinitely(self):
+        lb = [-1, -1]
+        ub = [1, 1]
+
+        with self.assertWarns(UserWarning):
+            self.strat = Strategy(
+                model=GPClassificationModel(
+                    lb=lb,
+                    ub=ub,
+                ),
+                generator=SobolGenerator(lb=lb, ub=ub),
+                lb=lb,
+                ub=ub,
+                stimuli_per_trial=1,
+                outcome_types=["binary"],
+                min_asks=1,  # should be ignored
+                run_indefinitely=True,
+            )
+        self.strat.gen()
+        self.assertFalse(self.strat.finished)
+        self.strat.finish()
+        self.assertTrue(self.strat.finished)
+
     def test_n_trials_deprecation(self):
         seed = 1
         torch.manual_seed(seed)


### PR DESCRIPTION
Summary: This allows the client to check which strategy is currently active and manually move on to the next strategy if desired

Differential Revision: D38800925

