### PR TITLE
add outcome_type property to models

### DIFF
--- a/aepsych/models/gp_classification.py
+++ b/aepsych/models/gp_classification.py
@@ -42,6 +42,7 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP):
     _batch_size = 1
     _num_outputs = 1
     stimuli_per_trial = 1
+    outcome_type = "binary"
 
     def __init__(
         self,

--- a/aepsych/models/gp_regression.py
+++ b/aepsych/models/gp_regression.py
@@ -29,6 +29,7 @@ class GPRegressionModel(AEPsychMixin, ExactGP):
     _num_outputs = 1
     _batch_size = 1
     stimuli_per_trial = 1
+    outcome_type = "continuous"
 
     def __init__(
         self,

--- a/aepsych/models/monotonic_rejection_gp.py
+++ b/aepsych/models/monotonic_rejection_gp.py
@@ -46,6 +46,7 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
 
     _num_outputs = 1
     stimuli_per_trial = 1
+    outcome_type = "binary"
 
     def __init__(
         self,

--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -26,6 +26,7 @@ logger = getLogger()
 class PairwiseProbitModel(PairwiseGP, AEPsychMixin):
     _num_outputs = 1
     stimuli_per_trial = 2
+    outcome_type = "binary"
 
     def _pairs_to_comparisons(self, x, y):
         """

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -313,6 +313,10 @@ class Strategy(object):
                 stimuli_per_trial == generator.stimuli_per_trial
             ), f"stimuli_per_trial, {stimuli_per_trial}, does not match model {generator}, which takes {generator.stimuli_per_trial} stimuli!"
 
+            assert (
+                model.outcome_type in outcome_types
+            ), f"model outcome type, {model.outcome_type}, not found in outcome_types, {outcome_types}!"
+
         else:
             model = None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -629,6 +629,66 @@ class ConfigTestCase(unittest.TestCase):
         with self.assertRaises(AssertionError):
             SequentialStrategy.from_config(config3)
 
+    def test_outcome_compatibility(self):
+        config_str1 = """
+            [common]
+            lb = [0, 0]
+            ub = [1, 1]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+            parnames = [par1, par2]
+            strategy_names = [init_strat]
+
+            [init_strat]
+            generator = SobolGenerator
+            model = GPClassificationModel
+            """
+        config1 = Config()
+        config1.update(config_str=config_str1)
+
+        config_str2 = """
+            [common]
+            lb = [0, 0]
+            ub = [1, 1]
+            stimuli_per_trial = 1
+            outcome_types = [continuous]
+            parnames = [par1, par2]
+            strategy_names = [init_strat]
+
+            [init_strat]
+            generator = SobolGenerator
+            model = GPClassificationModel
+            """
+        config2 = Config()
+        config2.update(config_str=config_str2)
+
+        config_str3 = """
+            [common]
+            lb = [0, 0]
+            ub = [1, 1]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+            parnames = [par1, par2]
+            strategy_names = [init_strat]
+
+            [init_strat]
+            generator = SobolGenerator
+            model = GPRegressionModel
+            """
+        config3 = Config()
+        config3.update(config_str=config_str3)
+
+        # this should work
+        SequentialStrategy.from_config(config1)
+
+        # this should fail
+        with self.assertRaises(AssertionError):
+            SequentialStrategy.from_config(config3)
+
+        # this should fail too
+        with self.assertRaises(AssertionError):
+            SequentialStrategy.from_config(config3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: This adds an outcome_type property to models so that we can check that they are compatible with data and other classes

Differential Revision: D38835538

