### PR TITLE
add get_config message

### DIFF
--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -108,12 +108,12 @@ class Config(configparser.ConfigParser):
             )
 
     # Convert config into a dictionary (eliminate duplicates from defaulted 'common' section.)
-    def to_dict(self):
+    def to_dict(self, deduplicate=True):
         _dict = {}
         for section in self:
             _dict[section] = {}
             for setting in self[section]:
-                if section != "common" and setting in self["common"]:
+                if deduplicate and section != "common" and setting in self["common"]:
                     continue
                 _dict[section][setting] = self[section][setting]
         return _dict


### PR DESCRIPTION
Summary: The client doesn't know how to parse configs, so this implements a message that returns the current config as a json that can easily be parsed like a dictionary.

Differential Revision: D38843598

