### PR TITLE
Removed MIT License from root directory.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -401,24 +401,3 @@ Creative Commons may be contacted at creativecommons.org.
 =======================================================================
 
 
-MIT License
-
-Copyright (c) Meta Platforms, Inc. and affiliates.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/scripts/LICENSE
+++ b/scripts/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THESOFTWARE.

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -2,7 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
+# LICENSE file in the scripts directory.
 
 # run this script from the project root using `./scripts/build_docs.sh`
 

--- a/scripts/parse_sphinx.py
+++ b/scripts/parse_sphinx.py
@@ -2,7 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
+# LICENSE file in the scripts directory.
 
 from __future__ import annotations
 

--- a/scripts/parse_tutorials.py
+++ b/scripts/parse_tutorials.py
@@ -2,7 +2,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
+# LICENSE file in the scripts directory.
 
 from __future__ import annotations
 

--- a/scripts/publish_site.sh
+++ b/scripts/publish_site.sh
@@ -2,7 +2,8 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
+# LICENSE file in the scripts directory.
+
 # give your self permision to execute file `chmod +x ./scripts/publish_site.sh `
 # run this script from the project root using `./scripts/publish_site.sh`
 

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -8,6 +8,10 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the scripts directory.
+
+
 
 # -- Path setup --------------------------------------------------------------
 

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -2,8 +2,9 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */const PropTypes = require('prop-types');
+ * LICENSE file in the scripts directory.
+*/
+const PropTypes = require('prop-types');
 const React = require('react');
 
 

--- a/website/core/Tutorial.js
+++ b/website/core/Tutorial.js
@@ -2,7 +2,7 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * LICENSE file in the scripts directory.
  *
  * @format
  */

--- a/website/core/TutorialSidebar.js
+++ b/website/core/TutorialSidebar.js
@@ -2,7 +2,7 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * LICENSE file in the scripts directory.
  *
  * @format
  */

--- a/website/pages/tutorials/index.js
+++ b/website/pages/tutorials/index.js
@@ -2,7 +2,7 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
+ * LICENSE file in the scripts directory.
  *
  * @format
  */


### PR DESCRIPTION
Summary: - Removed the MIT License from the root License directory and added it to the files that need it.

Differential Revision: D39142745

