### PR TITLE
Bug fixes to enable strategy switching (#24)

### DIFF
--- a/clients/unity/Packages/com.frl.aepsych/Runtime/TrialConfig.cs
+++ b/clients/unity/Packages/com.frl.aepsych/Runtime/TrialConfig.cs
@@ -102,6 +102,16 @@ namespace AEPsych
             return innerDict.ContainsKey(key);
         }
 
+        public TrialConfig Copy()
+        {
+            TrialConfig t = new TrialConfig();
+            foreach (KeyValuePair<string, List<float>> pair in innerDict)
+            {
+                t.Add(pair.Key, pair.Value);
+            }
+            return t;
+        }
+
         public void CopyTo(KeyValuePair<string, List<float>>[] array, int arrayIndex)
         {
             int idx = arrayIndex;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/aepsych_prerelease/pull/24

Changes some experiment flow to enable strategy switching without automatically sending Ask messages to the server.

Reviewed By: tymmsc

Differential Revision: D39933769

