### PR TITLE
Response Time built-in feature (#26)

### DIFF
--- a/clients/unity/Packages/com.frl.aepsych/.Samples/Client/Scenes/Examples.unity
+++ b/clients/unity/Packages/com.frl.aepsych/.Samples/Client/Scenes/Examples.unity
@@ -193,6 +193,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 0
   startMode: 1
   client: {fileID: 0}
@@ -200,6 +201,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 1
@@ -441,6 +443,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 1
   client: {fileID: 0}
@@ -448,6 +451,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -507,6 +511,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 1
   client: {fileID: 0}
@@ -514,6 +519,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -744,6 +750,7 @@ MonoBehaviour:
   useModelExploration: 1
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 0
   startMode: 1
   client: {fileID: 0}
@@ -751,6 +758,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 1
@@ -848,6 +856,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 0
   startMode: 1
   client: {fileID: 0}
@@ -855,6 +864,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 1
@@ -966,6 +976,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 2
   client: {fileID: 0}
@@ -973,6 +984,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -1070,6 +1082,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 2
   client: {fileID: 0}
@@ -1077,6 +1090,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -1136,6 +1150,7 @@ MonoBehaviour:
   useModelExploration: 1
   autoDisableOtherCanvases: 1
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 2
   client: {fileID: 0}
@@ -1143,6 +1158,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -1386,6 +1402,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 2
   client: {fileID: 0}
@@ -1393,6 +1410,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -1483,6 +1501,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 1
   client: {fileID: 0}
@@ -1490,6 +1509,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -1731,6 +1751,7 @@ MonoBehaviour:
   useModelExploration: 1
   autoDisableOtherCanvases: 1
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 2
   client: {fileID: 0}
@@ -1738,6 +1759,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -1829,6 +1851,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 2
   client: {fileID: 0}
@@ -1836,6 +1859,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -1893,6 +1917,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 1
   client: {fileID: 0}
@@ -1900,6 +1925,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -2209,6 +2235,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 0
   startMode: 1
   client: {fileID: 0}
@@ -2216,6 +2243,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 1
@@ -2400,6 +2428,7 @@ MonoBehaviour:
   useModelExploration: 0
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 2
   client: {fileID: 0}
@@ -2407,6 +2436,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -2583,6 +2613,7 @@ MonoBehaviour:
   useModelExploration: 1
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 0
   startMode: 1
   client: {fileID: 0}
@@ -2590,6 +2621,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 1
@@ -2698,6 +2730,7 @@ MonoBehaviour:
   useModelExploration: 1
   autoDisableOtherCanvases: 1
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 1
   startMode: 2
   client: {fileID: 0}
@@ -2705,6 +2738,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 0
@@ -2784,6 +2818,7 @@ MonoBehaviour:
   useModelExploration: 1
   autoDisableOtherCanvases: 0
   recordToCSV: 0
+  recordResponseTime: 1
   asyncAsk: 0
   startMode: 1
   client: {fileID: 0}
@@ -2791,6 +2826,7 @@ MonoBehaviour:
   configGenerator: {fileID: 0}
   isDone: 0
   isPaused: 0
+  autoAsk: 1
   defaultUI: {fileID: 0}
   queryModel: {fileID: 0}
   responseType: 1

--- a/clients/unity/Packages/com.frl.aepsych/Runtime/AEPsychClient.cs
+++ b/clients/unity/Packages/com.frl.aepsych/Runtime/AEPsychClient.cs
@@ -43,7 +43,7 @@ namespace AEPsych
             this.type = type;
             this.extra_info = null;
         }
-        public Request(object message, RequestType type, TrialMetadata extra_info)
+        public Request(object message, RequestType type, TrialMetadata extra_info = null)
         {
             this.message = message;
             this.type = type;
@@ -77,12 +77,11 @@ namespace AEPsych
         public TrialConfig config;
         public float outcome;
 
-        public TrialWithOutcome(TrialConfig config, float outcome)
+        public TrialWithOutcome(TrialConfig config, float outcome, float response_time = -1f)
         {
             this.config = config;
             this.outcome = outcome;
         }
-
     }
 
     public class QueryMessage
@@ -348,7 +347,6 @@ namespace AEPsych
 
         public int GetStrat() //can only call this after setup
         {
-
             if (status != ClientStatus.GotResponse)
             {
                 Debug.Log("Error! Called getConfig() when there is no reply available! Current status is " + status);
@@ -359,19 +357,13 @@ namespace AEPsych
             return currentStrat;
         }
 
-        public IEnumerator Tell(TrialConfig trialConfig, float outcome, TrialMetadata metadata = null)
+        public IEnumerator Tell(TrialConfig trialConfig, float outcome, TrialMetadata metadata = null, float responseTime = -1f)
         {
-            TrialWithOutcome message = new TrialWithOutcome(trialConfig, outcome);
-
+            TrialWithOutcome message = new TrialWithOutcome(trialConfig, outcome, responseTime);
             Request req;
-            if (metadata != null)
-            {
-                req = new Request(message, RequestType.tell, metadata);
-            }
-            else
-            {
-                req = new Request(message, RequestType.tell);
-            }
+            //req = new Request(message, RequestType.tell, metadata, responseTime);
+            req = new Request(message, RequestType.tell, metadata);
+            
             yield return StartCoroutine(this.SendRequest(JsonConvert.SerializeObject(req)));
         }
         public IEnumerator Ask()


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/aepsych_prerelease/pull/26

Automatically records response time as metadata in extra_info object. Enabled by default.

Reviewed By: tymmsc

Differential Revision: D40029203

