### PR TITLE
Formatting fixes, train_data consistency

### DIFF
--- a/aepsych/acquisition/__init__.py
+++ b/aepsych/acquisition/__init__.py
@@ -8,26 +8,19 @@
 import sys
 
 from ..config import Config
-from .lookahead import (
-    GlobalMI,
-    GlobalSUR,
-    ApproxGlobalSUR,
-    EAVC,
-    LocalMI,
-    LocalSUR,
-)
+from .lookahead import ApproxGlobalSUR, EAVC, GlobalMI, GlobalSUR, LocalMI, LocalSUR
 from .lse import MCLevelSetEstimation
 from .mc_posterior_variance import MCPosteriorVariance, MonotonicMCPosteriorVariance
 from .monotonic_rejection import MonotonicMCLSE
 from .mutual_information import (
-    MonotonicBernoulliMCMutualInformation,
     BernoulliMCMutualInformation,
+    MonotonicBernoulliMCMutualInformation,
 )
 from .objective import (
-    ProbitObjective,
-    FloorProbitObjective,
-    FloorLogitObjective,
     FloorGumbelObjective,
+    FloorLogitObjective,
+    FloorProbitObjective,
+    ProbitObjective,
 )
 
 

--- a/aepsych/acquisition/bvn.py
+++ b/aepsych/acquisition/bvn.py
@@ -11,7 +11,7 @@ import torch
 
 
 inv_2pi = 1 / (2 * _pi)
-_neg_inv_sqrt2 = -1 / (2 ** 0.5)
+_neg_inv_sqrt2 = -1 / (2**0.5)
 
 
 def _gauss_legendre20(dtype):
@@ -75,7 +75,7 @@ def _bvnu(
 
     asr = 0.5 * torch.asin(r)
     sn = torch.sin(asr[..., None] * x)
-    res = (sn * hk[..., None] - 0.5 * (h ** 2 + k ** 2)[..., None]) / (1 - sn ** 2)
+    res = (sn * hk[..., None] - 0.5 * (h**2 + k**2)[..., None]) / (1 - sn**2)
     res = torch.sum(w * torch.exp(res), dim=-1)
     res = res * inv_2pi * asr + _ndtr(-h) * _ndtr(-k)
 

--- a/aepsych/acquisition/lookahead_utils.py
+++ b/aepsych/acquisition/lookahead_utils.py
@@ -136,7 +136,7 @@ def lookahead_p_at_xstar(
 
     def lookahead_inner(f_q):
         mu_tilde_star = Mu_s + (f_q - Mu_q) * Sigma_sq / Sigma2_q
-        sigma_tilde_star = Sigma2_s - (Sigma_sq ** 2) / Sigma2_q
+        sigma_tilde_star = Sigma2_s - (Sigma_sq**2) / Sigma2_q
         return probit(mu_tilde_star / torch.sqrt(sigma_tilde_star + 1)) * probit(f_q)
 
     pstar_marginal_1 = probit(Mu_s / torch.sqrt(1 + Sigma2_s))
@@ -185,17 +185,17 @@ def approximate_lookahead_levelset_at_xstar(
     Mu_s_cdf = Norm.cdf(Mu_s)
 
     # Formulae from the supplement of the paper (Result 2)
-    vnp1_p = Mu_s_pdf ** 2 / Mu_s_cdf ** 2 + Mu_s * Mu_s_pdf / Mu_s_cdf  # (C.4)
+    vnp1_p = Mu_s_pdf**2 / Mu_s_cdf**2 + Mu_s * Mu_s_pdf / Mu_s_cdf  # (C.4)
     p_p = Norm.cdf(Mu_s / torch.sqrt(1 + Sigma2_s))  # (C.5)
 
-    vnp1_n = Mu_s_pdf ** 2 / (1 - Mu_s_cdf) ** 2 - Mu_s * Mu_s_pdf / (
+    vnp1_n = Mu_s_pdf**2 / (1 - Mu_s_cdf) ** 2 - Mu_s * Mu_s_pdf / (
         1 - Mu_s_cdf
     )  # (C.6)
     p_n = 1 - p_p  # (C.7)
 
     vtild = vnp1_p * p_p + vnp1_n * p_n
 
-    Sigma2_q_np1 = Sigma2_q - Sigma_sq ** 2 / ((1 / vtild) + Sigma2_s)  # (C.8)
+    Sigma2_q_np1 = Sigma2_q - Sigma_sq**2 / ((1 / vtild) + Sigma2_s)  # (C.8)
 
     Px = Norm.cdf((gamma - Mu_q) / torch.sqrt(Sigma2_q))
     P1 = Norm.cdf((gamma - Mu_q) / torch.sqrt(Sigma2_q_np1))

--- a/aepsych/benchmark/__init__.py
+++ b/aepsych/benchmark/__init__.py
@@ -7,13 +7,13 @@
 
 from .benchmark import Benchmark, DerivedValue
 from .pathos_benchmark import PathosBenchmark, run_benchmarks_with_checkpoints
-from .problem import Problem, LSEProblem
+from .problem import LSEProblem, Problem
 from .test_functions import (
+    discrim_highdim,
     make_songetal_testfun,
+    modified_hartmann6,
     novel_detection_testfun,
     novel_discrimination_testfun,
-    modified_hartmann6,
-    discrim_highdim,
 )
 
 __all__ = [

--- a/aepsych/benchmark/benchmark.py
+++ b/aepsych/benchmark/benchmark.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 import torch
 from aepsych.config import Config
-from aepsych.strategy import SequentialStrategy, ensure_model_is_fresh
+from aepsych.strategy import ensure_model_is_fresh, SequentialStrategy
 from tqdm.contrib.itertools import product as tproduct
 
 from .problem import Problem

--- a/aepsych/benchmark/test_functions.py
+++ b/aepsych/benchmark/test_functions.py
@@ -119,7 +119,7 @@ def make_songetal_testfun(
     def song_testfun(x, cdf=False):
         logfreq = x[..., 0]
         intensity = x[..., 1]
-        thresh = threshfun(2 ** logfreq)
+        thresh = threshfun(2**logfreq)
         return (
             norm.cdf((intensity - thresh) / beta)
             if cdf
@@ -145,7 +145,7 @@ def novel_discrimination_testfun(x: np.ndarray) -> np.ndarray:
     """
     freq = x[..., 0]
     amp = x[..., 1]
-    context = 2 * (0.05 + 0.4 * (-1 + 0.2 * freq) ** 2 * freq ** 2)
+    context = 2 * (0.05 + 0.4 * (-1 + 0.2 * freq) ** 2 * freq**2)
     return 2 * (amp + 1) / context
 
 
@@ -163,7 +163,7 @@ def novel_detection_testfun(x: np.ndarray) -> np.ndarray:
     """
     freq = x[..., 0]
     amp = x[..., 1]
-    context = 2 * (0.05 + 0.4 * (-1 + 0.2 * freq) ** 2 * freq ** 2)
+    context = 2 * (0.05 + 0.4 * (-1 + 0.2 * freq) ** 2 * freq**2)
     return 4 * (amp + 1) / context - 4
 
 

--- a/aepsych/factory/__init__.py
+++ b/aepsych/factory/__init__.py
@@ -10,8 +10,8 @@ import sys
 from ..config import Config
 from .factory import (
     default_mean_covar_factory,
-    ordinal_mean_covar_factory,
     monotonic_mean_covar_factory,
+    ordinal_mean_covar_factory,
     song_mean_covar_factory,
 )
 

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -60,7 +60,7 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
 
             # this is still very ugly
             extra_acqf_args = {}
-            if acqf_name in config: 
+            if acqf_name in config:
                 full_section = config[acqf_name]
                 for k in acqf_args_expected:
                     # if this thing is configured

--- a/aepsych/generators/monotonic_rejection_generator.py
+++ b/aepsych/generators/monotonic_rejection_generator.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, Sequence, Dict, Any
+from typing import Any, Dict, Optional, Sequence
 
 import torch
 from aepsych.acquisition.monotonic_rejection import MonotonicMCAcquisition

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -53,12 +53,14 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
         self.max_gen_time = max_gen_time
         self.stimuli_per_trial = stimuli_per_trial
 
-    def _instantiate_acquisition_fn(self, model: ModelProtocol, train_x):
+    def _instantiate_acquisition_fn(self, model: ModelProtocol):
         if self.acqf == AnalyticExpectedUtilityOfBestOption:
             return self.acqf(pref_model=model)
 
         if self.acqf in self.baseline_requiring_acqfs:
-            return self.acqf(model=model, X_baseline=train_x, **self.acqf_kwargs)
+            return self.acqf(
+                model=model, X_baseline=model.train_inputs[0], **self.acqf_kwargs
+            )
         else:
             return self.acqf(model=model, **self.acqf_kwargs)
 
@@ -87,7 +89,7 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
         # eval should be inherited from superclass
         model.eval()  # type: ignore
         train_x = model.train_inputs[0]
-        acqf = self._instantiate_acquisition_fn(model, train_x)
+        acqf = self._instantiate_acquisition_fn(model)
 
         logger.info("Starting gen...")
         starttime = time.time()

--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -404,13 +404,12 @@ class AEPsychMixin(GPyTorchModel):
 
     def _fit_mll(
         self,
-        train_x: torch.Tensor,
-        train_y: torch.Tensor,
         mll: MarginalLogLikelihood,
         optimizer_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         self.train()
+        train_x, train_y = mll.model.train_inputs[0], mll.model.train_targets
         optimizer_kwargs = {} if optimizer_kwargs is None else optimizer_kwargs.copy()
         max_fit_time = kwargs.pop("max_fit_time", self.max_fit_time)
         if max_fit_time is not None:

--- a/aepsych/models/gp_classification.py
+++ b/aepsych/models/gp_classification.py
@@ -228,7 +228,7 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP):
         n = train_y.shape[0]
         mll = gpytorch.mlls.VariationalELBO(self.likelihood, self, n)
 
-        self._fit_mll(train_x, train_y, mll, **kwargs)
+        self._fit_mll(mll, **kwargs)
 
     def sample(
         self, x: Union[torch.Tensor, np.ndarray], num_samples: int

--- a/aepsych/models/gp_regression.py
+++ b/aepsych/models/gp_regression.py
@@ -60,7 +60,7 @@ class GPRegressionModel(AEPsychMixin, ExactGP):
         if likelihood is None:
             likelihood = GaussianLikelihood()
 
-        if num_outputs is not None: 
+        if num_outputs is not None:
             self._num_outputs = num_outputs
             self._batch_size = num_outputs
 
@@ -75,7 +75,7 @@ class GPRegressionModel(AEPsychMixin, ExactGP):
                     "default_mean_covar_factory": {
                         "lb": str(self.lb.tolist()),
                         "ub": str(self.ub.tolist()),
-                        "num_outputs":num_outputs,
+                        "num_outputs": num_outputs,
                     }
                 }
             )  # type: ignore
@@ -144,7 +144,7 @@ class GPRegressionModel(AEPsychMixin, ExactGP):
         """
         self.set_train_data(train_x, train_y)
         mll = gpytorch.mlls.ExactMarginalLogLikelihood(self.likelihood, self)
-        self._fit_mll(train_x, train_y, mll, **kwargs)
+        self._fit_mll(mll, **kwargs)
 
     def sample(
         self, x: Union[torch.Tensor, np.ndarray], num_samples: int

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -10,10 +10,10 @@ from typing import Callable, Iterable, List, Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
-from scipy.stats import norm
 
 from aepsych.strategy import Strategy
 from aepsych.utils import get_lse_contour, get_lse_interval, make_scaled_sobol
+from scipy.stats import norm
 
 
 def plot_strat(
@@ -279,7 +279,7 @@ def _plot_strat_2d(
     if logx:
         locs = np.arange(strat.lb[0], strat.ub[0])
         ax.set_xticks(ticks=locs)
-        ax.set_xticklabels(2.0 ** locs)
+        ax.set_xticklabels(2.0**locs)
 
     ax.plot(x[y == 0, 0], x[y == 0, 1], "ro", alpha=0.7, label=no_label)
     ax.plot(x[y == 1, 0], x[y == 1, 1], "bo", alpha=0.7, label=yes_label)

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -79,7 +79,9 @@ class AEPsychServer(object):
                 result = self.unversioned_handler(request)
         except Exception as e:
             result = "bad request"
-            logger.warning(f"Request '{request}' raised error '{e}'! Full traceback follows:")
+            logger.warning(
+                f"Request '{request}' raised error '{e}'! Full traceback follows:"
+            )
             logger.warning(traceback.format_exc())
 
         self.socket.send(result)

--- a/tests/acquisition/test_monotonic.py
+++ b/tests/acquisition/test_monotonic.py
@@ -6,11 +6,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from botorch.acquisition.objective import IdentityMCObjective
-from botorch.utils.testing import BotorchTestCase
 from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
 from aepsych.acquisition.objective import ProbitObjective
 from aepsych.models.derivative_gp import MixedDerivativeVariationalGP
+from botorch.acquisition.objective import IdentityMCObjective
+from botorch.utils.testing import BotorchTestCase
 
 
 class TestMonotonicAcq(BotorchTestCase):

--- a/tests/acquisition/test_objective.py
+++ b/tests/acquisition/test_objective.py
@@ -11,12 +11,12 @@ from itertools import product
 import numpy as np
 import torch
 from aepsych.acquisition.objective import (
+    FloorGumbelObjective,
     FloorLogitObjective,
     FloorProbitObjective,
-    FloorGumbelObjective,
 )
 from parameterized import parameterized
-from scipy.stats import logistic, gumbel_l, norm
+from scipy.stats import gumbel_l, logistic, norm
 
 objective_pairs = [
     (FloorLogitObjective, logistic),

--- a/tests/acquisition/test_rejection_sampler.py
+++ b/tests/acquisition/test_rejection_sampler.py
@@ -6,9 +6,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
-from botorch.utils.testing import BotorchTestCase
-from aepsych.models.derivative_gp import MixedDerivativeVariationalGP
 from aepsych.acquisition.rejection_sampler import RejectionSampler
+from aepsych.models.derivative_gp import MixedDerivativeVariationalGP
+from botorch.utils.testing import BotorchTestCase
 
 
 class TestRejectionSampling(BotorchTestCase):

--- a/tests/generators/test_optimize_acqf_generator.py
+++ b/tests/generators/test_optimize_acqf_generator.py
@@ -78,7 +78,7 @@ class TestOptimizeAcqfGenerator(unittest.TestCase):
         train_x = torch.Tensor([-0.5, 1, 0.5, -1]).reshape((2, 1, 2))
         train_y = torch.Tensor([0, 1])
         model.fit(train_x, train_y)
-        acqf = generator._instantiate_acquisition_fn(model=model, train_x=train_x)
+        acqf = generator._instantiate_acquisition_fn(model=model)
         self.assertTrue(isinstance(acqf, AnalyticExpectedUtilityOfBestOption))
 
 

--- a/tests/models/test_gp_regression.py
+++ b/tests/models/test_gp_regression.py
@@ -22,7 +22,7 @@ if "CI" in os.environ or "SANDCASTLE" in os.environ:
 
 class GPRegressionTest(unittest.TestCase):
     def f(self, x):
-        return x ** 3 - 4 * x ** 2 + np.random.normal() * 0.1
+        return x**3 - 4 * x**2 + np.random.normal() * 0.1
 
     def simulate_response(self, trial_params):
         x = trial_params["par1"][0]

--- a/tests/models/test_monotonic_projection_gp.py
+++ b/tests/models/test_monotonic_projection_gp.py
@@ -20,7 +20,6 @@ from sklearn.datasets import make_classification
 
 
 class MonotonicProjectionGPtest(unittest.TestCase):
-
     def setUp(self):
         np.random.seed(1)
         torch.manual_seed(1)
@@ -72,6 +71,7 @@ class MonotonicProjectionGPtest(unittest.TestCase):
         # And in samples
         samps = model.sample(Xtest, num_samples=10)
         self.assertTrue(samps.min().item() >= 4.9)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,7 +74,7 @@ class ConfigTestCase(unittest.TestCase):
 
         self.assertTrue(
             config.get_section("MCLevelSetEstimation")
-            == {"beta": "3.84", "objective": "ProbitObjective", "target":"0.75"}
+            == {"beta": "3.84", "objective": "ProbitObjective", "target": "0.75"}
         )
         self.assertTrue(
             config.get_section("OptimizeAcqfGenerator")
@@ -158,9 +158,7 @@ class ConfigTestCase(unittest.TestCase):
                 ProbitObjective,
             )
         )
-        self.assertTrue(
-            strat.strat_list[1].generator.samps == 1000
-        )
+        self.assertTrue(strat.strat_list[1].generator.samps == 1000)
         self.assertTrue(strat.strat_list[0].min_asks == 10)
         self.assertTrue(strat.strat_list[0].stimuli_per_trial == 1)
         self.assertTrue(strat.strat_list[0].outcome_types == ["binary"])
@@ -171,7 +169,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(torch.all(strat.strat_list[1].model.ub == torch.Tensor([1, 1])))
 
     def test_nonmonotonic_optimization_config_file(self):
-        
+
         config_file = "../configs/nonmonotonic_optimization_example.ini"
         config_file = os.path.join(os.path.dirname(__file__), config_file)
 
@@ -187,8 +185,7 @@ class ConfigTestCase(unittest.TestCase):
         )
         self.assertTrue(strat.strat_list[1].generator.acqf is qNoisyExpectedImprovement)
         self.assertTrue(
-            set(strat.strat_list[1].generator.acqf_kwargs.keys())
-            == {"objective"}
+            set(strat.strat_list[1].generator.acqf_kwargs.keys()) == {"objective"}
         )
         self.assertTrue(
             isinstance(
@@ -550,8 +547,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(isinstance(strat.strat_list[1].model, PairwiseProbitModel))
         self.assertTrue(strat.strat_list[1].generator.acqf is qNoisyExpectedImprovement)
         self.assertTrue(
-            set(strat.strat_list[1].generator.acqf_kwargs.keys())
-            == {"objective"}
+            set(strat.strat_list[1].generator.acqf_kwargs.keys()) == {"objective"}
         )
         self.assertTrue(
             isinstance(

--- a/tests/test_lookahead.py
+++ b/tests/test_lookahead.py
@@ -11,17 +11,15 @@ from itertools import product
 import numpy as np
 import torch
 from aepsych.acquisition import (
-    GlobalMI,
-    GlobalSUR,
     ApproxGlobalSUR,
     EAVC,
+    GlobalMI,
+    GlobalSUR,
     LocalMI,
     LocalSUR,
 )
 from aepsych.acquisition.bvn import bvn_cdf
-from aepsych.acquisition.lookahead_utils import (
-    posterior_at_xstar_xq,
-)
+from aepsych.acquisition.lookahead_utils import posterior_at_xstar_xq
 from botorch.utils.testing import MockModel, MockPosterior
 from gpytorch.distributions import MultivariateNormal
 from scipy.stats import multivariate_normal

--- a/tests/test_mean_covar_factories.py
+++ b/tests/test_mean_covar_factories.py
@@ -15,12 +15,8 @@ from aepsych.factory import (
     monotonic_mean_covar_factory,
     song_mean_covar_factory,
 )
-from aepsych.kernels.rbf_partial_grad import (
-    RBFKernelPartialObsGrad,
-)
-from aepsych.means.constant_partial_grad import (
-    ConstantMeanPartialObsGrad,
-)
+from aepsych.kernels.rbf_partial_grad import RBFKernelPartialObsGrad
+from aepsych.means.constant_partial_grad import ConstantMeanPartialObsGrad
 from scipy.stats import norm
 
 
@@ -238,7 +234,12 @@ class TestFactories(unittest.TestCase):
 
     def test_song_factory_2d_intensity_RBF(self):
         conf = {
-            "song_mean_covar_factory": {"lb": [0, 1], "ub": [1, 70], "target": 0.75, "intensity_RBF": True}
+            "song_mean_covar_factory": {
+                "lb": [0, 1],
+                "ub": [1, 70],
+                "target": 0.75,
+                "intensity_RBF": True,
+            }
         }
         config = Config(config_dict=conf)
         meanfun, covarfun = song_mean_covar_factory(config)
@@ -251,7 +252,9 @@ class TestFactories(unittest.TestCase):
         self.assertTrue(
             isinstance(covarfun.kernels[0].base_kernel, gpytorch.kernels.RBFKernel)
         )
-        self.assertTrue(np.allclose(covarfun.kernels[0].base_kernel.active_dims, [0,1]))
+        self.assertTrue(
+            np.allclose(covarfun.kernels[0].base_kernel.active_dims, [0, 1])
+        )
         self.assertTrue(
             isinstance(covarfun.kernels[1].base_kernel, gpytorch.kernels.LinearKernel)
         )
@@ -270,4 +273,6 @@ class TestFactories(unittest.TestCase):
         config = Config(config_dict=conf)
         meanfun, covarfun = song_mean_covar_factory(config)
         self.assertTrue(covarfun.kernels[1].base_kernel.active_dims == 0)
-        self.assertTrue(np.allclose(covarfun.kernels[0].base_kernel.active_dims, [0,1]))
+        self.assertTrue(
+            np.allclose(covarfun.kernels[0].base_kernel.active_dims, [0, 1])
+        )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,7 +9,7 @@ import json
 import logging
 import unittest
 import uuid
-from unittest.mock import MagicMock, PropertyMock, call, patch
+from unittest.mock import call, MagicMock, patch, PropertyMock
 
 import aepsych.server as server
 import aepsych.utils_logging as utils_logging

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,7 +44,7 @@ class UtilsTestCase(unittest.TestCase):
 
         # Wrong dim
         with self.assertRaises(AssertionError):
-            _process_bounds(np.r_[0,0], np.r_[1,1], 3)
+            _process_bounds(np.r_[0, 0], np.r_[1, 1], 3)
 
         # ub < lb
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
`fit_gpytorch_model` uses `model.train_inputs` and `model.train_targets` so we should only pass them in once, `set_train_data` once, and then always use the attributes we've set. Really sorry about combining all the formatting changes into the same PR, I habitually ran ufmt and backing all of this out without backing out the actual changes I wanted to make seemed not worth it. 