### PR TITLE
allow aepsych client to connect to in-memory server

### DIFF
--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -6,7 +6,7 @@
 
 from os import path
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "Readme.md"), encoding="utf-8") as f:
@@ -14,7 +14,7 @@ with open(path.join(this_directory, "Readme.md"), encoding="utf-8") as f:
 
 setup(
     name="aepsych_client",
-    version="0.1",
+    version="0.1.1",
     packages=find_packages(),
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/examples/data_collection_analysis_tutorial.ipynb
+++ b/examples/data_collection_analysis_tutorial.ipynb
@@ -209,30 +209,54 @@
   {
    "cell_type": "markdown",
    "source": [
-    "## Starting the AEPsych Server\n",
-    "The code block below starts an AEPsych server that will run in the background (you can also start the server by running the second line in a command prompt). We can contact the server at IP address 0.0.0.0, port 5555, and the data will be saved in a database named \"data_collection_analysis_tutorial.db\". In this tutorial, we will run the server on the same computer as the experiment, but it is also possible to run the server remotely. "
+    "## Starting the AEPsych Server and Client\n",
+    "The code block below starts an AEPsychClient and connects it to a local AEPsychServer. The data will be saved in a database named \"data_collection_analysis_tutorial.db\"."
    ],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "source": [
-    "%%bash --bg\n",
-    "\n",
-    "aepsych_server --ip 0.0.0.0 --port 5555 database --db data_collection_analysis_tutorial.db"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "source": [
+    "from aepsych.server import AEPsychServer\n",
     "from aepsych_client import AEPsychClient\n",
-    "client = AEPsychClient(ip=\"0.0.0.0\", port=5555)"
+    "\n",
+    "server = AEPsychServer(database_path=\"data_collection_analysis_tutorial.db\")\n",
+    "client = AEPsychClient(server=server)"
    ],
    "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Note that in the code block above, we run both the client and the sever in the same Python process. If we wanted to run the server in a separate process, or even a separate computer, we could start it by running the code block below in a command line:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "```bash\n",
+    "aepsych_server --ip 0.0.0.0 --port 5555 database --db data_collection_analysis_tutorial.db\n",
+    "```"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "And then connecting the client to the server using the `ip` and `port` arguments, like so:"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "```Python\n",
+    "client = AEPsychClient(ip=\"0.0.0.0\", port=5555)\n",
+    "```"
+   ],
    "metadata": {}
   },
   {
@@ -425,7 +449,7 @@
    "cell_type": "markdown",
    "source": [
     "## Replaying the Experiment and Analyzing Data\n",
-    "To analyze the data, we open the database with an `AEPsychServer` object. This server runs here in the notebook rather than in the background like the server we used to collect data."
+    "To analyze the data, we open the database with an `AEPsychServer` object. We'll create a new server object, since the one we used earlier was closed by the client."
    ],
    "metadata": {}
   },
@@ -433,8 +457,6 @@
    "cell_type": "code",
    "execution_count": 14,
    "source": [
-    "from aepsych.server import AEPsychServer\n",
-    "\n",
     "serv = AEPsychServer(database_path=\"data_collection_analysis_tutorial.db\")"
    ],
    "outputs": [
@@ -761,9 +783,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
+   "name": "python3",
+   "display_name": "Python 3.9.7 64-bit"
   },
   "language_info": {
    "codemirror_mode": {
@@ -776,6 +797,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.7"
+  },
+  "interpreter": {
+   "hash": "445720f8fdcbba65d997174e9b6315f32a9c0fb7d8d99a631746a7b63e54ff16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Summary: This allows users to pass a server object to the python client, allowing them to communicate with the server using the client interface, but without having to start it in a separate process. This should simplify some of our tests and tutorials.

Reviewed By: mshvartsman

Differential Revision: D39830540

