### PR TITLE
fix bug with async server

### DIFF
--- a/aepsych/server/sockets.py
+++ b/aepsych/server/sockets.py
@@ -125,7 +125,7 @@ class PySocket(object):
 
         while not server_exiting:
             rlist, wlist, xlist = select.select(
-                [self.conn], [], [], timeout=0
+                [self.conn], [], [], 0
             )  # 0 Here is the timeout. It makes the server constantly poll for output. Timeout can be added to save CPU usage.
             # rlist,wlist,xlist represent lists of sockets to check against. Rlist is sockets to read from, wlist is sockets to write to, xlist is sockets to listen to for errors.
             for sock in rlist:


### PR DESCRIPTION
Summary: select.select cannot take keyword arguments, so calling with an explicit timeout argument caused the server to crash. This makes timeout a positional argument instead.

Differential Revision: D40486252

