### PR TITLE
added ax functionality

### DIFF
--- a/aepsych/acquisition/__init__.py
+++ b/aepsych/acquisition/__init__.py
@@ -8,7 +8,7 @@
 import sys
 
 from ..config import Config
-from .lookahead import ApproxGlobalSUR, EAVC, GlobalMI, GlobalSUR, LocalMI, LocalSUR
+from .lookahead import EAVC, ApproxGlobalSUR, GlobalMI, GlobalSUR, LocalMI, LocalSUR
 from .lse import MCLevelSetEstimation
 from .mc_posterior_variance import MCPosteriorVariance, MonotonicMCPosteriorVariance
 from .monotonic_rejection import MonotonicMCLSE
@@ -22,7 +22,6 @@ from .objective import (
     FloorProbitObjective,
     ProbitObjective,
 )
-
 
 lse_acqfs = [
     MonotonicMCLSE,

--- a/aepsych/acquisition/acquisition.py
+++ b/aepsych/acquisition/acquisition.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from ax.models.torch.botorch_modular.acquisition import Acquisition
+from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
+
+
+class AEPsychAcquisition(Acquisition):
+    def get_botorch_objective_and_transform(
+        self, **kwargs
+    ) -> Tuple[Optional[MCAcquisitionObjective], Optional[PosteriorTransform]]:
+
+        objective, transform = super().get_botorch_objective_and_transform(**kwargs)
+
+        if "objective" in self.options:
+            objective = self.options.pop("objective")
+
+        return objective, transform

--- a/aepsych/acquisition/lse.py
+++ b/aepsych/acquisition/lse.py
@@ -9,6 +9,7 @@ from typing import Optional, Union
 
 import torch
 from aepsych.acquisition.objective import ProbitObjective
+from botorch.acquisition.input_constructors import acqf_input_constructor
 from botorch.acquisition.monte_carlo import (
     MCAcquisitionFunction,
     MCAcquisitionObjective,
@@ -84,3 +85,23 @@ class MCLevelSetEstimation(MCAcquisitionFunction):
         post = self.model.posterior(X)
         samples = self.sampler(post)  # num_samples x batch_shape x q x d_out
         return self.acquisition(self.objective(samples, X)).squeeze(-1)
+
+
+@acqf_input_constructor(MCLevelSetEstimation)
+def construct_inputs_lse(
+    model,
+    training_data,
+    objective=None,
+    target=0.75,
+    beta=3.84,
+    sampler=None,
+    **kwargs,
+):
+
+    return {
+        "model": model,
+        "objective": objective,
+        "target": target,
+        "beta": beta,
+        "sampler": sampler,
+    }

--- a/aepsych/acquisition/mc_posterior_variance.py
+++ b/aepsych/acquisition/mc_posterior_variance.py
@@ -10,6 +10,7 @@ from typing import Optional
 import torch
 from aepsych.acquisition.monotonic_rejection import MonotonicMCAcquisition
 from aepsych.acquisition.objective import ProbitObjective
+from botorch.acquisition.input_constructors import acqf_input_constructor
 from botorch.acquisition.monte_carlo import MCAcquisitionFunction
 from botorch.acquisition.objective import MCAcquisitionObjective
 from botorch.models.model import Model
@@ -84,6 +85,21 @@ class MCPosteriorVariance(MCAcquisitionFunction):
         if len(obj_samples.shape) == 2:
             obj_samples = obj_samples[..., None]
         return balv_acq(obj_samples)
+
+
+@acqf_input_constructor(MCPosteriorVariance)
+def construct_inputs(
+    model,
+    training_data,
+    objective=None,
+    sampler=None,
+    **kwargs,
+):
+    return {
+        "model": model,
+        "objective": objective,
+        "sampler": sampler,
+    }
 
 
 class MonotonicMCPosteriorVariance(MonotonicMCAcquisition):

--- a/aepsych/acquisition/mutual_information.py
+++ b/aepsych/acquisition/mutual_information.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 import torch
 from aepsych.acquisition.monotonic_rejection import MonotonicMCAcquisition
+from botorch.acquisition.input_constructors import acqf_input_constructor
 from botorch.acquisition.monte_carlo import MCAcquisitionFunction
 from botorch.acquisition.objective import MCAcquisitionObjective
 from botorch.models.model import Model
@@ -110,6 +111,21 @@ class BernoulliMCMutualInformation(MCAcquisitionFunction):
         if len(obj_samples.shape) == 2:
             obj_samples = obj_samples[..., None]
         return bald_acq(obj_samples)
+
+
+@acqf_input_constructor(BernoulliMCMutualInformation)
+def construct_inputs_mi(
+    model,
+    training_data,
+    objective=None,
+    sampler=None,
+    **kwargs,
+):
+    return {
+        "model": model,
+        "objective": objective,
+        "sampler": sampler,
+    }
 
 
 class MonotonicBernoulliMCMutualInformation(MonotonicMCAcquisition):

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -4,7 +4,7 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-
+import abc
 import ast
 import configparser
 import json
@@ -355,6 +355,18 @@ class Config(configparser.ConfigParser):
 
         else:
             raise RuntimeError("Unrecognized config format!")
+
+
+class ConfigurableMixin(abc.ABC):
+    @abc.abstractclassmethod
+    def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]:  # noqa
+        raise NotImplementedError(
+            f"get_config_options hasn't been defined for {cls.__name__}!"
+        )
+
+    @classmethod
+    def from_config(cls, config: Config, name: Optional[str] = None):
+        return cls(**cls.get_config_options(config, name))
 
 
 Config.register_module(gpytorch.kernels)

--- a/aepsych/config.pyi
+++ b/aepsych/config.pyi
@@ -5,6 +5,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import abc
 import configparser
 from typing import Any, ClassVar, Dict, List, Mapping, Optional, TypeVar, Union
 
@@ -62,3 +63,9 @@ class Config(configparser.ConfigParser):
     ) -> Union[np.ndarray, _T]: ...
     @classmethod
     def register_module(cls: _T, module): ...
+
+class ConfigurableMixin(abc.ABC):
+    @classmethod
+    def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]: ...
+    @classmethod
+    def from_config(cls, config: Config, name: Optional[str] = None): ...

--- a/aepsych/factory/factory.py
+++ b/aepsych/factory/factory.py
@@ -13,6 +13,7 @@ import torch
 from aepsych.config import Config
 from aepsych.kernels.rbf_partial_grad import RBFKernelPartialObsGrad
 from aepsych.means.constant_partial_grad import ConstantMeanPartialObsGrad
+from aepsych.utils import get_dim
 from scipy.stats import norm
 
 """AEPsych factory functions.
@@ -48,8 +49,6 @@ def default_mean_covar_factory(
             ConstantMean and ScaleKernel with priors based on bounds.
     """
 
-    lb = config.gettensor("default_mean_covar_factory", "lb")
-    ub = config.gettensor("default_mean_covar_factory", "ub")
     fixed_mean = config.getboolean(
         "default_mean_covar_factory", "fixed_mean", fallback=False
     )
@@ -63,8 +62,17 @@ def default_mean_covar_factory(
         "default_mean_covar_factory", "kernel", fallback=gpytorch.kernels.RBFKernel
     )
 
-    assert lb.shape[0] == ub.shape[0], "bounds shape mismatch!"
-    dim = lb.shape[0]
+    mean = gpytorch.means.ConstantMean()
+
+    if config.getboolean("common", "use_ax", fallback=False):
+        dim = get_dim(config)
+
+    else:
+        lb = config.gettensor("default_mean_covar_factory", "lb")
+        ub = config.gettensor("default_mean_covar_factory", "ub")
+        assert lb.shape[0] == ub.shape[0], "bounds shape mismatch!"
+        dim = lb.shape[0]
+
     mean = gpytorch.means.ConstantMean()
 
     if fixed_mean:
@@ -184,10 +192,15 @@ def song_mean_covar_factory(
         Tuple[gpytorch.means.ConstantMean, gpytorch.kernels.AdditiveKernel]: Instantiated
             constant mean object and additive kernel object.
     """
-    lb = config.gettensor("song_mean_covar_factory", "lb")
-    ub = config.gettensor("song_mean_covar_factory", "ub")
-    assert lb.shape[0] == ub.shape[0], "bounds shape mismatch!"
-    dim = lb.shape[0]
+
+    if config.getboolean("common", "use_ax", fallback=False):
+        dim = get_dim(config)
+
+    else:
+        lb = config.gettensor("song_mean_covar_factory", "lb")
+        ub = config.gettensor("song_mean_covar_factory", "ub")
+        assert lb.shape[0] == ub.shape[0], "bounds shape mismatch!"
+        dim = lb.shape[0]
 
     mean = gpytorch.means.ConstantMean()
 

--- a/aepsych/generators/__init__.py
+++ b/aepsych/generators/__init__.py
@@ -12,11 +12,11 @@ from .epsilon_greedy_generator import EpsilonGreedyGenerator
 from .manual_generator import ManualGenerator
 from .monotonic_rejection_generator import MonotonicRejectionGenerator
 from .monotonic_thompson_sampler_generator import MonotonicThompsonSamplerGenerator
-from .optimize_acqf_generator import OptimizeAcqfGenerator
+from .optimize_acqf_generator import AxOptimizeAcqfGenerator, OptimizeAcqfGenerator
 from .pairwise_optimize_acqf_generator import PairwiseOptimizeAcqfGenerator
 from .pairwise_sobol_generator import PairwiseSobolGenerator
 from .random_generator import RandomGenerator
-from .sobol_generator import SobolGenerator
+from .sobol_generator import AxSobolGenerator, SobolGenerator
 
 __all__ = [
     "OptimizeAcqfGenerator",
@@ -28,6 +28,8 @@ __all__ = [
     "ManualGenerator",
     "PairwiseOptimizeAcqfGenerator",
     "PairwiseSobolGenerator",
+    "AxOptimizeAcqfGenerator",
+    "AxSobolGenerator",
 ]
 
 Config.register_module(sys.modules[__name__])

--- a/aepsych/generators/completion_criterion/__init__.py
+++ b/aepsych/generators/completion_criterion/__init__.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+
+from aepsych.config import Config
+
+from .min_asks import MinAsks
+from .min_total_outcome_occurrences import MinTotalOutcomeOccurrences
+from .min_total_tells import MinTotalTells
+from .run_indefinitely import RunIndefinitely
+
+completion_criteria = [
+    MinTotalTells,
+    MinAsks,
+    MinTotalOutcomeOccurrences,
+    RunIndefinitely,
+]
+
+__all__ = [
+    "completion_criteria",
+    "MinTotalTells",
+    "MinAsks",
+    "MinTotalOutcomeOccurrences",
+    "RunIndefinitely",
+]
+
+Config.register_module(sys.modules[__name__])

--- a/aepsych/generators/completion_criterion/min_asks.py
+++ b/aepsych/generators/completion_criterion/min_asks.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+from aepsych.config import Config, ConfigurableMixin
+from ax.core.base_trial import TrialStatus
+from ax.modelbridge.completion_criterion import MinimumTrialsInStatus
+
+
+class MinAsks(MinimumTrialsInStatus, ConfigurableMixin):
+    @classmethod
+    def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]:
+        min_asks = config.getint(name, "min_asks", fallback=1)
+        options = {"status": TrialStatus.RUNNING, "threshold": min_asks}
+        return options

--- a/aepsych/generators/completion_criterion/min_total_outcome_occurrences.py
+++ b/aepsych/generators/completion_criterion/min_total_outcome_occurrences.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+from aepsych.config import Config, ConfigurableMixin
+from ax.modelbridge.completion_criterion import MinimumPreferenceOccurances
+
+
+class MinTotalOutcomeOccurrences(MinimumPreferenceOccurances, ConfigurableMixin):
+    @classmethod
+    def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]:
+        outcome_types = config.getlist(name, "outcome_types", element_type=str)
+        min_total_outcome_occurrences = config.getint(
+            name,
+            "min_total_outcome_occurrences",
+            fallback=1 if "binary" in outcome_types else 0,
+        )
+        options = {
+            "metric_name": "objective",
+            "threshold": min_total_outcome_occurrences,
+        }
+        return options

--- a/aepsych/generators/completion_criterion/min_total_tells.py
+++ b/aepsych/generators/completion_criterion/min_total_tells.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+from aepsych.config import Config, ConfigurableMixin
+from ax.core.base_trial import TrialStatus
+from ax.modelbridge.completion_criterion import MinimumTrialsInStatus
+
+
+class MinTotalTells(MinimumTrialsInStatus, ConfigurableMixin):
+    @classmethod
+    def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]:
+        min_total_tells = config.getint(name, "min_total_tells", fallback=1)
+        options = {"status": TrialStatus.COMPLETED, "threshold": min_total_tells}
+        return options

--- a/aepsych/generators/completion_criterion/run_indefinitely.py
+++ b/aepsych/generators/completion_criterion/run_indefinitely.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+from aepsych.config import Config, ConfigurableMixin
+from ax.core import Experiment
+from ax.modelbridge.completion_criterion import CompletionCriterion
+
+
+class RunIndefinitely(CompletionCriterion, ConfigurableMixin):
+    def __init__(self, run_indefinitely: bool) -> None:
+        self.run_indefinitely = run_indefinitely
+
+    def is_met(self, experiment: Experiment) -> bool:
+        return not self.run_indefinitely
+
+    @classmethod
+    def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]:
+        run_indefinitely = config.getboolean(name, "run_indefinitely", fallback=False)
+        options = {"run_indefinitely": run_indefinitely}
+        return options

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -4,15 +4,17 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 import torch
 from aepsych.config import Config
-from aepsych.generators.base import AEPsychGenerator
+from aepsych.generators.base import AEPsychGenerationStep, AEPsychGenerator
 from aepsych.models.base import AEPsychMixin
 from aepsych.utils import _process_bounds
+from ax.modelbridge import Models
 from torch.quasirandom import SobolEngine
 
 
@@ -82,3 +84,23 @@ class SobolGenerator(AEPsychGenerator):
         return cls(
             lb=lb, ub=ub, dim=dim, seed=seed, stimuli_per_trial=stimuli_per_trial
         )
+
+    @classmethod
+    def get_config_options(cls, config: Config, name: str):
+        return AxSobolGenerator.get_config_options(config, name)
+
+
+class AxSobolGenerator(AEPsychGenerationStep):
+    @classmethod
+    def get_config_options(cls, config: Config, name: str) -> Dict:
+        classname = "SobolGenerator"
+        seed = config.getint(classname, "seed", fallback=None)
+        scramble = config.getboolean(classname, "scramble", fallback=True)
+
+        opts = {
+            "model": Models.SOBOL,
+            "model_kwargs": {"seed": seed, "scramble": scramble},
+        }
+        opts.update(super().get_config_options(config, name))
+
+        return opts

--- a/aepsych/models/__init__.py
+++ b/aepsych/models/__init__.py
@@ -8,12 +8,14 @@
 import sys
 
 from ..config import Config
+from .exact_gp import ContinuousRegressionGP, ExactGP
 from .gp_classification import GPClassificationModel
 from .gp_regression import GPRegressionModel
 from .monotonic_projection_gp import MonotonicProjectionGP
 from .monotonic_rejection_gp import MonotonicRejectionGP
 from .ordinal_gp import OrdinalGPModel
 from .pairwise_probit import PairwiseProbitModel
+from .variational_gp import BinaryClassificationGP, VariationalGP
 
 __all__ = [
     "GPClassificationModel",
@@ -22,6 +24,10 @@ __all__ = [
     "PairwiseProbitModel",
     "OrdinalGPModel",
     "MonotonicProjectionGP",
+    "VariationalGP",
+    "BinaryClassificationGP",
+    "ExactGP",
+    "ContinuousRegressionGP",
 ]
 
 Config.register_module(sys.modules[__name__])

--- a/aepsych/models/exact_gp.py
+++ b/aepsych/models/exact_gp.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from aepsych.models.base import AEPsychModel
+from aepsych.utils_logging import getLogger
+from botorch.models import SingleTaskGP
+from gpytorch.mlls import ExactMarginalLogLikelihood
+
+logger = getLogger()
+
+
+class ExactGP(AEPsychModel, SingleTaskGP):
+    @classmethod
+    def get_mll_class(cls):
+        return ExactMarginalLogLikelihood
+
+
+class ContinuousRegressionGP(ExactGP):
+    """GP Regression model for single continuous outcomes, using exact inference."""
+
+    stimuli_per_trial = 1
+    outcome_type = "continuous"

--- a/aepsych/models/gp_classification.py
+++ b/aepsych/models/gp_classification.py
@@ -189,7 +189,7 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP):
     def _reset_variational_strategy(self):
         inducing_points = select_inducing_points(
             inducing_size=self.inducing_size,
-            model=self,
+            covar_module=self.covar_module,
             X=self.train_inputs[0],
             bounds=self.bounds,
             method=self.inducing_point_method,

--- a/aepsych/models/monotonic_rejection_gp.py
+++ b/aepsych/models/monotonic_rejection_gp.py
@@ -158,7 +158,7 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
 
         self.inducing_points = select_inducing_points(
             inducing_size=self.inducing_size,
-            model=self,
+            covar_module=self.covar_module,
             X=self.train_inputs[0],
             bounds=self.bounds,
             method=self.inducing_point_method,

--- a/aepsych/models/surrogate.py
+++ b/aepsych/models/surrogate.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import dataclasses
+import time
+from typing import Dict, List, Optional
+
+from aepsych.utils_logging import getLogger
+from ax.core.search_space import SearchSpaceDigest
+from ax.core.types import TCandidateMetadata
+from ax.models.torch.botorch_modular.surrogate import Surrogate
+from botorch.fit import fit_gpytorch_mll
+from botorch.utils.datasets import SupervisedDataset
+from torch import Tensor
+
+logger = getLogger()
+
+
+class AEPsychSurrogate(Surrogate):
+    def __init__(self, max_fit_time: Optional[float] = None, **kwargs) -> None:
+        self.max_fit_time = max_fit_time
+        super().__init__(**kwargs)
+
+    def fit(
+        self,
+        datasets: List[SupervisedDataset],
+        metric_names: List[str],
+        search_space_digest: SearchSpaceDigest,
+        candidate_metadata: Optional[List[List[TCandidateMetadata]]] = None,
+        state_dict: Optional[Dict[str, Tensor]] = None,
+        refit: bool = True,
+        **kwargs,
+    ) -> None:
+        self.construct(
+            datasets=datasets,
+            metric_names=metric_names,
+            **dataclasses.asdict(search_space_digest),
+        )
+        self._outcomes = metric_names
+        if state_dict:
+            self.model.load_state_dict(state_dict)
+
+        if state_dict is None or refit:
+            mll = self.mll_class(self.model.likelihood, self.model, **self.mll_options)
+            optimizer_kwargs = {}
+            if self.max_fit_time is not None:
+                # figure out how long evaluating a single samp
+                starttime = time.time()
+                _ = mll(self.model(datasets[0].X()), datasets[0].Y().squeeze())
+                single_eval_time = time.time() - starttime
+                n_eval = int(self.max_fit_time / single_eval_time)
+                logger.info(f"fit maxfun is {n_eval}")
+                optimizer_kwargs["options"] = {"maxfun": n_eval}
+
+            logger.info("Starting fit...")
+            starttime = time.time()
+            fit_gpytorch_mll(
+                mll, optimizer_kwargs=optimizer_kwargs
+            )  # TODO: Support flexible optimizers
+            logger.info(f"Fit done, time={time.time()-starttime}")

--- a/aepsych/models/variational_gp.py
+++ b/aepsych/models/variational_gp.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Dict, Optional, Tuple, Union
+
+import numpy as np
+import torch
+from aepsych.config import Config
+from aepsych.models.base import AEPsychModel
+from aepsych.models.utils import get_probability_space, select_inducing_points
+from aepsych.utils import promote_0d
+from botorch.models import SingleTaskVariationalGP
+from gpytorch.likelihoods import BernoulliLikelihood
+from gpytorch.mlls import VariationalELBO
+
+
+# TODO: Find a better way to do this on the Ax/Botorch side
+class MyHackyVariationalELBO(VariationalELBO):
+    def __init__(self, likelihood, model, beta=1.0, combine_terms=True):
+        num_data = model.model.train_targets.shape[0]
+        super().__init__(likelihood, model.model, num_data, beta, combine_terms)
+
+
+class VariationalGP(AEPsychModel, SingleTaskVariationalGP):
+    @classmethod
+    def get_mll_class(cls):
+        return MyHackyVariationalELBO
+
+    @classmethod
+    def construct_inputs(cls, training_data, **kwargs):
+        inputs = super().construct_inputs(training_data=training_data, **kwargs)
+
+        inducing_size = kwargs.get("inducing_size")
+        inducing_point_method = kwargs.get("inducing_point_method")
+        bounds = kwargs.get("bounds")
+        inducing_points = select_inducing_points(
+            inducing_size,
+            inputs["covar_module"],
+            inputs["train_X"],
+            bounds,
+            inducing_point_method,
+        )
+
+        inputs.update(
+            {
+                "inducing_points": inducing_points,
+            }
+        )
+
+        return inputs
+
+    @classmethod
+    def get_config_options(cls, config: Config, name: Optional[str] = None) -> Dict:
+        classname = cls.__name__
+
+        options = super().get_config_options(config, classname)
+
+        inducing_point_method = config.get(
+            classname, "inducing_point_method", fallback="auto"
+        )
+        inducing_size = config.getint(classname, "inducing_size", fallback=10)
+        learn_inducing_points = config.getboolean(
+            classname, "learn_inducing_points", fallback=False
+        )
+
+        options.update(
+            {
+                "inducing_size": inducing_size,
+                "inducing_point_method": inducing_point_method,
+                "learn_inducing_points": learn_inducing_points,
+            }
+        )
+
+        return options
+
+
+class BinaryClassificationGP(VariationalGP):
+    stimuli_per_trial = 1
+    outcome_type = "binary"
+
+    def predict(
+        self, x: Union[torch.Tensor, np.ndarray], probability_space: bool = False
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Query the model for posterior mean and variance.
+
+        Args:
+            x (torch.Tensor): Points at which to predict from the model.
+            probability_space (bool, optional): Return outputs in units of
+                response probability instead of latent function value. Defaults to False.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: Posterior mean and variance at queries points.
+        """
+        with torch.no_grad():
+            post = self.posterior(x)
+
+        if probability_space:
+            fmean, fvar = get_probability_space(
+                likelihood=self.likelihood, posterior=post
+            )
+        else:
+            fmean = post.mean.squeeze()
+        fvar = post.variance.squeeze()
+
+        return promote_0d(fmean), promote_0d(fvar)
+
+    @classmethod
+    def get_config_options(cls, config: Config, name: Optional[str] = None):
+        options = super().get_config_options(config)
+        if options["likelihood"] is None:
+            options["likelihood"] = BernoulliLikelihood()
+        return options

--- a/configs/ax_example.ini
+++ b/configs/ax_example.ini
@@ -1,0 +1,61 @@
+# The common section includes parameters and other info used by multiple parts of the server.
+[common]
+use_ax = True # Required to enable the new parameter features.
+
+stimuli_per_trial = 1 # The number of stimuli shown in each trial; currently the Ax backend only supports 1
+outcome_types = [continuous] # The type of response given by the participant; can be [binary] or [continuous].
+                             # Multiple outcomes will be supported in a future update.
+
+parnames = [par1, par2, par3] # Names of continuous parameters.
+lb = [0, 0, 1] # Lower bounds of the continuous parameters, in the same order as above.
+ub = [10, 10, 100] # Upper bounds of the continuous parameter, in the same order as above.
+par_constraints = [par1 >= par2] # Linear constrains placed on the continuous parameters
+                                                     # Parameters with log_scale = True cannot be included here.
+                                                     # Having lots of constraints may make trial generation slow.
+
+choice_parnames = [par4, par5] # Names of discrete parameters; the possible values of each are specified below.
+
+fixed_parnames = [par6, par7] # Names of fixed parameters, the values of which are specified below. These parameters
+                              # always have the same value and are not modeled.
+
+strategy_names = [init_strat, opt_strat] # The strategies that will be used, corresponding to the named sections below
+
+# Configuration for the initialization strategy, which we use to gather initial points
+# before we start doing model-based acquisition.
+[init_strat]
+generator = SobolGenerator # Start trial generation with sobol samples.
+min_total_tells = 2 # Number of data points required to complete this strategy. For a real experiment, you will want
+                    # 5-10 initialization trials per parameter.
+
+# Configuration for the optimization strategy, our model-based acquisition strategy.
+[opt_strat]
+generator = OptimizeAcqfGenerator # after sobol, do model-based active-learning
+min_total_tells = 3 # Finish the experiment after 4 total data points have been collected. Depending on how noisy
+                    # your problem is, you may need several dozen points per parameter to get an accurate model.
+acqf = qNoisyExpectedImprovement # The acquisition function to be used with the model. We recommend
+                                 # qNoisyExpectedImprovement for optimization problems.
+model = ContinuousRegressionGP # Basic model for continuous outcomes.
+
+# Configuration for the model
+[ContinuousRegressionGP]
+max_fit_time = 0.1 # Maximum fitting time in seconds. This is set to a small value here for testing, but setting a
+                   # higher value can produce better model fits. If not specified, model will spend as much time as
+                   # it needs to get the best fit it can.
+
+[par3]
+log_scale = True # Indicates that par4 should be searched in log space. This is useful when percentage increases are
+                 # more important than absolute increases, i.e., the difference from 1 to 2 is greater than 10 to 11.
+value_type = int # Specifies that par1 can only take integer values.
+
+[par4]
+choices = [a, b] # Possible values for the discrete parameter, par4. By default, no ordering is assumed.
+
+[par5]
+choices = [low, med, high] # Possible values for the discrete parameter, par5.
+is_ordered = True # Indicates that the choices for par5 are ordered such that low < med < high.
+
+[par6]
+value = 123 # Value of the fixed parameter, par6. Can be a float or string.
+
+[par7]
+value = placeholder # Value of the fixed parameter, par7. Can be a float or string.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,7 @@ torch
 pyzmq==19.0.2
 scipy
 sklearn
-gpytorch>=1.8.1
 statsmodels
-botorch>=0.8.0
 SQLAlchemy
 dill
 pandas
@@ -14,3 +12,4 @@ pathos
 aepsych_client>=0.2.0
 voila==0.3.6
 ipywidgets==7.6.5
+ax-platform

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ REQUIRES = [
     "pyzmq==19.0.2",
     "scipy",
     "sklearn",
-    "gpytorch>=1.9.0",
-    "botorch>=0.8.0",
     "SQLAlchemy",
     "dill",
     "pandas",
@@ -28,6 +26,7 @@ REQUIRES = [
     "voila==0.3.6",
     "ipywidgets==7.6.5",
     "statsmodels",
+    "ax-platform"
 ]
 
 DEV_REQUIRES = [

--- a/tests/generators/test_completion_criteria.py
+++ b/tests/generators/test_completion_criteria.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from aepsych.config import Config
+from aepsych.generators.completion_criterion import (
+    MinAsks,
+    MinTotalOutcomeOccurrences,
+    MinTotalTells,
+    RunIndefinitely,
+)
+from aepsych.strategy import AEPsychStrategy
+
+
+class CompletionCriteriaTestCase(unittest.TestCase):
+    def setUp(self):
+        config_str = """
+        [common]
+        use_ax = True
+        stimuli_per_trial = 1
+        outcome_types = [binary]
+        parnames = [x]
+        lb = [0]
+        ub = [1]
+        strategy_names = [test_strat]
+
+        [test_strat]
+        generator = SobolGenerator
+        """
+        config = Config(config_str=config_str)
+        self.strat = AEPsychStrategy.from_config(config)
+
+    def test_min_asks(self):
+        config_str = """
+        [test_strat]
+        min_asks = 2
+        """
+        config = Config(config_str=config_str)
+        criterion = MinAsks.from_config(config, "test_strat")
+        self.assertEqual(criterion.threshold, 2)
+
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.add_data({"x": [0.0]}, 0.0)
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.add_data({"x": [1.0]}, 0.0)
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.gen()
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.gen()
+        self.assertTrue(criterion.is_met(self.strat.experiment))
+
+    def test_min_total_tells(self):
+        config_str = """
+        [test_strat]
+        min_total_tells = 2
+        """
+        config = Config(config_str=config_str)
+        criterion = MinTotalTells.from_config(config, "test_strat")
+        self.assertEqual(criterion.threshold, 2)
+
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.gen()
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.gen()
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.add_data({"x": [0.0]}, 0.0)
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.add_data({"x": [1.0]}, 0.0)
+        self.assertTrue(criterion.is_met(self.strat.experiment))
+
+    def test_min_total_outcome_occurences(self):
+        config_str = """
+        [common]
+        outcome_types = [binary]
+        min_total_outcome_occurrences = 2
+        """
+        config = Config(config_str=config_str)
+        criterion = MinTotalOutcomeOccurrences.from_config(config, "test_strat")
+        self.assertEqual(criterion.threshold, 2)
+
+        self.strat.add_data({"x": [0.0]}, 0.0)
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.add_data({"x": [1.0]}, 0.0)
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.add_data({"x": [0.0]}, 1.0)
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+        self.strat.add_data({"x": [1.0]}, 1.0)
+        self.assertTrue(criterion.is_met(self.strat.experiment))
+
+    def run_indefinitely(self):
+        config_str = """
+        [common]
+        outcome_types = [binary]
+        run_indefinitely = False
+        """
+        config = Config(config_str=config_str)
+        criterion = RunIndefinitely(**RunIndefinitely.from_config(config, "test_strat"))
+        self.assertTrue(criterion.is_met(self.strat.experiment))
+
+        config_str = """
+        [common]
+        outcome_types = [binary]
+        run_indefinitely = True
+        """
+        config = Config(config_str=config_str)
+        criterion = RunIndefinitely(**RunIndefinitely.from_config(config, "test_strat"))
+        self.assertFalse(criterion.is_met(self.strat.experiment))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/generators/test_optimize_acqf_generator.py
+++ b/tests/generators/test_optimize_acqf_generator.py
@@ -12,8 +12,13 @@ import numpy as np
 import torch
 from aepsych.acquisition import MCLevelSetEstimation
 from aepsych.config import Config
-from aepsych.generators import OptimizeAcqfGenerator
-from aepsych.models import GPClassificationModel, PairwiseProbitModel
+from aepsych.generators import AxOptimizeAcqfGenerator, OptimizeAcqfGenerator
+from aepsych.models import (
+    ContinuousRegressionGP,
+    GPClassificationModel,
+    PairwiseProbitModel,
+)
+from ax.modelbridge import Models
 from botorch.acquisition.preference import AnalyticExpectedUtilityOfBestOption
 from sklearn.datasets import make_classification
 
@@ -80,6 +85,49 @@ class TestOptimizeAcqfGenerator(unittest.TestCase):
         model.fit(train_x, train_y)
         acqf = generator._instantiate_acquisition_fn(model=model)
         self.assertTrue(isinstance(acqf, AnalyticExpectedUtilityOfBestOption))
+
+    def test_axoptimizeacqf_config(self):
+        config_str = """
+                [common]
+                use_ax = True
+                parnames = [foo]
+                lb = [0]
+                ub = [1]
+                stimuli_per_trial = 1
+                outcome_types = [continuous]
+                strat_names = [opt]
+
+                [opt]
+                generator = OptimizeAcqfGenerator
+                model = ContinuousRegressionGP
+
+                [ContinuousRegressionGP]
+                max_fit_time = 1
+
+                [OptimizeAcqfGenerator]
+                acqf = MCLevelSetEstimation
+                max_gen_time = 1
+                restarts = 1
+                samps = 100
+
+                [MCLevelSetEstimation]
+                beta = 1
+                target = 0.5
+                """
+
+        config = Config(config_str=config_str)
+        gen = AxOptimizeAcqfGenerator.from_config(config, "opt")
+
+        self.assertEqual(gen.model, Models.BOTORCH_MODULAR)
+
+        self.assertEqual(
+            gen.model_kwargs["surrogate"].botorch_model_class, ContinuousRegressionGP
+        )
+        self.assertEqual(gen.model_gen_kwargs["restarts"], 1)
+        self.assertEqual(gen.model_gen_kwargs["samps"], 100)
+        self.assertEqual(gen.model_kwargs["acquisition_options"]["target"], 0.5)
+        self.assertEqual(gen.model_kwargs["acquisition_options"]["beta"], 1.0)
+        # TODO: Implement max_gen_time
 
 
 if __name__ == "__main__":

--- a/tests/generators/test_sobol_generator.py
+++ b/tests/generators/test_sobol_generator.py
@@ -11,8 +11,9 @@ import numpy as np
 import numpy.testing as npt
 import torch
 from aepsych.config import Config
-from aepsych.generators import SobolGenerator
+from aepsych.generators import AxSobolGenerator, SobolGenerator
 from aepsych.utils import make_scaled_sobol
+from ax.modelbridge import Models
 
 
 class TestSobolGenerator(unittest.TestCase):
@@ -75,3 +76,30 @@ class TestSobolGenerator(unittest.TestCase):
                 )
                 shape_out = (nsamp, dim, 2)
                 self.assertEqual(generator.gen(nsamp).shape, shape_out)
+
+    def test_axsobol_config(self):
+        config_str = """
+                [common]
+                parnames = [par1]
+                lb = [0]
+                ub = [1]
+                stimuli_per_trial = 1
+                outcome_types = [continuous]
+                strategy_names = [init]
+
+                [init]
+                generator = SobolGenerator
+
+                [SobolGenerator]
+                seed=12345
+                scramble=False
+                """
+        config = Config(config_str=config_str)
+        gen = AxSobolGenerator.from_config(config, name="init")
+        self.assertEqual(gen.model, Models.SOBOL)
+        self.assertEqual(gen.model_kwargs["seed"], 12345)
+        self.assertFalse(gen.model_kwargs["scramble"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ax_integration.py
+++ b/tests/test_ax_integration.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import unittest
+import uuid
+
+import numpy as np
+import torch
+from aepsych.config import Config
+from aepsych.server import AEPsychServer
+from aepsych_client import AEPsychClient
+from ax.service.utils.report_utils import exp_to_df
+
+
+class AxIntegrationTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Simulate participant responses; just returns the sum of the flat parameters
+        def simulate_response(trial_params):
+            pars = [
+                trial_params[par][0]
+                for par in trial_params
+                if type(trial_params[par][0]) == float
+            ]
+            response = np.array(pars).sum()
+            return response
+
+        # Fix random seeds
+        np.random.seed(0)
+        torch.manual_seed(0)
+
+        # Create a server object configured to run a 2d threshold experiment
+        database_path = "./{}.db".format(str(uuid.uuid4().hex))
+        cls.client = AEPsychClient(server=AEPsychServer(database_path=database_path))
+        config_file = "../configs/ax_example.ini"
+        config_file = os.path.join(os.path.dirname(__file__), config_file)
+        cls.client.configure(config_file)
+
+        while not cls.client.server.strat.finished:
+            # Ask the server what the next parameter values to test should be.
+            trial_params = cls.client.ask()
+
+            # Simulate a participant response.
+            outcome = simulate_response(trial_params["config"])
+
+            # Tell the server what happened so that it can update its model.
+            cls.client.tell(trial_params["config"], outcome)
+
+        cls.df = exp_to_df(cls.client.server.strat.experiment)
+
+        cls.config = Config(config_fnames=[config_file])
+
+    def tearDown(self):
+        if self.client.server.db is not None:
+            self.client.server.db.delete_db()
+
+    def test_bounds(self):
+        lb = self.config.getlist("common", "lb", element_type=float)
+        ub = self.config.getlist("common", "ub", element_type=float)
+        par4choices = self.config.getlist("par4", "choices", element_type=str)
+        par5choices = self.config.getlist("par5", "choices", element_type=str)
+        par6value = self.config.getfloat("par6", "value")
+        par7value = self.config.get("par7", "value")
+
+        self.assertTrue((self.df["par1"] >= lb[0]).all())
+        self.assertTrue((self.df["par1"] <= ub[0]).all())
+
+        self.assertTrue((self.df["par2"] >= lb[1]).all())
+        self.assertTrue((self.df["par2"] <= ub[1]).all())
+
+        self.assertTrue((self.df["par3"] >= lb[2]).all())
+        self.assertTrue((self.df["par3"] <= ub[2]).all())
+
+        self.assertTrue(self.df["par4"].isin(par4choices).all())
+
+        self.assertTrue(self.df["par5"].isin(par5choices).all())
+
+        self.assertTrue((self.df["par6"] == par6value).all())
+
+        self.assertTrue((self.df["par7"] == par7value).all())
+
+    def test_constraints(self):
+        constraints = self.config.getlist("common", "par_constraints", element_type=str)
+        for constraint in constraints:
+            self.assertEqual(len(self.df.query(constraint)), len(self.df))
+
+        self.assertEqual(self.df["par3"].dtype, "int64")
+
+    def test_trial_status(self):
+        n_asks = (self.df["trial_status"] == "RUNNING").sum()
+        n_tells = (self.df["trial_status"] == "COMPLETED").sum()
+        n_parameterizations = len(
+            self.df[[f"par{i}" for i in range(1, 8)]].drop_duplicates()
+        )
+
+        correct_n_asks = self.config.getint("opt_strat", "min_total_tells")
+
+        self.assertEqual(n_asks, correct_n_asks)
+        self.assertEqual(n_tells, correct_n_asks)
+        self.assertEqual(n_parameterizations, correct_n_asks)
+
+    def test_generation_method(self):
+        n_sobol = (self.df["generation_method"] == "Sobol").sum()
+        n_opt = (self.df["generation_method"] == "BoTorch").sum()
+
+        correct_n_sobol = self.config.getint("init_strat", "min_total_tells")
+        correct_n_opt = (
+            self.config.getint("opt_strat", "min_total_tells") - correct_n_sobol
+        )
+
+        self.assertEqual(n_sobol, correct_n_sobol)
+        self.assertEqual(n_opt, correct_n_opt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -11,10 +11,11 @@ from unittest.mock import MagicMock
 import numpy as np
 import torch
 from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
+from aepsych.config import Config
 from aepsych.generators import MonotonicRejectionGenerator, SobolGenerator
 from aepsych.models.gp_classification import GPClassificationModel
 from aepsych.models.monotonic_rejection_gp import MonotonicRejectionGP
-from aepsych.strategy import SequentialStrategy, Strategy
+from aepsych.strategy import AEPsychStrategy, SequentialStrategy, Strategy
 
 
 class TestSequenceGenerators(unittest.TestCase):
@@ -332,6 +333,30 @@ class TestSequenceGenerators(unittest.TestCase):
             )
         except AssertionError:
             self.fail("Strategy raised unexpected AssertionError on __init__!")
+
+
+class GenerationStrategyTestCase(unittest.TestCase):
+    def test_finish(self):
+        config_str = """
+        [common]
+        use_ax = True
+        stimuli_per_trial = 1
+        outcome_types = [binary]
+        parnames = [x]
+        lb = [0]
+        ub = [1]
+        strategy_names = [test_strat]
+
+        [test_strat]
+        generator = SobolGenerator
+        run_indefinitely = True
+        """
+        config = Config(config_str=config_str)
+        strat = AEPsychStrategy.from_config(config)
+
+        self.assertFalse(strat.finished)
+        strat.finish()
+        self.assertTrue(strat.finished)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,11 +6,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from copy import deepcopy
 
 import numpy as np
 import torch
+from aepsych.config import Config
 from aepsych.models import GPClassificationModel
-from aepsych.utils import _process_bounds, make_scaled_sobol
+from aepsych.utils import _process_bounds, get_dim, get_parameters, make_scaled_sobol
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -27,7 +29,6 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(grid.shape, (100, 2))
 
     def test_dim_grid_model_size(self):
-
         lb = -4.0
         ub = 4.0
         dim = 1
@@ -49,6 +50,158 @@ class UtilsTestCase(unittest.TestCase):
         # ub < lb
         with self.assertRaises(AssertionError):
             _process_bounds(np.r_[1], np.r_[0], None)
+
+
+class ParameterUtilsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        config_str = """
+        [common]
+        parnames = [par1, par2, par3]
+        lb = [0, 0, 0]
+        ub = [1, 1000, 10]
+        choice_parnames = [par4, par5, par6, par9]
+        fixed_parnames = [par7, par8]
+
+        [par2]
+        log_scale = True
+
+        [par3]
+        value_type = int
+
+        [par4]
+        choices = [a, b]
+
+        [par5]
+        choices = [x]
+
+        [par6]
+        choices = [x, y, z]
+        is_ordered = True
+
+        [par7]
+        value = 123
+
+        [par8]
+        value = foo
+
+        [par9]
+        choices = [x, y, z]
+        """
+        self.config = Config(config_str=config_str)
+
+    def test_get_ax_parameters(self):
+        params = get_parameters(self.config)
+
+        correct_range_params = [
+            {
+                "name": "par1",
+                "type": "range",
+                "value_type": "float",
+                "log_scale": False,
+                "bounds": [0.0, 1.0],
+            },
+            {
+                "name": "par2",
+                "type": "range",
+                "value_type": "float",
+                "log_scale": True,
+                "bounds": [0.0, 1000.0],
+            },
+            {
+                "name": "par3",
+                "type": "range",
+                "value_type": "int",
+                "log_scale": False,
+                "bounds": [0.0, 10.0],
+            },
+        ]
+        correct_choice_params = [
+            {
+                "name": "par4",
+                "type": "choice",
+                "value_type": "str",
+                "is_ordered": False,
+                "values": ["a", "b"],
+            },
+            {
+                "name": "par5",
+                "type": "choice",
+                "value_type": "str",
+                "is_ordered": False,
+                "values": ["x"],
+            },
+            {
+                "name": "par6",
+                "type": "choice",
+                "value_type": "str",
+                "is_ordered": True,
+                "values": ["x", "y", "z"],
+            },
+            {
+                "name": "par9",
+                "type": "choice",
+                "value_type": "str",
+                "is_ordered": False,
+                "values": ["x", "y", "z"],
+            },
+        ]
+
+        correct_fixed_params = [
+            {
+                "name": "par7",
+                "type": "fixed",
+                "value": 123.0,
+            },
+            {
+                "name": "par8",
+                "type": "fixed",
+                "value": "foo",
+            },
+        ]
+
+        self.assertEqual(
+            params, correct_range_params + correct_choice_params + correct_fixed_params
+        )
+
+    def test_get_dim(self):
+        dim = get_dim(self.config)
+
+        # 3 dims from par1, par2, par3
+        # 1 binary dim from par4
+        # 0 dim from par5 (effectively a fixed dim)
+        # 1 dim from par6 (is_ordered makes it one continuous dim)
+        # 0 dim from par7 & par8 (fixed dims aren't modeled)
+        # 3 dim from par9 (one-hot vector with 3 elements)
+        # 8 total dims
+        self.assertEqual(8, dim)
+
+        # Count only choice dims
+        copied_config = deepcopy(self.config)
+        del copied_config["common"]["parnames"]
+        del copied_config["common"]["lb"]
+        del copied_config["common"]["ub"]
+        dim = get_dim(copied_config)
+        self.assertEqual(5, dim)
+
+        # Removing par5 does nothing
+        copied_config["common"]["choice_parnames"] = "[par4, par6, par9]"
+        dim = get_dim(copied_config)
+        self.assertEqual(5, dim)
+
+        # Removing par6 leaves us with 3 binary dimension and 1 continuous dimension
+        copied_config["common"]["choice_parnames"] = "[par4, par9]"
+        dim = get_dim(copied_config)
+        self.assertEqual(4, dim)
+
+        # Removing par9 leaves us with 1 binary dimension
+        copied_config["common"]["choice_parnames"] = "[par4]"
+        dim = get_dim(copied_config)
+        self.assertEqual(1, dim)
+
+        # Removing par7 & par8 does nothing
+        del copied_config["common"]["fixed_parnames"]
+        dim = get_dim(copied_config)
+        self.assertEqual(1, dim)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: This is the first step in a larger refactor to make use of ax. This changes the AEPsych models and strategies to be thin wrappers around their Ax/Botorch counterparts. The eventual goal here is for AEPsych to rely on Ax/Botorch machinery as much as possible and only have to implement the extra functionality that is specific to our use cases.

Differential Revision: D38942727

