### PR TITLE
[AEPsych] Flexible optimizer arg

### DIFF
--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -15,7 +15,7 @@ import torch
 from aepsych.utils import dim_grid, get_jnd_multid, make_scaled_sobol
 from aepsych.utils_logging import getLogger
 from botorch.acquisition import PosteriorMean
-from botorch.fit import fit_gpytorch_mll
+from botorch.fit import fit_gpytorch_mll, fit_gpytorch_mll_scipy
 from botorch.models.approximate_gp import _select_inducing_points
 from botorch.models.gpytorch import GPyTorchModel
 from botorch.optim import optimize_acqf
@@ -406,6 +406,7 @@ class AEPsychMixin(GPyTorchModel):
         self,
         mll: MarginalLogLikelihood,
         optimizer_kwargs: Optional[Dict[str, Any]] = None,
+        optimizer=fit_gpytorch_mll_scipy,
         **kwargs,
     ) -> None:
         self.train()
@@ -423,8 +424,11 @@ class AEPsychMixin(GPyTorchModel):
 
         logger.info("Starting fit...")
         starttime = time.time()
-        fit_gpytorch_mll(mll, optimizer_kwargs=optimizer_kwargs, **kwargs)
+        res = fit_gpytorch_mll(
+            mll, optimizer=optimizer, optimizer_kwargs=optimizer_kwargs, **kwargs
+        )
         logger.info(f"Fit done, time={time.time()-starttime}")
+        return res
 
     def p_below_threshold(self, x, f_thresh) -> np.ndarray:
         f, var = self.predict(x)

--- a/aepsych/models/gp_classification.py
+++ b/aepsych/models/gp_classification.py
@@ -286,6 +286,8 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP):
         else:
             return promote_0d(fmean), promote_0d(fvar)
 
-    def update(self, train_x: torch.Tensor, train_y: torch.Tensor):
+    def update(self, train_x: torch.Tensor, train_y: torch.Tensor, **kwargs):
         """Perform a warm-start update of the model from previous fit."""
-        self.fit(train_x, train_y, warmstart_hyperparams=True, warmstart_induc=True)
+        return self.fit(
+            train_x, train_y, warmstart_hyperparams=True, warmstart_induc=True, **kwargs
+        )

--- a/aepsych/models/gp_regression.py
+++ b/aepsych/models/gp_regression.py
@@ -144,7 +144,7 @@ class GPRegressionModel(AEPsychMixin, ExactGP):
         """
         self.set_train_data(train_x, train_y)
         mll = gpytorch.mlls.ExactMarginalLogLikelihood(self.likelihood, self)
-        self._fit_mll(mll, **kwargs)
+        return self._fit_mll(mll, **kwargs)
 
     def sample(
         self, x: Union[torch.Tensor, np.ndarray], num_samples: int
@@ -161,9 +161,9 @@ class GPRegressionModel(AEPsychMixin, ExactGP):
         """
         return self.posterior(x).rsample(torch.Size([num_samples])).detach().squeeze()
 
-    def update(self, train_x: torch.Tensor, train_y: torch.Tensor):
+    def update(self, train_x: torch.Tensor, train_y: torch.Tensor, **kwargs):
         """Perform a warm-start update of the model from previous fit."""
-        self.fit(train_x, train_y)
+        return self.fit(train_x, train_y, **kwargs)
 
     def predict(
         self, x: Union[torch.Tensor, np.ndarray], **kwargs


### PR DESCRIPTION
With the recent botorch changes in https://github.com/pytorch/botorch/pull/1371 it's easier to be more flexible in which optimizers we use. This brings that flexibility to AEPsych (in particular, fitting with pytorch/Adam might be much faster while having acceptable accuracy for our human in the loop requirements). 

Test plan: 
New units! 