### PR TITLE
allow MonotonicRejectionGP to be built from configs

### DIFF
--- a/aepsych/models/__init__.py
+++ b/aepsych/models/__init__.py
@@ -10,6 +10,7 @@ import sys
 from ..config import Config
 from .gp_classification import GPClassificationModel
 from .gp_regression import GPRegressionModel
+from .monotonic_projection_gp import MonotonicProjectionGP
 from .monotonic_rejection_gp import MonotonicRejectionGP
 from .ordinal_gp import OrdinalGPModel
 from .pairwise_probit import PairwiseProbitModel
@@ -20,6 +21,7 @@ __all__ = [
     "GPRegressionModel",
     "PairwiseProbitModel",
     "OrdinalGPModel",
+    "MonotonicProjectionGP",
 ]
 
 Config.register_module(sys.modules[__name__])

--- a/tests/models/test_monotonic_projection_gp.py
+++ b/tests/models/test_monotonic_projection_gp.py
@@ -15,6 +15,7 @@ if "CI" in os.environ or "SANDCASTLE" in os.environ:
     torch.set_num_threads(1)
 
 import numpy as np
+from aepsych.config import Config
 from aepsych.models.monotonic_projection_gp import MonotonicProjectionGP
 from sklearn.datasets import make_classification
 
@@ -71,6 +72,34 @@ class MonotonicProjectionGPtest(unittest.TestCase):
         # And in samples
         samps = model.sample(Xtest, num_samples=10)
         self.assertTrue(samps.min().item() >= 4.9)
+
+    def test_from_config(self):
+        config_str = """
+        [common]
+        parnames = [x, y]
+        lb = [0, 0]
+        ub = [1, 1]
+        stimuli_per_trial = 1
+        outcome_types = [binary]
+
+        strategy_names = [init_strat]
+
+        [init_strat]
+        generator = OptimizeAcqfGenerator
+        model = MonotonicProjectionGP
+
+        [MonotonicProjectionGP]
+        monotonic_dims = [0]
+        monotonic_grid_size = 10
+        min_f_val = 0.1
+        """
+        config = Config(config_str=config_str)
+
+        model = MonotonicProjectionGP.from_config(config)
+
+        self.assertEqual(model.monotonic_dims, [0])
+        self.assertEqual(model.mon_grid_size, 10)
+        self.assertEqual(model.min_f_val, 0.1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Implements from_config for MonotonicProjectionGP and exposes it to configs.

Reviewed By: mshvartsman

Differential Revision: D40949183

