### PR TITLE
Fixes to post-experiment manual server tells

### DIFF
--- a/clients/unity/Packages/com.frl.aepsych/Runtime/Experiment.cs
+++ b/clients/unity/Packages/com.frl.aepsych/Runtime/Experiment.cs
@@ -407,9 +407,12 @@ namespace AEPsych
             //check if strat or experiment is done
             if (client.finished) //check if this was the final ask for this strat
             {
-                isDone = true;
-                strategy.isDone = true;
-                ExperimentComplete();
+                if (!isDone)
+                {
+                    isDone = true;
+                    strategy.isDone = true;
+                    ExperimentComplete();
+                }
                 yield break;
             }
 
@@ -843,7 +846,7 @@ namespace AEPsych
         /// </summary>
         public bool IsBusy()
         {
-            if (_experimentState == ExperimentState.ConfigReady || _experimentState == ExperimentState.WaitingForTell)
+            if (_experimentState == ExperimentState.ConfigReady || _experimentState == ExperimentState.WaitingForTell || _experimentState == ExperimentState.Exploring)
             {
                 if (!client.IsBusy())
                     return false;


### PR DESCRIPTION
Summary: Fixes IsBusy() returning true when experiment is in the exploration state. Changes ExperimentComplete() so that it's only called the first time a server message has "is_finished" set to "true".

Reviewed By: tymmsc

Differential Revision: D40875431

