### PR TITLE
Fix linter errors (mypy type checks)

### DIFF
--- a/aepsych/generators/manual_generator.py
+++ b/aepsych/generators/manual_generator.py
@@ -47,7 +47,7 @@ class ManualGenerator(AEPsychGenerator):
     def gen(
         self,
         num_points: int = 1,
-        model: AEPsychMixin = None,  # included for API compatibility
+        model: Optional[AEPsychMixin] = None,  # included for API compatibility
     ):
         """Query next point(s) to run by quasi-randomly sampling the parameter space.
         Args:

--- a/aepsych/generators/random_generator.py
+++ b/aepsych/generators/random_generator.py
@@ -39,7 +39,7 @@ class RandomGenerator(AEPsychGenerator):
     def gen(
         self,
         num_points: int = 1,
-        model: AEPsychMixin = None,  # included for API compatibility.
+        model: Optional[AEPsychMixin] = None,  # included for API compatibility.
     ) -> np.ndarray:
         """Query next point(s) to run by randomly sampling the parameter space.
         Args:

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -48,7 +48,7 @@ class SobolGenerator(AEPsychGenerator):
     def gen(
         self,
         num_points: int = 1,
-        model: AEPsychMixin = None,  # included for API compatibility
+        model: Optional[AEPsychMixin] = None,  # included for API compatibility
     ):
         """Query next point(s) to run by quasi-randomly sampling the parameter space.
         Args:

--- a/aepsych/likelihoods/ordinal.py
+++ b/aepsych/likelihoods/ordinal.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Optional
 
 import gpytorch
 import torch
@@ -15,7 +15,7 @@ class OrdinalLikelihood(Likelihood):
     and :math:`d_k` is a learned cutpoint parameter for each level.
     """
 
-    def __init__(self, n_levels: int, link: Callable = None):
+    def __init__(self, n_levels: int, link: Optional[Callable] = None):
         super().__init__()
         self.n_levels = n_levels
         self.register_parameter(

--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -269,7 +269,7 @@ class AEPsychMixin(GPyTorchModel):
     def get_jnd(
         self: ModelProtocol,
         grid: Optional[Union[np.ndarray, torch.Tensor]] = None,
-        cred_level: float = None,
+        cred_level: Optional[float] = None,
         intensity_dim: int = -1,
         confsamps: int = 500,
         method: str = "step",
@@ -364,7 +364,7 @@ class AEPsychMixin(GPyTorchModel):
     def dim_grid(
         self: ModelProtocol,
         gridsize: int = 30,
-        slice_dims: Mapping[int, float] = None,
+        slice_dims: Optional[Mapping[int, float]] = None,
     ) -> torch.Tensor:
         return dim_grid(self.lb, self.ub, self.dim, gridsize, slice_dims)
 

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -323,7 +323,7 @@ def _plot_strat_2d(
 
 def plot_strat_3d(
     strat: Strategy,
-    parnames: List[str] = None,
+    parnames: Optional[List[str]] = None,
     outcome_label: str = "Yes Trial",
     slice_dim: int = 0,
     slice_vals: Union[List[float], int] = 5,


### PR DESCRIPTION
# Description

A recent breaking change in MyPy related to PEP 484 (https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html) makes linter checks fail. 

# Solution

As described on the website, just update any typing in the form of `variable: some_type = None` to `variable: Optional[some_type] = None`, which is equivalent to `variable: Union[some_type, None] = None` or `variable: some_type | None = None` (this last option requires python 3.10.


