### PR TITLE
Plot db with continuous data

### DIFF
--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -63,10 +63,6 @@ def plot_strat(
                                  Default: True.
     """
 
-    assert (
-        "binary" in strat.outcome_types
-    ), f"Plotting not supported for outcome_type {strat.outcome_types[0]}"
-
     if target_level is not None and not hasattr(strat.model, "monotonic_idxs"):
         warnings.warn(
             "Threshold estimation may not be accurate for non-monotonic models."


### PR DESCRIPTION
Summary: AEPsych visualizer is unable to plot dbs with continuous data. Discussed with Craig an assertion statement in plotting.py line 66 prevents continuous plotting. Removed the assertion statement to plot continuous data.

Differential Revision: D41165604

