### PR TITLE
Forward more informative messages to the python client when the server crahses

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -10,8 +10,8 @@ import io
 import logging
 import os
 import sys
-import traceback
 import threading
+import traceback
 import warnings
 
 import aepsych.database.db as db
@@ -40,7 +40,7 @@ class AEPsychServer(object):
         """Server for doing black box optimization using gaussian processes.
         Keyword Arguments:
             socket -- socket object that implements `send` and `receive` for json
-            messages (default: ZMQSocket).
+            messages (default: DummySocket()).
             TODO actually make an abstract interface to subclass from here
         """
         if socket is None:
@@ -90,11 +90,10 @@ class AEPsychServer(object):
             try:
                 result = self.handle_request(request)
             except Exception as e:
-                result = BAD_REQUEST
-                logger.warning(
-                f"Request '{request}' raised error '{e}'! Full traceback follows:"
-                )
-                logger.warning(traceback.format_exc())
+                error_message = f"Request '{request}' raised error '{e}'!"
+                result = f"server_error, {error_message}"
+                logger.error(f"{error_message}! Full traceback follows:")
+                logger.error(traceback.format_exc())
             self.socket.send(result)
 
     def serve(self):

--- a/aepsych/server/sockets.py
+++ b/aepsych/server/sockets.py
@@ -139,7 +139,6 @@ class PySocket(object):
                         logger.info(f"Got: {msg}")
                         return msg
                 except Exception as e:
-                    logger.error(f"Failed with error {e}")
                     return BAD_REQUEST
 
     def send(self, message):

--- a/clients/python/aepsych_client/client.py
+++ b/clients/python/aepsych_client/client.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 if TYPE_CHECKING:
     from aepsych.server import AEPsychServer
 
+class ServerError(RuntimeError):
+    pass
 
 class AEPsychClient:
     def __init__(
@@ -71,8 +73,11 @@ class AEPsychClient:
         message = bytes(json.dumps(message), encoding="utf-8")
         self.socket.send(message)
         response = self.socket.recv(4096).decode("utf-8")
-        if response == "bad request":
-            raise RuntimeError(f"Bad request '{message}'")
+        # TODO this is hacky but we don't consistencly return json
+        # from the server so we can't check for a status
+        if response[:12] == "server_error":
+            error_message = response[13:]
+            raise ServerError(error_message)
 
         return response
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -47,7 +47,6 @@ mean_covar_factory = default_mean_covar_factory
 n_points = 2
 """
 
-
 class ServerTestCase(unittest.TestCase):
     def setUp(self):
         # setup logger
@@ -538,8 +537,10 @@ class ServerTestCase(unittest.TestCase):
             self.s.serve()
 
     def test_error_handling(self):
+        # double brace escapes, single brace to substitute, so we end up with 3 braces
+        request = f"{{{BAD_REQUEST}}}"
 
-        request = {BAD_REQUEST}
+        expected_error = f"server_error, Request '{request}' raised error ''str' object has no attribute 'keys''!"
 
         self.s.socket.accept_client = MagicMock()
 
@@ -548,7 +549,7 @@ class ServerTestCase(unittest.TestCase):
         self.s.exit_server_loop = True
         with self.assertRaises(SystemExit):
             self.s.serve()
-        self.s.socket.send.assert_called_once_with(BAD_REQUEST)
+        self.s.socket.send.assert_called_once_with(expected_error)
 
     def test_queue(self):
         """Test to see that the queue is being handled correctly"""


### PR DESCRIPTION
Summary: Currently if the server crashes, the client has no idea of why. This forwards the crash message to the python client. TODO should probably do the same for the other clients.

Reviewed By: ivyzhong93

Differential Revision: D35450975

