### PR TITLE
Fix mystery gradient issue in tests

### DIFF
--- a/aepsych/models/gp_classification.py
+++ b/aepsych/models/gp_classification.py
@@ -267,8 +267,8 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP):
         """
         with torch.no_grad():
             post = self.posterior(x)
-        fmean = post.mean.squeeze()
-        fvar = post.variance.squeeze()
+            fmean = post.mean.squeeze()
+            fvar = post.variance.squeeze()
         if probability_space:
             if isinstance(self.likelihood, BernoulliLikelihood):
                 # Probability-space mean and variance for Bernoulli-probit models is


### PR DESCRIPTION
Summary: A few aepsych tests were failing with recent gpytorch changes from D41538893 with a `RuntimeError: Can't call numpy() on Tensor that requires grad` error. This fixes these failures

Differential Revision: D42021856

