### PR TITLE
correctly track number of asks

### DIFF
--- a/aepsych/generators/completion_criterion/min_asks.py
+++ b/aepsych/generators/completion_criterion/min_asks.py
@@ -7,14 +7,21 @@
 
 from typing import Any, Dict
 
+from ax.core.experiment import Experiment
+from ax.modelbridge.completion_criterion import CompletionCriterion
+
 from aepsych.config import Config, ConfigurableMixin
-from ax.core.base_trial import TrialStatus
-from ax.modelbridge.completion_criterion import MinimumTrialsInStatus
 
 
-class MinAsks(MinimumTrialsInStatus, ConfigurableMixin):
+class MinAsks(CompletionCriterion, ConfigurableMixin):
+    def __init__(self, threshold: int) -> None:
+        self.threshold = threshold
+
+    def is_met(self, experiment: Experiment) -> bool:
+        return experiment.num_asks >= self.threshold
+
     @classmethod
     def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]:
         min_asks = config.getint(name, "min_asks", fallback=1)
-        options = {"status": TrialStatus.RUNNING, "threshold": min_asks}
+        options = {"threshold": min_asks}
         return options

--- a/configs/ax_example.ini
+++ b/configs/ax_example.ini
@@ -30,7 +30,7 @@ min_total_tells = 2 # Number of data points required to complete this strategy. 
 # Configuration for the optimization strategy, our model-based acquisition strategy.
 [opt_strat]
 generator = OptimizeAcqfGenerator # after sobol, do model-based active-learning
-min_total_tells = 3 # Finish the experiment after 4 total data points have been collected. Depending on how noisy
+min_total_tells = 3 # Finish the experiment after 3 total data points have been collected. Depending on how noisy
                     # your problem is, you may need several dozen points per parameter to get an accurate model.
 acqf = qNoisyExpectedImprovement # The acquisition function to be used with the model. We recommend
                                  # qNoisyExpectedImprovement for optimization problems.


### PR DESCRIPTION
Summary:
The number of asks was being kept track of in a hacky way after the Ax refactor, and this broke from some Ax changes. This adds an explicit `num_asks` property to the experiment object that gets updated on strat.gen.

Also fixes a typo in the ax example config, and changes `add_data` to hopefully not be a O(n) operation in most cases.

Differential Revision: D42480328

