### PR TITLE
pin SQLAlchemy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyzmq==19.0.2
 scipy
 sklearn
 statsmodels
-SQLAlchemy
+SQLAlchemy==1.4.46
 dill
 pandas
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ REQUIRES = [
     "pyzmq==19.0.2",
     "scipy",
     "sklearn",
-    "SQLAlchemy",
+    "SQLAlchemy==1.4.46",
     "dill",
     "pandas",
     "tqdm",


### PR DESCRIPTION
Summary: There seems to be an issue with SQLAlchemy v2.0. Reverting to an older version to bypass it for now.

Differential Revision: D42940775

