### PR TITLE
change sklearn -> scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ matplotlib
 torch
 pyzmq==19.0.2
 scipy
-sklearn
+scikit-learn
 statsmodels
 SQLAlchemy==1.4.46
 dill

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIRES = [
     "torch",
     "pyzmq==19.0.2",
     "scipy",
-    "sklearn",
+    "scikit-learn",
     "SQLAlchemy==1.4.46",
     "dill",
     "pandas",


### PR DESCRIPTION
Summary: The 'sklearn' moniker is deprecated in favor of 'scikit-learn'. This updates our requirements to reflect that.

Differential Revision: D43193378

