### PR TITLE
Switch aepsych `select_inducing_points` from soon-to-be-deprecated BoTorch function to replacement with equivalent behavior

### DIFF
--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -10,7 +10,7 @@ from typing import Optional, Union
 
 import numpy as np
 import torch
-from botorch.models.approximate_gp import _select_inducing_points
+from botorch.models.utils.inducing_point_allocators import GreedyVarianceReduction
 from botorch.utils.sampling import draw_sobol_samples
 from gpytorch.kernels import Kernel
 from gpytorch.likelihoods import BernoulliLikelihood
@@ -76,7 +76,8 @@ def select_inducing_points(
                 method = "kmeans++"
 
         if method == "pivoted_chol":
-            inducing_points = _select_inducing_points(
+            inducing_point_allocator = GreedyVarianceReduction()
+            inducing_points = inducing_point_allocator.allocate_inducing_points(
                 inputs=X,
                 covar_module=covar_module,
                 num_inducing=inducing_size,


### PR DESCRIPTION
Summary: BoTorch `_select_inducing_points` is being deprecated in https://github.com/pytorch/botorch/pull/1652/ / D43001106. It is being replaced by more general inducing point allocator functionality; the legacy behavior remains a special case.

Differential Revision: D43438578

