### PR TITLE
Semi-parametric AEPsych models and associated likelihoods / acquisition objectives

### DIFF
--- a/aepsych/acquisition/__init__.py
+++ b/aepsych/acquisition/__init__.py
@@ -8,7 +8,7 @@
 import sys
 
 from ..config import Config
-from .lookahead import EAVC, ApproxGlobalSUR, GlobalMI, GlobalSUR, LocalMI, LocalSUR
+from .lookahead import ApproxGlobalSUR, EAVC, GlobalMI, GlobalSUR, LocalMI, LocalSUR
 from .lse import MCLevelSetEstimation
 from .mc_posterior_variance import MCPosteriorVariance, MonotonicMCPosteriorVariance
 from .monotonic_rejection import MonotonicMCLSE
@@ -21,6 +21,7 @@ from .objective import (
     FloorLogitObjective,
     FloorProbitObjective,
     ProbitObjective,
+    semi_p,
 )
 
 lse_acqfs = [
@@ -50,6 +51,7 @@ __all__ = [
     "EAVC",
     "LocalMI",
     "LocalSUR",
+    "semi_p",
 ]
 
 Config.register_module(sys.modules[__name__])

--- a/aepsych/acquisition/objective/__init__.py
+++ b/aepsych/acquisition/objective/__init__.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+
+from ...config import Config
+from .objective import (
+    AEPsychObjective,
+    FloorGumbelObjective,
+    FloorLogitObjective,
+    FloorProbitObjective,
+    ProbitObjective,
+)
+from .semi_p import SemiPProbabilityObjective, SemiPThresholdObjective
+
+
+__all__ = [
+    "AEPsychObjective",
+    "FloorGumbelObjective",
+    "FloorLogitObjective",
+    "FloorProbitObjective",
+    "ProbitObjective",
+    "SemiPProbabilityObjective",
+    "SemiPThresholdObjective",
+]
+
+Config.register_module(sys.modules[__name__])

--- a/aepsych/acquisition/objective/objective.py
+++ b/aepsych/acquisition/objective/objective.py
@@ -15,7 +15,12 @@ from torch import Tensor
 from torch.distributions.normal import Normal
 
 
-class ProbitObjective(MCAcquisitionObjective):
+class AEPsychObjective(MCAcquisitionObjective):
+    def inverse(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
+        raise NotImplementedError
+
+
+class ProbitObjective(AEPsychObjective):
     """Probit objective
 
     Transforms the input through the normal CDF (probit).
@@ -48,7 +53,7 @@ class ProbitObjective(MCAcquisitionObjective):
         return Normal(loc=0, scale=1).icdf(samples.squeeze(-1))
 
 
-class FloorLinkObjective(MCAcquisitionObjective):
+class FloorLinkObjective(AEPsychObjective):
     """
     Wrapper for objectives to add a floor, when
     the probability is known not to go below it.

--- a/aepsych/acquisition/objective/semi_p.py
+++ b/aepsych/acquisition/objective/semi_p.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from aepsych.config import Config
+from aepsych.likelihoods import LinearBernoulliLikelihood
+from botorch.acquisition.objective import MCAcquisitionObjective
+from gpytorch.likelihoods import Likelihood
+from torch import Tensor
+
+
+class SemiPObjectiveBase(MCAcquisitionObjective):
+    """Wraps the semi-parametric transform into an objective
+    that correctly extracts various things
+    """
+
+    # because we have an extra dim for the SemiP batch dimension,
+    # all the q-batch output shape checks fail, disable them here
+    _verify_output_shape: bool = False
+
+    def __init__(self, stim_dim: int = 0):
+        super().__init__()
+        self.stim_dim = stim_dim
+
+
+class SemiPProbabilityObjective(SemiPObjectiveBase):
+    """Wraps the semi-parametric transform into an objective
+    that gives outcome probabilities
+    """
+
+    def __init__(self, likelihood: Likelihood = None, *args, **kwargs):
+        """Evaluates the probability objective.
+
+        Args:
+            likelihood (Likelihood). Underlying SemiP likelihood (which we use for its objective/link)
+            other arguments are passed to the base class (notably, stim_dim).
+        """
+        super().__init__(*args, **kwargs)
+        self.likelihood = likelihood or LinearBernoulliLikelihood()
+
+    def forward(self, samples: Tensor, X: Tensor) -> Tensor:
+        """Evaluates the probability objective.
+
+        Args:
+            samples (Tensor): GP samples.
+            X (Tensor): Inputs at which to evaluate objective. Unlike most AEPsych objectives,
+                we need X here to split out the intensity dimension.
+
+        Returns:
+            Tensor: Response probabilities at the specific X values and function samples.
+        """
+
+        Xi = X[..., self.stim_dim]
+        # the output of LinearBernoulliLikelihood is (nsamp x b x n x 1)
+        # but the output of MCAcquisitionObjective should be `nsamp x *batch_shape x q`
+        # so we remove the final dim
+        return self.likelihood.p(function_samples=samples, Xi=Xi).squeeze(-1)
+
+    @classmethod
+    def from_config(cls, config: Config):
+
+        classname = cls.__name__
+
+        likelihood_cls = config.getobj(classname, "likelihood", fallback=None)
+
+        if likelihood_cls is not None:
+            if hasattr(likelihood_cls, "from_config"):
+                likelihood = likelihood_cls.from_config(config)
+            else:
+                likelihood = likelihood_cls()
+        else:
+            likelihood = None  # fall back to __init__ default
+
+        return cls(likelihood=likelihood)
+
+
+class SemiPThresholdObjective(SemiPObjectiveBase):
+    """Wraps the semi-parametric transform into an objective
+    that gives the threshold distribution.
+    """
+
+    def __init__(self, target: float, likelihood=None, *args, **kwargs):
+        """Evaluates the probability objective.
+
+        Args:
+            target (float): the threshold to evaluate.
+            likelihood (Likelihood): Underlying SemiP likelihood (which we use for its inverse link)
+            other arguments are passed to the base class (notably, stim_dim).
+        """
+        super().__init__(*args, **kwargs)
+
+        self.likelihood = likelihood or LinearBernoulliLikelihood()
+        self.fspace_target = self.likelihood.objective.inverse(torch.tensor(target))
+
+    def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
+        """Evaluates the probability objective.
+
+        Args:
+            samples (Tensor): GP samples.
+            X (Tensor, optional): Ignored, here for compatibility with the objective API.
+
+        Returns:
+            Tensor: Threshold probabilities at the specific GP sample values.
+        """
+        offset = samples[..., 0, :]
+        slope = samples[..., 1, :]
+        return (self.fspace_target + slope * offset) / slope
+
+    @classmethod
+    def from_config(cls, config: Config):
+
+        classname = cls.__name__
+
+        likelihood_cls = config.getobj(classname, "likelihood", fallback=None)
+
+        if likelihood_cls is not None:
+            if hasattr(likelihood_cls, "from_config"):
+                likelihood = likelihood_cls.from_config(config)
+            else:
+                likelihood = likelihood_cls()
+        else:
+            likelihood = None  # fall back to __init__ default
+
+        target = config.getfloat(classname, "target", fallback=0.75)
+        return cls(likelihood=likelihood, target=target)

--- a/aepsych/generators/__init__.py
+++ b/aepsych/generators/__init__.py
@@ -17,6 +17,7 @@ from .pairwise_optimize_acqf_generator import PairwiseOptimizeAcqfGenerator
 from .pairwise_sobol_generator import PairwiseSobolGenerator
 from .random_generator import RandomGenerator
 from .sobol_generator import AxSobolGenerator, SobolGenerator
+from .semi_p import IntensityAwareSemiPGenerator
 
 __all__ = [
     "OptimizeAcqfGenerator",
@@ -30,6 +31,7 @@ __all__ = [
     "PairwiseSobolGenerator",
     "AxOptimizeAcqfGenerator",
     "AxSobolGenerator",
+    "IntensityAwareSemiPGenerator",
 ]
 
 Config.register_module(sys.modules[__name__])

--- a/aepsych/generators/semi_p.py
+++ b/aepsych/generators/semi_p.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Type
+
+import numpy as np
+import torch
+from aepsych.acquisition.objective.semi_p import SemiPThresholdObjective
+from aepsych.generators import OptimizeAcqfGenerator
+from aepsych.models.semi_p import SemiParametricGPModel
+
+
+class IntensityAwareSemiPGenerator(OptimizeAcqfGenerator):
+    """Generator for SemiP. With botorch machinery, in order to optimize acquisition
+    separately over context and intensity, we need two ingredients.
+    1. An objective that samples from some posterior w.r.t. the context. From the
+        paper, this is ThresholdBALV and needs the threshold posterior.
+        `SemiPThresholdObjective` implements this for ThresholdBALV but theoretically
+        this can be any subclass of `SemiPObjectiveBase`.
+    2. A way to do acquisition over context and intensity separately, which is
+        provided by this class. We optimize the acquisition function over context
+        dimensions, then conditioned on the optimum we evaluate the intensity
+        at the objective to obtain the intensity value.
+
+    We only developed ThresholdBALV that is specific to SemiP, which is what we tested
+    with this generator. It should work with other similar acquisition functions.
+    """
+
+    def gen(  # type: ignore[override]
+        self,
+        num_points: int,
+        model: SemiParametricGPModel,  # type: ignore[override]
+        context_objective: Type = SemiPThresholdObjective,
+    ) -> np.ndarray:
+
+        fixed_features = {model.stim_dim: 0}
+        next_x = super().gen(
+            num_points=num_points, model=model, fixed_features=fixed_features
+        )
+        # to compute intensity, we need the point where f is at the
+        # threshold as a function of context. self.acqf_kwargs should contain
+        # remaining objective args (like threshold target value)
+
+        thresh_objective = context_objective(
+            likelihood=model.likelihood, stim_dim=model.stim_dim, **self.acqf_kwargs
+        )
+        kc_mean_at_best_context = model(torch.Tensor(next_x)).mean
+        thresh_at_best_context = thresh_objective(kc_mean_at_best_context)
+        thresh_at_best_context = torch.clamp(
+            thresh_at_best_context,
+            min=model.lb[model.stim_dim],
+            max=model.ub[model.stim_dim],
+        )
+        next_x[..., model.stim_dim] = thresh_at_best_context.detach().numpy()
+        return next_x

--- a/aepsych/likelihoods/__init__.py
+++ b/aepsych/likelihoods/__init__.py
@@ -10,10 +10,12 @@ import sys
 from ..config import Config
 from .bernoulli import BernoulliObjectiveLikelihood
 from .ordinal import OrdinalLikelihood
+from .semi_p import LinearBernoulliLikelihood
 
 __all__ = [
     "BernoulliObjectiveLikelihood",
     "OrdinalLikelihood",
+    "LinearBernoulliLikelihood",
 ]
 
 Config.register_module(sys.modules[__name__])

--- a/aepsych/likelihoods/semi_p.py
+++ b/aepsych/likelihoods/semi_p.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+from aepsych.acquisition.objective import AEPsychObjective, FloorProbitObjective
+from aepsych.config import Config
+from gpytorch.likelihoods import _OneDimensionalLikelihood
+
+
+class LinearBernoulliLikelihood(_OneDimensionalLikelihood):
+    """
+    A likelihood of the form Bernoulli(sigma(k(x+c))), where k and c are
+    GPs and sigma is a flexible link function.
+    """
+
+    def __init__(self, objective: Optional[AEPsychObjective] = None):
+        """Initializes the linear bernoulli likelihood.
+
+        Args:
+            objective (Callable, optional): Link function to use (sigma in the notation above).
+                Defaults to probit with no floor.
+        """
+        super().__init__()
+        self.objective = objective or FloorProbitObjective(floor=0.0)
+
+    def f(self, function_samples: torch.Tensor, Xi: torch.Tensor) -> torch.Tensor:
+        """Return the latent function value, k(x-c).
+
+        Args:
+            function_samples (torch.Tensor): Samples from a batched GP
+            Xi (torch.Tensor): Intensity values.
+
+        Returns:
+            torch.Tensor: latent function value.
+        """
+        # function_samples is of shape nsamp x (b) x 2 x n
+
+        # If (b) is present,
+        if function_samples.ndim > 3:
+            assert function_samples.ndim == 4
+            assert function_samples.shape[2] == 2
+            # In this case, Xi will be of size b x n
+            # Offset and slope should be num_samps x b x n
+            offset = function_samples[:, :, 0, :]
+            slope = function_samples[:, :, 1, :]
+            fsamps = slope * (Xi - offset)
+            # Expand from (nsamp x b x n) to (nsamp x b x n x 1)
+            fsamps = fsamps.unsqueeze(-1)
+        else:
+            assert function_samples.ndim == 3
+            assert function_samples.shape[1] == 2
+            # Shape is num_samps x 2 x n
+            # Offset and slope should be num_samps x n
+            # Xi will be of size n
+            offset = function_samples[:, 0, :]
+            slope = function_samples[:, 1, :]
+            fsamps = slope * (Xi - offset)
+            # Expand from (nsamp x n) to (nsamp x 1 x n x 1)
+            fsamps = fsamps.unsqueeze(1).unsqueeze(-1)
+        return fsamps
+
+    def p(self, function_samples: torch.Tensor, Xi: torch.Tensor) -> torch.Tensor:
+        """Returns the response probability sigma(k(x+c)).
+
+        Args:
+            function_samples (torch.Tensor): Samples from the batched GP (see documentation for self.f)
+            Xi (torch.Tensor): Intensity Values.
+
+        Returns:
+            torch.Tensor: Response probabilities.
+        """
+        fsamps = self.f(function_samples, Xi)
+        return self.objective(fsamps)
+
+    def forward(
+        self, function_samples: torch.Tensor, Xi: torch.Tensor, **kwargs
+    ) -> torch.distributions.Bernoulli:
+        """Forward pass for the likelihood
+
+        Args:
+            function_samples (torch.Tensor): Samples from a batched GP of batch size 2.
+            Xi (torch.Tensor): Intensity values.
+
+        Returns:
+            torch.distributions.Bernoulli: Outcome likelihood.
+        """
+        output_probs = self.p(function_samples, Xi)
+        return torch.distributions.Bernoulli(probs=output_probs)
+
+    def expected_log_prob(self, observations, function_dist, *args, **kwargs):
+        """This has to be overridden to fix a bug in gpytorch where the kwargs
+        aren't being passed along to self.forward.
+        """
+
+        # modified, TODO fixme upstream (cc @bletham)
+        def log_prob_lambda(function_samples):
+            return self.forward(function_samples, **kwargs).log_prob(observations)
+
+        log_prob = self.quadrature(log_prob_lambda, function_dist)
+        return log_prob
+
+    @classmethod
+    def from_config(cls, config: Config):
+        classname = cls.__name__
+
+        objective = config.getobj(classname, "objective")
+
+        if hasattr(objective, "from_config"):
+            objective = objective.from_config(config)
+        else:
+            objective = objective
+
+        return cls(objective=objective)

--- a/aepsych/models/__init__.py
+++ b/aepsych/models/__init__.py
@@ -16,7 +16,13 @@ from .monotonic_rejection_gp import MonotonicRejectionGP
 from .multitask_regression import IndependentMultitaskGPRModel, MultitaskGPRModel
 from .ordinal_gp import OrdinalGPModel
 from .pairwise_probit import PairwiseProbitModel
+from .semi_p import (
+    HadamardSemiPModel,
+    semi_p_posterior_transform,
+    SemiParametricGPModel,
+)
 from .variational_gp import BinaryClassificationGP, VariationalGP
+
 
 __all__ = [
     "GPClassificationModel",
@@ -31,6 +37,9 @@ __all__ = [
     "ContinuousRegressionGP",
     "MultitaskGPRModel",
     "IndependentMultitaskGPRModel",
+    "HadamardSemiPModel",
+    "SemiParametricGPModel",
+    "semi_p_posterior_transform",
 ]
 
 Config.register_module(sys.modules[__name__])

--- a/aepsych/models/semi_p.py
+++ b/aepsych/models/semi_p.py
@@ -1,0 +1,630 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Optional, Tuple, Union
+
+import gpytorch
+import numpy as np
+import torch
+from aepsych.acquisition.objective import FloorLogitObjective
+
+from aepsych.acquisition.objective.semi_p import SemiPThresholdObjective
+from aepsych.config import Config
+from aepsych.likelihoods import BernoulliObjectiveLikelihood, LinearBernoulliLikelihood
+from aepsych.models import GPClassificationModel
+from aepsych.utils import _process_bounds, promote_0d
+from aepsych.utils_logging import getLogger
+from botorch.optim.fit import fit_gpytorch_mll_scipy
+from botorch.posteriors import GPyTorchPosterior
+from gpytorch.distributions import MultivariateNormal
+from gpytorch.kernels import RBFKernel, ScaleKernel
+from gpytorch.likelihoods import BernoulliLikelihood, Likelihood
+from gpytorch.means import ConstantMean, ZeroMean
+from gpytorch.priors import GammaPrior
+from torch import Tensor
+from torch.distributions import Normal
+
+# TODO: Implement a covar factory and analytic method for getting the lse
+logger = getLogger()
+
+
+def _hadamard_mvn_approx(x_intensity, slope_mean, slope_cov, offset_mean, offset_cov):
+    """
+
+    MVN approximation to the hadamard product of GPs (from the SemiP paper, extending the
+    zero-mean results in https://mathoverflow.net/questions/293955/normal-approximation-to-the-pointwise-hadamard-schur-product-of-two-multivariat)
+    """
+    offset_mean = offset_mean + x_intensity
+
+    mean_x = offset_mean * slope_mean
+
+    # Same as torch.diag_embed(slope_mean) @ offset_cov @ torch.diag_embed(slope_mean), but more efficient
+    term1 = slope_mean.unsqueeze(-1) * offset_cov * slope_mean.unsqueeze(-2)
+
+    # Same as torch.diag_embed(offset_mean) @ slope_cov @ torch.diag_embed(offset_mean), but more efficient
+    term2 = offset_mean.unsqueeze(-1) * slope_cov * offset_mean.unsqueeze(-2)
+
+    term3 = slope_cov * offset_cov
+
+    cov_x = term1 + term2 + term3
+
+    return mean_x, cov_x
+
+
+def semi_p_posterior_transform(posterior):
+    batch_mean = posterior.mvn.mean
+    batch_cov = posterior.mvn.covariance_matrix
+    offset_mean = batch_mean[..., 0, :]
+    slope_mean = batch_mean[..., 1, :]
+    offset_cov = batch_cov[..., 0, :, :]
+    slope_cov = batch_cov[..., 1, :, :]
+    Xi = posterior.Xi
+    approx_mean, approx_cov = _hadamard_mvn_approx(
+        x_intensity=Xi,
+        slope_mean=slope_mean,
+        slope_cov=slope_cov,
+        offset_mean=offset_mean,
+        offset_cov=offset_cov,
+    )
+    approx_mvn = MultivariateNormal(mean=approx_mean, covariance_matrix=approx_cov)
+    return GPyTorchPosterior(mvn=approx_mvn)
+
+
+class SemiPPosterior(GPyTorchPosterior):
+    def __init__(
+        self,
+        mvn: MultivariateNormal,
+        likelihood: LinearBernoulliLikelihood,
+        Xi: torch.Tensor,
+    ):
+        super().__init__(distribution=mvn)
+        self.likelihood = likelihood
+        self.Xi = Xi
+
+    def rsample_from_base_samples(
+        self,
+        sample_shape: torch.Size,
+        base_samples: Tensor,
+    ) -> Tensor:
+        r"""Sample from the posterior (with gradients) using base samples.
+
+        This is intended to be used with a sampler that produces the corresponding base
+        samples, and enables acquisition optimization via Sample Average Approximation.
+        """
+        return (
+            super()
+            .rsample_from_base_samples(
+                sample_shape=sample_shape, base_samples=base_samples
+            )
+            .squeeze(-1)
+        )
+
+    def rsample(
+        self,
+        sample_shape: Optional[torch.Size] = None,
+        base_samples: Optional[torch.Tensor] = None,
+    ):
+        kcsamps = (
+            super()
+            .rsample(sample_shape=sample_shape, base_samples=base_samples)
+            .squeeze(-1)
+        )
+        # fsamps is of shape nsamp x 2 x n, or nsamp x b x 2 x n
+        return kcsamps
+
+    def sample_p(
+        self,
+        sample_shape: Optional[torch.Size] = None,
+        base_samples: Optional[torch.Tensor] = None,
+    ):
+        kcsamps = self.rsample(sample_shape=sample_shape, base_samples=base_samples)
+        return self.likelihood.p(function_samples=kcsamps, Xi=self.Xi).squeeze(-1)
+
+    def sample_f(
+        self,
+        sample_shape: Optional[torch.Size] = None,
+        base_samples: Optional[torch.Tensor] = None,
+    ):
+        kcsamps = self.rsample(sample_shape=sample_shape, base_samples=base_samples)
+        return self.likelihood.f(function_samples=kcsamps, Xi=self.Xi).squeeze(-1)
+
+    def sample_thresholds(
+        self,
+        threshold_level: float,
+        sample_shape: Optional[torch.Size] = None,
+        base_samples: Optional[torch.Tensor] = None,
+    ):
+
+        fsamps = self.rsample(sample_shape=sample_shape, base_samples=base_samples)
+        return SemiPThresholdObjective(
+            likelihood=self.likelihood, target=threshold_level
+        )(samples=fsamps, X=self.Xi)
+
+
+class SemiParametricGPModel(GPClassificationModel):
+    """
+    Semiparametric GP model for psychophysics.
+
+    Implements a semi-parametric model with a functional form like :math:`k(x_c()x_i + c(x_c))`,
+    for scalar intensity dimension :math:`x_i` and vector-valued context dimensions :math:`x_c`,
+    with k and c having a GP prior. In contrast to HadamardSemiPModel, this version uses a batched GP
+    directly, which is about 2-3x slower but does not use the MVN approximation.
+
+    Intended for use with a BernoulliObjectiveLikelihood with flexible link function such as
+    Logistic or Gumbel nonlinearity with a floor.
+    """
+
+    _num_outputs = 1
+    _batch_shape = 2
+    stimuli_per_trial = 1
+    outcome_type = "binary"
+
+    def __init__(
+        self,
+        lb: Union[np.ndarray, torch.Tensor],
+        ub: Union[np.ndarray, torch.Tensor],
+        dim: Optional[int] = None,
+        stim_dim: int = 0,
+        mean_module: Optional[gpytorch.means.Mean] = None,
+        covar_module: Optional[gpytorch.kernels.Kernel] = None,
+        likelihood: Optional[Any] = None,
+        slope_mean: float = 2,
+        inducing_size: int = 100,
+        max_fit_time: Optional[float] = None,
+        inducing_point_method: str = "auto",
+    ):
+        """
+        Initialize SemiParametricGP.
+        Args:
+        Args:
+            lb (Union[numpy.ndarray, torch.Tensor]): Lower bounds of the parameters.
+            ub (Union[numpy.ndarray, torch.Tensor]): Upper bounds of the parameters.
+            dim (int, optional): The number of dimensions in the parameter space. If None, it is inferred from the size
+                of lb and ub.
+            stim_dim (int): Index of the intensity (monotonic) dimension. Defaults to 0.
+            mean_module (gpytorch.means.Mean, optional): GP mean class. Defaults to a constant with a normal prior.
+            covar_module (gpytorch.kernels.Kernel, optional): GP covariance kernel class. Defaults to scaled RBF with a
+                gamma prior.
+            likelihood (gpytorch.likelihood.Likelihood, optional): The likelihood function to use. If None defaults to
+                linear-Bernouli likelihood with probit link.
+            inducing_size (int): Number of inducing points. Defaults to 100.
+            max_fit_time (float, optional): The maximum amount of time, in seconds, to spend fitting the model. If None,
+                there is no limit to the fitting time.
+            inducing_point_method (string): The method to use to select the inducing points. Defaults to "auto".
+                If "sobol", a number of Sobol points equal to inducing_size will be selected.
+                If "pivoted_chol", selects points based on the pivoted Cholesky heuristic.
+                If "kmeans++", selects points by performing kmeans++ clustering on the training data.
+                If "auto", tries to determine the best method automatically.
+        """
+
+        lb, ub, dim = _process_bounds(lb, ub, dim)
+        self.stim_dim = stim_dim
+        self.context_dims = list(range(dim))
+        self.context_dims.pop(stim_dim)
+
+        if mean_module is None:
+            mean_module = ConstantMean(batch_shape=torch.Size([2]))
+            mean_module.requires_grad_(False)
+            mean_module.constant.copy_(
+                torch.tensor([0.0, slope_mean])  # offset mean is 0, slope mean is 2
+            )
+
+        if covar_module is None:
+            covar_module = ScaleKernel(
+                RBFKernel(
+                    ard_num_dims=dim - 1,
+                    lengthscale_prior=GammaPrior(3, 6),
+                    active_dims=self.context_dims,  # Operate only on x_s
+                    batch_shape=torch.Size([2]),
+                ),
+                outputscale_prior=GammaPrior(1.5, 1.0),
+            )
+
+        likelihood = likelihood or LinearBernoulliLikelihood()
+        assert isinstance(
+            likelihood, LinearBernoulliLikelihood
+        ), "SemiP model only supports linear Bernoulli likelihoods!"
+
+        super().__init__(
+            lb=lb,
+            ub=ub,
+            dim=dim,
+            mean_module=mean_module,
+            covar_module=covar_module,
+            likelihood=likelihood,
+            inducing_size=inducing_size,
+            max_fit_time=max_fit_time,
+            inducing_point_method=inducing_point_method,
+        )
+
+    @classmethod
+    def from_config(cls, config: Config) -> SemiParametricGPModel:
+        """Alternate constructor for SemiParametricGPModel model.
+
+        This is used when we recursively build a full sampling strategy
+        from a configuration.
+
+        Args:
+            config (Config): A configuration containing keys/values matching this class
+
+        Returns:
+            SemiParametricGPModel: Configured class instance.
+        """
+
+        classname = cls.__name__
+        inducing_size = config.getint(classname, "inducing_size", fallback=100)
+
+        lb = config.gettensor(classname, "lb")
+        ub = config.gettensor(classname, "ub")
+        dim = config.getint(classname, "dim", fallback=None)
+
+        max_fit_time = config.getfloat(classname, "max_fit_time", fallback=None)
+
+        inducing_point_method = config.get(
+            classname, "inducing_point_method", fallback="auto"
+        )
+
+        likelihood_cls = config.getobj(classname, "likelihood", fallback=None)
+
+        if hasattr(likelihood_cls, "from_config"):
+            likelihood = likelihood_cls.from_config(config)
+        else:
+            likelihood = likelihood_cls()
+
+        stim_dim = config.getint(classname, "stim_dim", fallback=0)
+
+        slope_mean = config.getfloat(classname, "slope_mean", fallback=2)
+
+        return cls(
+            lb=lb,
+            ub=ub,
+            stim_dim=stim_dim,
+            dim=dim,
+            likelihood=likelihood,
+            slope_mean=slope_mean,
+            inducing_size=inducing_size,
+            max_fit_time=max_fit_time,
+            inducing_point_method=inducing_point_method,
+        )
+
+    def fit(
+        self,
+        train_x: torch.Tensor,
+        train_y: torch.Tensor,
+        warmstart_hyperparams: bool = False,
+        warmstart_induc: bool = False,
+        **kwargs,
+    ) -> None:
+        """Fit underlying model.
+
+        Args:
+            train_x (torch.Tensor): Inputs.
+            train_y (torch.LongTensor): Responses.
+            warmstart_hyperparams (bool): Whether to reuse the previous hyperparameters (True) or fit from scratch
+                (False). Defaults to False.
+            warmstart_induc (bool): Whether to reuse the previous inducing points or fit from scratch (False).
+                Defaults to False.
+            kwargs: Keyword arguments passed to `optimizer=fit_gpytorch_mll_scipy`.
+        """
+        super().fit(
+            train_x=train_x,
+            train_y=train_y,
+            optimizer=fit_gpytorch_mll_scipy,
+            warmstart_hyperparams=warmstart_hyperparams,
+            warmstart_induc=warmstart_induc,
+            closure_kwargs={"Xi": train_x[..., self.stim_dim]},
+            **kwargs,
+        )
+
+    def sample(
+        self,
+        x: Union[torch.Tensor, np.ndarray],
+        num_samples: int,
+        probability_space=False,
+    ) -> torch.Tensor:
+        """Sample from underlying model.
+
+        Args:
+            x ((n x d) torch.Tensor): Points at which to sample.
+            num_samples (int, optional): Number of samples to return. Defaults to None.
+            kwargs are ignored
+
+        Returns:
+            (num_samples x n) torch.Tensor: Posterior samples
+        """
+        post = self.posterior(x)
+        if probability_space is True:
+            samps = post.sample_p(torch.Size([num_samples])).detach()
+        else:
+            samps = post.sample_f(torch.Size([num_samples])).detach()
+
+        assert samps.shape == (num_samples, 1, x.shape[0])
+        return samps.squeeze(1)
+
+    def predict(
+        self, x: Union[torch.Tensor, np.ndarray], probability_space: bool = False
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Query the model for posterior mean and variance.
+
+        Args:
+            x (torch.Tensor): Points at which to predict from the model.
+            probability_space (bool, optional): Return outputs in units of
+                response probability instead of latent function value. Defaults to False.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: Posterior mean and variance at query points.
+        """
+        with torch.no_grad():
+            samps = self.sample(
+                x, num_samples=10000, probability_space=probability_space
+            )
+        m, v = samps.mean(0), samps.var(0)
+        return promote_0d(m), promote_0d(v)
+
+    def posterior(self, X, posterior_transform=None):
+        # Assume x is (b) x n x d
+        if X.ndim > 3:
+            raise ValueError
+        # Add in the extra 2 batch for the 2 GPs in this model
+        Xnew = X.unsqueeze(-3).expand(
+            X.shape[:-2]  # (b)
+            + torch.Size([2])  # For the two GPs
+            + X.shape[-2:]  # n x d
+        )
+        # The shape of Xnew is: (b) x 2 x n x d
+        posterior = SemiPPosterior(
+            mvn=self(Xnew),
+            likelihood=self.likelihood,
+            Xi=X[..., self.stim_dim],
+        )
+
+        if posterior_transform is not None:
+            return posterior_transform(posterior)
+        else:
+            return posterior
+
+
+class HadamardSemiPModel(GPClassificationModel):
+    """
+    Semiparametric GP model for psychophysics, with a MVN approximation to the elementwise
+    product of GPs.
+
+    Implements a semi-parametric model with a functional form like :math:`k(x_c()x_i + c(x_c))`,
+    for scalar intensity dimension :math:`x_i` and vector-valued context dimensions :math:`x_c`,
+    with k and c having a GP prior. In contrast to SemiParametricGPModel, this version approximates
+    the product as a single multivariate normal, which should be faster (the approximation is exact
+    if one of the GP's variance goes to zero).
+    Intended for use with a BernoulliObjectiveLikelihood with flexible link function such as
+    Logistic or Gumbel nonlinearity with a floor.
+    """
+
+    _num_outputs = 1
+    stimuli_per_trial = 1
+    outcome_type = "binary"
+
+    def __init__(
+        self,
+        lb: Union[np.ndarray, torch.Tensor],
+        ub: Union[np.ndarray, torch.Tensor],
+        dim: Optional[int] = None,
+        stim_dim: int = 0,
+        slope_mean_module: Optional[gpytorch.means.Mean] = None,
+        slope_covar_module: Optional[gpytorch.kernels.Kernel] = None,
+        offset_mean_module: Optional[gpytorch.means.Mean] = None,
+        offset_covar_module: Optional[gpytorch.kernels.Kernel] = None,
+        likelihood: Optional[Likelihood] = None,
+        slope_mean: float = 2,
+        inducing_size: int = 100,
+        max_fit_time: Optional[float] = None,
+        inducing_point_method: str = "auto",
+    ):
+        """
+        Initialize HadamardSemiPModel.
+        Args:
+            lb (Union[numpy.ndarray, torch.Tensor]): Lower bounds of the parameters.
+            ub (Union[numpy.ndarray, torch.Tensor]): Upper bounds of the parameters.
+            dim (int, optional): The number of dimensions in the parameter space. If None, it is inferred from the size
+                of lb and ub.
+            stim_dim (int): Index of the intensity (monotonic) dimension. Defaults to 0.
+            slope_mean_module (gpytorch.means.Mean, optional): Mean module to use (default: constant mean) for slope.
+            slope_covar_module (gpytorch.kernels.Kernel, optional): Covariance kernel to use (default: scaled RBF) for slope.
+            offset_mean_module (gpytorch.means.Mean, optional): Mean module to use (default: constant mean) for offset.
+            offset_covar_module (gpytorch.kernels.Kernel, optional): Covariance kernel to use (default: scaled RBF) for offset.
+            likelihood (gpytorch.likelihood.Likelihood, optional)): defaults to bernoulli with logistic input and a floor of .5
+            inducing_size (int): Number of inducing points. Defaults to 100.
+            max_fit_time (float, optional): The maximum amount of time, in seconds, to spend fitting the model. If None,
+                there is no limit to the fitting time.
+            inducing_point_method (string): The method to use to select the inducing points. Defaults to "auto".
+                If "sobol", a number of Sobol points equal to inducing_size will be selected.
+                If "pivoted_chol", selects points based on the pivoted Cholesky heuristic.
+                If "kmeans++", selects points by performing kmeans++ clustering on the training data.
+                If "auto", tries to determine the best method automatically.
+        """
+        super().__init__(
+            lb=lb,
+            ub=ub,
+            dim=dim,
+            inducing_size=inducing_size,
+            max_fit_time=max_fit_time,
+            inducing_point_method=inducing_point_method,
+        )
+
+        self.stim_dim = stim_dim
+
+        if slope_mean_module is None:
+            self.slope_mean_module = ConstantMean()
+            self.slope_mean_module.requires_grad_(False)
+            self.slope_mean_module.constant.copy_(
+                torch.tensor(slope_mean)
+            )  # magic number to shift the slope prior to be generally positive.
+        else:
+            self.slope_mean_module = slope_mean_module
+
+        if offset_mean_module is None:
+            self.offset_mean_module = ZeroMean()
+        else:
+            self.offset_mean_module = offset_mean_module
+
+        self.offset_mean_module = offset_mean_module or ZeroMean()
+
+        context_dims = list(range(self.dim))
+        context_dims.pop(stim_dim)
+
+        self.slope_covar_module = slope_covar_module or ScaleKernel(
+            RBFKernel(
+                ard_num_dims=self.dim - 1,
+                lengthscale_prior=GammaPrior(3, 6),
+                active_dims=context_dims,  # Operate only on x_s
+            ),
+            outputscale_prior=GammaPrior(1.5, 1.0),
+        )
+
+        self.offset_covar_module = offset_covar_module or ScaleKernel(
+            RBFKernel(
+                ard_num_dims=self.dim - 1,
+                lengthscale_prior=GammaPrior(3, 6),
+                active_dims=context_dims,  # Operate only on x_s
+            ),
+            outputscale_prior=GammaPrior(1.5, 1.0),
+        )
+        self.likelihood = likelihood or BernoulliObjectiveLikelihood(
+            objective=FloorLogitObjective()
+        )
+
+        self._fresh_state_dict = deepcopy(self.state_dict())
+        self._fresh_likelihood_dict = deepcopy(self.likelihood.state_dict())
+
+    def forward(self, x: torch.Tensor) -> MultivariateNormal:
+        """Forward pass for semip GP.
+
+        generates a k(c + x[:,stim_dim]) = kc + kx[:,stim_dim] mvn object where k and c are
+        slope and offset GPs and x[:,stim_dim] are the intensity stimulus (x)
+        locations and thus acts as a constant offset to the k mvn.
+        Args:
+            x (torch.Tensor): Points at which to sample.
+
+        Returns:
+            MVN object evaluated at samples
+        """
+        transformed_x = self.normalize_inputs(x)
+        # TODO: make slope prop to intensity width.
+        slope_mean = self.slope_mean_module(transformed_x)
+
+        # kc mvn
+        offset_mean = self.offset_mean_module(transformed_x)
+
+        slope_cov = self.slope_covar_module(transformed_x)
+        offset_cov = self.offset_covar_module(transformed_x)
+
+        mean_x, cov_x = _hadamard_mvn_approx(
+            x_intensity=transformed_x[..., self.stim_dim],
+            slope_mean=slope_mean,
+            slope_cov=slope_cov,
+            offset_mean=offset_mean,
+            offset_cov=offset_cov,
+        )
+        return MultivariateNormal(mean_x, cov_x)
+
+    @classmethod
+    def from_config(cls, config: Config) -> HadamardSemiPModel:
+        """Alternate constructor for HadamardSemiPModel model.
+
+        This is used when we recursively build a full sampling strategy
+        from a configuration.
+
+        Args:
+            config (Config): A configuration containing keys/values matching this class
+
+        Returns:
+            HadamardSemiPModel: Configured class instance.
+        """
+
+        classname = cls.__name__
+        inducing_size = config.getint(classname, "inducing_size", fallback=100)
+
+        lb = config.gettensor(classname, "lb")
+        ub = config.gettensor(classname, "ub")
+        dim = config.getint(classname, "dim", fallback=None)
+
+        slope_mean_module = config.getobj(classname, "slope_mean_module", fallback=None)
+        slope_covar_module = config.getobj(
+            classname, "slope_covar_module", fallback=None
+        )
+        offset_mean_module = config.getobj(
+            classname, "offset_mean_module", fallback=None
+        )
+        offset_covar_module = config.getobj(
+            classname, "offset_covar_module", fallback=None
+        )
+
+        max_fit_time = config.getfloat(classname, "max_fit_time", fallback=None)
+
+        inducing_point_method = config.get(
+            classname, "inducing_point_method", fallback="auto"
+        )
+
+        likelihood_cls = config.getobj(classname, "likelihood", fallback=None)
+        if hasattr(likelihood_cls, "from_config"):
+            likelihood = likelihood_cls.from_config(config)
+        else:
+            likelihood = likelihood_cls()
+
+        slope_mean = config.getfloat(classname, "slope_mean", fallback=2)
+
+        stim_dim = config.getint(classname, "stim_dim", fallback=0)
+
+        return cls(
+            lb=lb,
+            ub=ub,
+            stim_dim=stim_dim,
+            dim=dim,
+            slope_mean_module=slope_mean_module,
+            slope_covar_module=slope_covar_module,
+            offset_mean_module=offset_mean_module,
+            offset_covar_module=offset_covar_module,
+            likelihood=likelihood,
+            slope_mean=slope_mean,
+            inducing_size=inducing_size,
+            max_fit_time=max_fit_time,
+            inducing_point_method=inducing_point_method,
+        )
+
+    def predict(
+        self, x: Union[torch.Tensor, np.ndarray], probability_space: bool = False
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Query the model for posterior mean and variance.
+
+        Args:
+            x (torch.Tensor): Points at which to predict from the model.
+            probability_space (bool, optional): Return outputs in units of
+                response probability instead of latent function value. Defaults to False.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: Posterior mean and variance at queries points.
+        """
+        if probability_space:
+            if hasattr(self.likelihood, "objective"):
+                fsamps = self.sample(x, 1000)
+                psamps = self.likelihood.objective(fsamps)
+                return psamps.mean(0).squeeze(), psamps.var(0).squeeze()
+            elif isinstance(self.likelihood, BernoulliLikelihood):  # default to probit
+                fsamps = self.sample(x, 1000)
+                psamps = Normal(0, 1).cdf(fsamps)
+                return psamps.mean(0).squeeze(), psamps.var(0).squeeze()
+            else:
+                raise NotImplementedError(
+                    f"p-space sampling not defined if likelihood ({self.likelihood}) does not have a link!"
+                )
+        else:
+            with torch.no_grad():
+                post = self.posterior(x)
+            fmean = post.mean.squeeze()
+            fvar = post.variance.squeeze()
+            return fmean, fvar

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -7,7 +7,7 @@
 
 from collections.abc import Iterable
 from configparser import NoOptionError
-from typing import Dict, List, Mapping, Optional
+from typing import Dict, List, Mapping, Optional, Tuple
 
 import numpy as np
 import torch
@@ -68,7 +68,7 @@ def dim_grid(
     return torch.Tensor(np.mgrid[mesh_vals].reshape(dim, -1).T)
 
 
-def _process_bounds(lb, ub, dim):
+def _process_bounds(lb, ub, dim) -> Tuple[torch.Tensor, torch.Tensor, int]:
     """Helper function for ensuring bounds are correct shape and type."""
     lb = promote_0d(lb)
     ub = promote_0d(ub)

--- a/tests/models/test_semi_p.py
+++ b/tests/models/test_semi_p.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import torch
+from aepsych.acquisition import MCPosteriorVariance
+from aepsych.acquisition.lookahead import GlobalMI
+from aepsych.acquisition.objective import (
+    FloorGumbelObjective,
+    FloorLogitObjective,
+    FloorProbitObjective,
+    ProbitObjective,
+)
+from aepsych.generators import OptimizeAcqfGenerator, SobolGenerator
+from aepsych.likelihoods import BernoulliObjectiveLikelihood
+from aepsych.strategy import SequentialStrategy, Strategy
+from aepsych.acquisition.objective.semi_p import (
+    SemiPProbabilityObjective,
+    SemiPThresholdObjective,
+)
+from aepsych.likelihoods.semi_p import LinearBernoulliLikelihood
+from aepsych.models import HadamardSemiPModel, SemiParametricGPModel
+from aepsych.models.semi_p import (
+    _hadamard_mvn_approx,
+    semi_p_posterior_transform,
+)
+from gpytorch.distributions import MultivariateNormal
+from parameterized import parameterized
+
+def _hadamard_model_constructor(lb, ub, stim_dim, floor, objective=FloorLogitObjective):
+    return HadamardSemiPModel(
+        lb=lb,
+        ub=ub,
+        stim_dim=stim_dim,
+        likelihood=BernoulliObjectiveLikelihood(objective=objective(floor=floor)),
+        inducing_size=10,
+        inducing_point_method="auto",
+        max_fit_time=0.5,
+    )
+
+
+def _semip_model_constructor(lb, ub, stim_dim, floor, objective=FloorLogitObjective):
+    return SemiParametricGPModel(
+        lb=lb,
+        ub=ub,
+        stim_dim=stim_dim,
+        likelihood=LinearBernoulliLikelihood(objective=objective(floor=floor)),
+        inducing_size=10,
+        inducing_point_method="auto",
+    )
+
+
+links = [FloorLogitObjective, FloorProbitObjective, FloorGumbelObjective]
+floors = [0, 0.3, 0.5]
+constructors = [_semip_model_constructor, _hadamard_model_constructor]
+test_configs = [[FloorLogitObjective, 0.3, _hadamard_model_constructor]]
+# test_configs = list(product(links, floors, constructors)) # TODO too slow
+
+
+class SemiPSmokeTests(unittest.TestCase):
+    def setUp(self):
+        self.seed = 1
+        self.stim_dim = 0
+        self.context_dim = 1
+        np.random.seed(1)
+        torch.manual_seed(1)
+        X = np.random.randn(100, 2) / 3
+        xcontext = X[..., self.context_dim]
+        xintensity = X[..., self.stim_dim]
+        # polynomial context
+        slope = (
+            xcontext - 0.7 * xcontext**2 + 0.3 * xcontext**3 - 0.1 * xcontext**4
+        )
+        intercept = (
+            xcontext + 0.03 * xcontext**5 - 0.2 * xcontext**3 - 0.7 * xcontext**4
+        )
+        # multiply by intensity
+        self.f = torch.Tensor(slope * (intercept + xintensity)).unsqueeze(-1)
+        X[:, 0] = X[:, 0] * 100
+        X[:, 1] = X[:, 1] / 100
+        self.lb = [-100, -0.01]
+        self.ub = [100, 0.01]
+        self.X = torch.Tensor(X)
+
+    @parameterized.expand(
+        [(SemiPThresholdObjective(target=0.75),), (SemiPProbabilityObjective(),)]
+    )
+    def test_mc_generation(self, objective):
+        # no objective here, the objective for `gen` is not the same as the objective
+        # for the likelihood in this case
+        model = SemiParametricGPModel(
+            lb=self.lb,
+            ub=self.ub,
+            stim_dim=self.stim_dim,
+            likelihood=LinearBernoulliLikelihood(),
+            inducing_size=10,
+            inducing_point_method="auto",
+        )
+
+        generator = OptimizeAcqfGenerator(
+            acqf=MCPosteriorVariance,
+            acqf_kwargs={"objective": objective},
+            max_gen_time=0.1,
+        )
+
+        y = torch.bernoulli(model.likelihood.objective(self.f))
+        model.set_train_data(
+            self.X[:10], y[:10]
+        )  # no need to fit for checking gen shapes
+        next_x = generator.gen(num_points=1, model=model)
+        self.assertEqual(
+            next_x.shape,
+            (
+                1,
+                2,
+            ),
+        )
+
+    def test_analytic_lookahead_generation(self):
+        floor = 0
+        objective = FloorProbitObjective
+        model = _semip_model_constructor(
+            lb=self.lb,
+            ub=self.ub,
+            stim_dim=self.stim_dim,
+            floor=floor,
+            objective=objective,
+        )
+
+        generator = OptimizeAcqfGenerator(
+            acqf=GlobalMI,
+            acqf_kwargs={
+                "posterior_transform": semi_p_posterior_transform,
+                "target": 0.75,
+                "query_set_size": 100,
+            },
+            max_gen_time=0.2,
+        )
+        link = objective(floor=floor)
+        y = torch.bernoulli(link(self.f))
+
+        model.set_train_data(
+            self.X[:10], y[:10]
+        )  # no need to fit for checking gen shapes
+
+        next_x = generator.gen(num_points=1, model=model)
+        self.assertEqual(
+            next_x.shape,
+            (
+                1,
+                2,
+            ),
+        )
+
+    @parameterized.expand(test_configs)
+    @unittest.skip("Slow smoke test, TODO speed me up")
+    def test_memorize_data(self, objective, floor, model_constructor):
+        """
+        see approximate accuracy on easy logistic ps that only varies in 1d
+        (no slope and intercept)
+        accuracy determined by average performance on training data
+        """
+        with self.subTest(
+            objective=objective.__name__,
+            floor=floor,
+            model_constructor=model_constructor,
+        ):
+            link = objective(floor=floor)
+            y = torch.bernoulli(link(self.f))
+
+            model = model_constructor(
+                lb=self.lb,
+                ub=self.ub,
+                stim_dim=self.stim_dim,
+                floor=floor,
+                objective=objective,
+            )
+
+            model.fit(train_x=self.X[:50], train_y=y[:50])
+
+            pm, _ = model.predict(self.X[:50])
+            pred = (link(pm) > 0.5).numpy()
+            npt.assert_allclose(pred, y[:50].numpy(), atol=1)  # mismatch at most one
+
+            model.update(self.X, y)
+
+            pm, _ = model.predict(self.X[50:])
+            pred = (link(pm) > 0.5).numpy()
+            npt.assert_allclose(pred, y[50:].numpy(), atol=1)
+
+    @parameterized.expand([(_semip_model_constructor,), (_hadamard_model_constructor,)])
+    def test_prediction_shapes(self, model_constructor):
+        n_opt = 1
+        lb = [-1, -1]
+        ub = [1, 1]
+
+        with self.subTest(model_constructor=model_constructor):
+            model = model_constructor(lb=lb, ub=ub, stim_dim=self.stim_dim, floor=0)
+
+            strat_list = [
+                Strategy(
+                    lb=lb,
+                    ub=ub,
+                    model=model,
+                    generator=SobolGenerator(lb=lb, ub=ub, seed=self.seed),
+                    min_asks=n_opt,
+                    stimuli_per_trial=1,
+                    outcome_types=["binary"],
+                ),
+            ]
+            strat = SequentialStrategy(strat_list)
+
+            train_x = torch.tensor([[0.0, 0.0], [2.0, 1.0], [2.0, 2.0]])
+            train_y = torch.tensor([1.0, 1.0, 0.0])
+            model.fit(train_x=train_x, train_y=train_y)
+            f, var = model.predict(train_x)
+            self.assertEqual(f.shape, torch.Size([3]))
+            self.assertEqual(var.shape, torch.Size([3]))
+
+            p, pvar = model.predict(train_x, probability_space=True)
+            self.assertEqual(p.shape, torch.Size([3]))
+            self.assertEqual(pvar.shape, torch.Size([3]))
+
+            if isinstance(model, SemiParametricGPModel):
+                samps = model.sample(train_x, 11, probability_space=True)
+                self.assertEqual(samps.shape, torch.Size([11, 3]))
+                post = model.posterior(train_x)
+                self.assertEqual(post.mvn.mean.shape, torch.Size([2, 3]))
+                self.assertTrue(torch.equal(post.Xi, torch.tensor([0.0, 2.0, 2.0])))
+                samps = post.rsample(sample_shape=torch.Size([6]))
+                # samps should be n_samp x 2 (slope, intercept) * 3 (xshape)
+                self.assertEqual(samps.shape, torch.Size([6, 2, 3]))
+
+                # now check posterior samp sizes. They have
+                # an extra dim (since it's 1d outcome), which
+                # model.sample squeezes, except for thresh sampling
+                # which is already squeezed by the threshold objective
+                # TODO be more consistent with how we use dims
+                post = model.posterior(train_x)
+                p_samps = post.sample_p(torch.Size([6]))
+                self.assertEqual(p_samps.shape, torch.Size([6, 1, 3]))
+                f_samps = post.sample_f(torch.Size([6]))
+                self.assertEqual(f_samps.shape, torch.Size([6, 1, 3]))
+                thresh_samps = post.sample_thresholds(
+                    threshold_level=0.75, sample_shape=torch.Size([6])
+                )
+                self.assertEqual(thresh_samps.shape, torch.Size([6, 3]))
+
+            strat.add_data(train_x, train_y)
+            Xopt = strat.gen()
+            self.assertEqual(Xopt.shape, torch.Size([1, 2]))
+
+    @parameterized.expand([(_semip_model_constructor,), (_hadamard_model_constructor,)])
+    def test_reset_variational_strategy(self, model_constructor):
+        lb = [-3, -3]
+        ub = [3, 3]
+        stim_dim = 0
+        with self.subTest(model_constructor=model_constructor):
+
+            model = model_constructor(lb=lb, ub=ub, stim_dim=stim_dim, floor=0)
+            link = FloorLogitObjective(floor=0)
+            y = torch.bernoulli(link(self.f))
+
+            variational_params_before = [
+                v.clone().detach().numpy() for v in model.variational_parameters()
+            ]
+            induc_before = model.variational_strategy.inducing_points
+
+            model.fit(torch.Tensor(self.X[:15]), torch.Tensor(y[:15]))
+
+            variational_params_after = [
+                v.clone().detach().numpy() for v in model.variational_parameters()
+            ]
+            induc_after = model.variational_strategy.inducing_points
+
+            model._reset_variational_strategy()
+
+            variational_params_reset = [
+                v.clone().detach().numpy() for v in model.variational_parameters()
+            ]
+            induc_reset = model.variational_strategy.inducing_points
+
+            # before should be different from after and after should be different
+            # from reset
+            self.assertFalse(np.allclose(induc_before, induc_after))
+            self.assertFalse(np.allclose(induc_after, induc_reset))
+            for before, after in zip(
+                variational_params_before, variational_params_after
+            ):
+                self.assertFalse(np.allclose(before, after))
+
+            for after, reset in zip(variational_params_after, variational_params_reset):
+                self.assertFalse(np.allclose(after, reset))
+
+    def test_slope_mean_setting(self):
+
+        for slope_mean in (2, 4):
+            model = SemiParametricGPModel(
+                lb=self.lb,
+                ub=self.ub,
+                stim_dim=self.stim_dim,
+                likelihood=LinearBernoulliLikelihood(),
+                inducing_size=10,
+                slope_mean=slope_mean,
+                inducing_point_method="auto",
+            )
+            with self.subTest(model=model, slope_mean=slope_mean):
+                self.assertEqual(model.mean_module.constant[-1], slope_mean)
+            model = HadamardSemiPModel(
+                lb=self.lb,
+                ub=self.ub,
+                stim_dim=self.stim_dim,
+                likelihood=BernoulliObjectiveLikelihood(objective=ProbitObjective()),
+                inducing_size=10,
+                slope_mean=slope_mean,
+                inducing_point_method="auto",
+            )
+            with self.subTest(model=model, slope_mean=slope_mean):
+                self.assertEqual(model.slope_mean_module.constant.item(), slope_mean)
+
+
+class HadamardSemiPtest(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(1)
+        torch.manual_seed(1)
+        stim_dim = 0
+        X = torch.randn(100, 2)
+        self.X = X
+        link = ProbitObjective()
+        self.y = torch.bernoulli(link(X[:, stim_dim]))
+
+    def test_reset_hyperparams(self):
+
+        model = HadamardSemiPModel(lb=[-3, -3], ub=[3, 3], inducing_size=20)
+
+        slope_os_before = model.slope_covar_module.outputscale.clone().detach().numpy()
+        offset_os_before = (
+            model.offset_covar_module.outputscale.clone().detach().numpy()
+        )
+        slope_ls_before = (
+            model.slope_covar_module.base_kernel.lengthscale.clone().detach().numpy()
+        )
+        offset_ls_before = (
+            model.offset_covar_module.base_kernel.lengthscale.clone().detach().numpy()
+        )
+
+        model.fit(self.X[:15], self.y[:15])
+
+        slope_os_after = model.slope_covar_module.outputscale.clone().detach().numpy()
+        offset_os_after = model.offset_covar_module.outputscale.clone().detach().numpy()
+        slope_ls_after = (
+            model.slope_covar_module.base_kernel.lengthscale.clone().detach().numpy()
+        )
+        offset_ls_after = (
+            model.offset_covar_module.base_kernel.lengthscale.clone().detach().numpy()
+        )
+
+        model._reset_hyperparameters()
+
+        slope_os_reset = model.slope_covar_module.outputscale.clone().detach().numpy()
+        offset_os_reset = model.offset_covar_module.outputscale.clone().detach().numpy()
+        slope_ls_reset = (
+            model.slope_covar_module.base_kernel.lengthscale.clone().detach().numpy()
+        )
+        offset_ls_reset = (
+            model.offset_covar_module.base_kernel.lengthscale.clone().detach().numpy()
+        )
+
+        # before should be different from after and after should be different
+        # from reset but before and reset should be same
+        self.assertFalse(np.allclose(slope_os_before, slope_os_after))
+        self.assertFalse(np.allclose(slope_os_after, slope_os_reset))
+        self.assertTrue(np.allclose(slope_os_before, slope_os_reset))
+        self.assertFalse(np.allclose(slope_ls_before, slope_ls_after))
+        self.assertFalse(np.allclose(slope_ls_after, slope_ls_reset))
+        self.assertTrue(np.allclose(slope_ls_before, slope_ls_reset))
+
+        self.assertFalse(np.allclose(offset_os_before, offset_os_after))
+        self.assertFalse(np.allclose(offset_os_after, offset_os_reset))
+        self.assertTrue(np.allclose(offset_os_before, offset_os_reset))
+        self.assertFalse(np.allclose(offset_ls_before, offset_ls_after))
+        self.assertFalse(np.allclose(offset_ls_after, offset_ls_reset))
+        self.assertTrue(np.allclose(offset_ls_before, offset_ls_reset))
+
+    def _make_psd_matrix(self, size):
+        L = torch.randn((size, size))
+        return L @ L.T
+
+    def test_normal_approx(self):
+        np.random.seed(123)
+        torch.manual_seed(123)
+
+        npoints = 10
+
+        def make_samp_and_approx_mvns(kcov_scale=1.0, ccov_scale=1.0):
+            X = torch.randn(npoints)
+            kmean = torch.randn(npoints)
+            cmean = torch.randn(npoints)
+            kcov = self._make_psd_matrix(npoints) * kcov_scale
+            ccov = self._make_psd_matrix(npoints) * ccov_scale
+
+            k_mvn = MultivariateNormal(kmean, kcov)
+            c_mvn = MultivariateNormal(cmean, ccov)
+
+            ksamps = k_mvn.sample(torch.Size([1000]))
+            csamps = c_mvn.sample(torch.Size([1000]))
+
+            samp_mean = (ksamps * (X + csamps)).mean(0)
+            samp_cov = (ksamps * (X + csamps)).T.cov()
+
+            approx_mean, approx_cov = _hadamard_mvn_approx(
+                X, slope_mean=kmean, slope_cov=kcov, offset_mean=cmean, offset_cov=ccov
+            )
+            return samp_mean, samp_cov, approx_mean, approx_cov
+
+        # verify that as kvar approaches 0, approx improves on average
+        mean_errs = []
+        cov_errs = []
+        for kcov_scale in [1e-5, 1e-2, 1]:
+            mean_err = 0
+            cov_err = 0
+            for _rep in range(100):
+                (
+                    samp_mean,
+                    samp_cov,
+                    approx_mean,
+                    approx_cov,
+                ) = make_samp_and_approx_mvns(kcov_scale=kcov_scale)
+                mean_err += (samp_mean - approx_mean).abs().mean().item()
+                cov_err += (samp_cov - approx_cov).abs().mean().item()
+            mean_errs.append(mean_err / 100)
+            cov_errs.append(cov_err / 100)
+        npt.assert_equal(mean_errs, sorted(mean_errs))
+        npt.assert_equal(cov_errs, sorted(cov_errs))
+
+        # verify that as cvar approaches 0, approx improves on average
+        mean_errs = []
+        cov_errs = []
+        for ccov_scale in [1e-5, 1e-2, 1]:
+            mean_err = 0
+            cov_err = 0
+            for _rep in range(100):
+                (
+                    samp_mean,
+                    samp_cov,
+                    approx_mean,
+                    approx_cov,
+                ) = make_samp_and_approx_mvns(ccov_scale=ccov_scale)
+                mean_err += (samp_mean - approx_mean).abs().mean().item()
+                cov_err += (samp_cov - approx_cov).abs().mean().item()
+            mean_errs.append(mean_err / 100)
+            cov_errs.append(cov_err / 100)
+
+        npt.assert_equal(mean_errs, sorted(mean_errs))
+        npt.assert_equal(cov_errs, sorted(cov_errs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
This includes the code to implement the methods from:
Keeley, Letham, Tymms, Sanders, Shvartsman AAAI 2023 "A semi-parametric model for decision making in high-dimensional sensory discrimination tasks".

Includes:
*  The "exact" `SemiParametricGPModel` model (still requires VI for inference, but likelihood is exact). Note that this model is a batched GP of size 2 containing individual GPs for the the slope and intercept of the psychometric function. For inference, `LinearBernoulliLikelihood` combines them into the response probability.
* `_hadamard_mvn_approx` utility function which can be used to approximate the Hadamard (elementwise) product of MVNs as a single MVN.
* and the HadamardSemiP approximate model (approximate likelihood which yields an MVN posterior).
* `HadamardSemiPModel`, which uses this approximation on the prior, meaning that the prior is a regular GP, with a particularly structured kernel. This is beneficial if you do something in inference which requires the MVN prior.
* `semi_p_posterior_transform`, which applies the transformation to a semi-parametric posterior. This is mostly useful for using analytic acquisition functions which require an MVN posterior, while still using the full SemiP model for prediction.
* A set of botorch-compatible objectives which expose a distribution over response probabilities (for use with MC acquisition functions like BALD or BALV) or a distribution over thresholds (which can be used to generate our novel `ThresholdBALV` objective -- and potentially others).
* A new generator (`IntensityAwareSemiPGenerator`) which can be used to independently optimize an acquisition function for context vs intensity dimensions. This is needed for `ThresholdBALV` (since the threshold variance is independent of intensity, so we first find the highest threshold variance context, and then pick the intensity at the threshold).

Code used to run all benchmarks and generate all the figures in the paper will be published in a separate repository.

Differential Revision: D42981149

