### PR TITLE
Inducing Point Allocators for Sparse GPs (#1652)

### DIFF
--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -10,7 +10,7 @@ from typing import Optional, Union
 
 import numpy as np
 import torch
-from botorch.models.approximate_gp import _select_inducing_points
+from botorch.models.utils.inducing_point_allocators import GreedyVarianceReduction
 from botorch.utils.sampling import draw_sobol_samples
 from gpytorch.kernels import Kernel
 from gpytorch.likelihoods import BernoulliLikelihood
@@ -76,7 +76,8 @@ def select_inducing_points(
                 method = "kmeans++"
 
         if method == "pivoted_chol":
-            inducing_points = _select_inducing_points(
+            inducing_point_allocator = GreedyVarianceReduction()
+            inducing_points = inducing_point_allocator.allocate_inducing_points(
                 inputs=X,
                 covar_module=covar_module,
                 num_inducing=inducing_size,


### PR DESCRIPTION
Summary:
## Motivation

As requested by eytan, I have had a go at implementing BO-specific inducing point allocation (IPA) strategies from my new paper (https://arxiv.org/abs/2301.10123). These allow you to build sparse Gaussian processes that are somewhat customized to the particular task at hand, be it BO, active learning e.t.c.

1. I have rewritten part of your approximate GP code to allow the specification of custom IPA strategies.
2.  BoTorch's existing behaviour (using the greedy variance reduction of Burt et al (2020)) is a special case of the new functionality and remains the default.
3. I have included one of the new IPAs from my paper to help demonstrate how custom IPAs can be defined. The one I chose is quite complicated (requiring access to model from the previous BO step) and so being able to implement it was a good test case to check that this code for custom IPA initialisation isnt stupid.
4. There ended up being a lot of IPA related code, so I moved it all into a utility file, with its own testing file.

X-link: https://github.com/pytorch/botorch/pull/1652

Differential Revision: D43556981

Pulled By: esantorella

