### PR TITLE
Fix BinaryClassificationGP bug

### DIFF
--- a/aepsych/models/variational_gp.py
+++ b/aepsych/models/variational_gp.py
@@ -9,13 +9,14 @@ from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 import torch
+from botorch.models import SingleTaskVariationalGP
+from gpytorch.likelihoods import BernoulliLikelihood
+from gpytorch.mlls import VariationalELBO
+
 from aepsych.config import Config
 from aepsych.models.base import AEPsychModel
 from aepsych.models.utils import get_probability_space, select_inducing_points
 from aepsych.utils import promote_0d
-from botorch.models import SingleTaskVariationalGP
-from gpytorch.likelihoods import BernoulliLikelihood
-from gpytorch.mlls import VariationalELBO
 
 
 # TODO: Find a better way to do this on the Ax/Botorch side
@@ -104,7 +105,7 @@ class BinaryClassificationGP(VariationalGP):
             )
         else:
             fmean = post.mean.squeeze()
-        fvar = post.variance.squeeze()
+            fvar = post.variance.squeeze()
 
         return promote_0d(fmean), promote_0d(fvar)
 

--- a/tests/models/test_variational_gp.py
+++ b/tests/models/test_variational_gp.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import torch
+from botorch.fit import fit_gpytorch_mll
+from gpytorch.likelihoods import BernoulliLikelihood
+from gpytorch.mlls import VariationalELBO
+from sklearn.datasets import make_classification
+
+from aepsych.models import BinaryClassificationGP
+
+
+class BinaryClassificationGPTestCase(unittest.TestCase):
+    """
+    Super basic smoke test to make sure we know if we broke the underlying model
+    for single-probit  ("1AFC") model
+    """
+
+    def setUp(self):
+        np.random.seed(1)
+        torch.manual_seed(1)
+        X, y = make_classification(
+            n_samples=10,
+            n_features=1,
+            n_redundant=0,
+            n_informative=1,
+            random_state=1,
+            n_clusters_per_class=1,
+        )
+        self.X, self.y = torch.Tensor(X), torch.Tensor(y).reshape(-1, 1)
+
+    def test_1d_classification(self):
+        """
+        Just see if we memorize the training set
+        """
+        X, y = self.X, self.y
+        model = BinaryClassificationGP(
+            train_X=X, train_Y=y, likelihood=BernoulliLikelihood(), inducing_points=10
+        )
+        mll = VariationalELBO(model.likelihood, model.model, len(y))
+        fit_gpytorch_mll(mll)
+
+        # pspace
+        pm, pv = model.predict(X, probability_space=True)
+        pred = (pm > 0.5).numpy()
+        npt.assert_allclose(pred.reshape(-1, 1), y)
+        npt.assert_array_less(pv, 1)
+
+        # fspace
+        pm, pv = model.predict(X, probability_space=False)
+        pred = (pm > 0).numpy()
+        npt.assert_allclose(pred.reshape(-1, 1), y)
+        npt.assert_array_less(1, pv)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: Put in a missing indent that was overriding the correct variance when setting `probability_space = True` in `BinaryClassificationGP.predict`

Differential Revision: D43876109

