### PR TITLE
update ax version to 0.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pathos
 aepsych_client>=0.2.0
 voila==0.3.6
 ipywidgets==7.6.5
-ax-platform>=0.3.0
+ax-platform>=0.3.1

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ REQUIRES = [
     "voila==0.3.6",
     "ipywidgets==7.6.5",
     "statsmodels",
-    "ax-platform>=0.3.0",
+    "ax-platform>=0.3.1",
 ]
 
 DEV_REQUIRES = [


### PR DESCRIPTION
Summary: There was an issue with ax 0.3.0 and typeguard, causing tests to fail. This is fixed with ax 0.3.1.

Differential Revision: D44172593

