### PR TITLE
async trial generation

### DIFF
--- a/configs/regression_example.ini
+++ b/configs/regression_example.ini
@@ -16,17 +16,18 @@ ub = [10, 10] # upper bounds of parameter, in the same order as above
 stimuli_per_trial = 1 # the number of stimuli shown in each trial; 1 for single, or 2 for pairwise experiments
 outcome_types = [continuous] # the type of response given by the participant; can be [binary] or [continuous]
 strategy_names = [init_strat, opt_strat] # The strategies that will be used, corresponding to the named sections below
+pregen_asks = True # The server will automatically generate new trial parameters in the background, saving time.
 
 # Configuration for the initialization strategy, which we use to gather initial points
 # before we start doing model-based acquisition
 [init_strat]
-min_asks = 10 # number of sobol trials to run
+min_total_tells = 10 # number of sobol trials to run
 # The generator class used to generate new parameter values
 generator = SobolGenerator
 
 # Configuration for the optimization strategy, our model-based acquisition
 [opt_strat]
-min_asks = 40 # number of model-based trials to run
+min_total_tells = 40 # number of model-based trials to run
 generator = OptimizeAcqfGenerator # The generator class used to generate new parameter values
 
 # The model, which must conform to the stimuli_per_trial and outcome_types settings above.


### PR DESCRIPTION
Summary: By setting `pregen_asks = True` under `common` in config files, you can tell the server to pre-generate `ask` responses in the background while the client is running the current trial, saving time.

Differential Revision: D44229448

