### PR TITLE
add ability to inverse query ax models

### DIFF
--- a/aepsych/models/exact_gp.py
+++ b/aepsych/models/exact_gp.py
@@ -5,10 +5,16 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from aepsych.models.base import AEPsychModel
-from aepsych.utils_logging import getLogger
+from typing import Tuple, Union
+
+import numpy as np
+import torch
 from botorch.models import SingleTaskGP
 from gpytorch.mlls import ExactMarginalLogLikelihood
+
+from aepsych.models.base import AEPsychModel
+from aepsych.utils import promote_0d
+from aepsych.utils_logging import getLogger
 
 logger = getLogger()
 
@@ -17,6 +23,23 @@ class ExactGP(AEPsychModel, SingleTaskGP):
     @classmethod
     def get_mll_class(cls):
         return ExactMarginalLogLikelihood
+
+    def predict(
+        self, x: Union[torch.Tensor, np.ndarray], **kwargs
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Query the model for posterior mean and variance.
+
+        Args:
+            x (torch.Tensor): Points at which to predict from the model.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: Posterior mean and variance at queries points.
+        """
+        with torch.no_grad():
+            post = self.posterior(x)
+        fmean = post.mean.squeeze()
+        fvar = post.variance.squeeze()
+        return promote_0d(fmean), promote_0d(fvar)
 
 
 class ContinuousRegressionGP(ExactGP):

--- a/tests/test_model_query.py
+++ b/tests/test_model_query.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import numpy as np
+import torch
+from botorch.fit import fit_gpytorch_mll
+from gpytorch.mlls import ExactMarginalLogLikelihood
+
+from aepsych.models.exact_gp import ExactGP
+
+# Fix random seeds
+np.random.seed(0)
+torch.manual_seed(0)
+
+
+class TestModelQuery(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.bounds = torch.tensor([[0.0], [1.0]])
+        x = torch.linspace(0.0, 1.0, 10).reshape(-1, 1)
+        y = torch.sin(6.28 * x).reshape(-1, 1)
+        cls.model = ExactGP(x, y)
+        mll = ExactMarginalLogLikelihood(cls.model.likelihood, cls.model)
+        fit_gpytorch_mll(mll)
+
+    def test_min(self):
+        mymin, my_argmin = self.model.get_min(self.bounds)
+        # Don't need to be precise since we're working with small data.
+        self.assertLess(mymin, -0.9)
+        self.assertTrue(0.7 < my_argmin < 0.8)
+
+    def test_max(self):
+        mymax, my_argmax = self.model.get_max(self.bounds)
+        # Don't need to be precise since we're working with small data.
+        self.assertGreater(mymax, 0.9)
+        self.assertTrue(0.2 < my_argmax < 0.3)
+
+    def test_inverse_query(self):
+        bounds = torch.tensor([[0.1], [0.9]])
+        val, arg = self.model.inv_query(0.0, bounds)
+        # Don't need to be precise since we're working with small data.
+        self.assertTrue(-0.01 < val < 0.01)
+        self.assertTrue(0.45 < arg < 0.55)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: This ports over from the old backend to Ax the ability to query a model for a point that will yield a particular outcome value.

Reviewed By: mshvartsman

Differential Revision: D44067161

