### PR TITLE
remove pre-generated asks on tell

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -867,8 +867,6 @@ class AEPsychServer(object):
             else:
                 x = config
             self.strat.add_data(x, outcome)
-            if self.can_pregen_ask:
-                self._pregen_asks.append(self.ask())
 
     def _configure(self, config):
         self._pregen_asks = (

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -746,7 +746,6 @@ class ServerTestCase(unittest.TestCase):
         self.assertTrue(self.s.use_ax)
         self.assertIsInstance(self.s.strat, AEPsychStrategy)
 
-
     @parameterized.expand([(True,), (False,)])
     def test_async_asks(self, enable_pregen):
         self.s.ask = MagicMock()
@@ -763,10 +762,6 @@ class ServerTestCase(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.s.serve()
         self.assertEqual(self.s.ask.call_count, int(enable_pregen))
-
-        # Should queue up an ask after a tell if pregen is enabled
-        self.s.tell(0, {"x": 0})
-        self.assertEqual(self.s.ask.call_count, int(enable_pregen) * 2)
 
         # Should reset queue
         self.s.configure(config=config)


### PR DESCRIPTION
Summary: This implementation of async asks was causing the client to have to wait for a new ask to resolve after every tell, defeating the point of async asks. This just removes the automatic asks from tells until a better implementatios is made.

Differential Revision: D45004014

