### PR TITLE
update example configs to stop suggesting MCLSE

### DIFF
--- a/configs/nonmonotonic_optimization_example.ini
+++ b/configs/nonmonotonic_optimization_example.ini
@@ -42,9 +42,8 @@ generator = OptimizeAcqfGenerator # The generator class used to generate new par
 model = GPClassificationModel
 
 # Acquisition function: the objective we use to decide where to sample next. We recommend
-# MonotonicMCLSE for threshold finding, MonotonicMCPosteriorVariance for global exploration,
-# qNoisyExpectedImprovement for optimization. For other options, check out the botorch and
-# aepsych docs
+# EAVC or GlobalMI for threshold finding or qNoisyExpectedImprovement for optimization.
+# For other options, check out the botorch and aepsych docs.
 acqf = qNoisyExpectedImprovement
 
 ## GPClassificationModel model settings.

--- a/configs/regression_example.ini
+++ b/configs/regression_example.ini
@@ -35,9 +35,8 @@ generator = OptimizeAcqfGenerator # The generator class used to generate new par
 model = GPRegressionModel
 
 # Acquisition function: the objective we use to decide where to sample next. We recommend
-# MonotonicMCLSE for threshold finding, MonotonicMCPosteriorVariance for global exploration,
-# qNoisyExpectedImprovement for optimization. For other options, check out the botorch and
-# aepsych docs
+# EAVC or GlobalMI for threshold finding or qNoisyExpectedImprovement for optimization.
+# For other options, check out the botorch and aepsych docs.
 acqf = qNoisyExpectedImprovement
 
 ## OptimizeAcqfGenerator model settings.

--- a/configs/single_lse_example.ini
+++ b/configs/single_lse_example.ini
@@ -14,7 +14,6 @@ lb = [0, 0] # lower bounds of the parameters, in the same order as above
 ub = [1, 1] # upper bounds of parameter, in the same order as above
 stimuli_per_trial = 1 # the number of stimuli shown in each trial; 1 for single, or 2 for pairwise experiments
 outcome_types = [binary] # the type of response given by the participant; can be [binary] or [continuous]
-target = 0.75 # desired threshold, for threshold estimation. Otherwise is ignored or can be removed.
 strategy_names = [init_strat, opt_strat] # The strategies that will be used, corresponding to the named sections below
 
 # Configuration for the initialization strategy, which we use to gather initial points
@@ -37,10 +36,9 @@ refit_every = 5
 generator = OptimizeAcqfGenerator # The generator class used to generate new parameter values
 
 # Acquisition function: the objective we use to decide where to sample next. We recommend
-# MCLevelSetEstimation for low-D threshold finding, MonotonicMCPosteriorVariance for global exploration,
-# qNoisyExpectedImprovement for optimization. For other options, check out the botorch and
-# aepsych docs
-acqf = MCLevelSetEstimation
+# EAVC or GlobalMI for threshold finding or qNoisyExpectedImprovement for optimization.
+# For other options, check out the botorch and aepsych docs.
+acqf = EAVC
 
 # The model, which must conform to the stimuli_per_trial and outcome_types settings above.
 # Use GPClassificationModel or GPRegressionModel for single or PairwiseProbitModel for pairwise.
@@ -66,13 +64,12 @@ mean_covar_factory = default_mean_covar_factory
 restarts = 10 # number of restarts for acquisition function optimization.
 samps = 1000 # number of samples for quasi-random initialization of the acquisition function optimizer
 
-## Acquisition function settings; we recommend not changing this.
-[MCLevelSetEstimation]
-# A sort of "temperature" parameter that affects how widely around the predicted
-# threshold we try to sample, analogous to beta in the UCB family of algorithms.
-# The 3.84 (1.96 ** 2) default corresponds to the "straddle" heuristic in Bryan et al. 2005.
-beta = 3.84
+## Acquisition function settings.
+[EAVC]
+target = 0.75 # desired threshold, for threshold estimation.
 
 # The transformation of the latent function before threshold estimation. ProbitObjective
-# lets us express the target threshold in probability.
+# lets us express the target threshold in probability space. Note that EAVC and GlobalMI require
+# ProbitObjective; other objectives will be ignored. If you need to do level set estimation
+# for non-probability quantities, try another acquisition function.
 objective = ProbitObjective

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,7 @@ import unittest
 import uuid
 
 import torch
-from aepsych.acquisition import MCLevelSetEstimation
+from aepsych.acquisition import EAVC, MCLevelSetEstimation
 from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
 from aepsych.acquisition.objective import FloorGumbelObjective, ProbitObjective
 from aepsych.config import Config
@@ -147,19 +147,11 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(
             isinstance(strat.strat_list[1].generator, OptimizeAcqfGenerator)
         )
-        self.assertTrue(strat.strat_list[1].generator.acqf is MCLevelSetEstimation)
+        self.assertTrue(strat.strat_list[1].generator.acqf is EAVC)
         self.assertTrue(
-            set(strat.strat_list[1].generator.acqf_kwargs.keys())
-            == {"beta", "target", "objective"}
+            set(strat.strat_list[1].generator.acqf_kwargs.keys()) == {"target"}
         )
         self.assertTrue(strat.strat_list[1].generator.acqf_kwargs["target"] == 0.75)
-        self.assertTrue(strat.strat_list[1].generator.acqf_kwargs["beta"] == 3.84)
-        self.assertTrue(
-            isinstance(
-                strat.strat_list[1].generator.acqf_kwargs["objective"],
-                ProbitObjective,
-            )
-        )
         self.assertTrue(strat.strat_list[1].generator.samps == 1000)
         self.assertTrue(strat.strat_list[0].min_asks == 10)
         self.assertTrue(strat.strat_list[0].stimuli_per_trial == 1)


### PR DESCRIPTION
Summary: Updating the example configs from the old straddle acqf to the newer, much better, lookahead EAVC function.

Differential Revision: D45456753

