### PR TITLE
add predict_probability methods to legacy models

### DIFF
--- a/aepsych/models/gp_classification.py
+++ b/aepsych/models/gp_classification.py
@@ -293,6 +293,11 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP):
         else:
             return promote_0d(fmean), promote_0d(fvar)
 
+    def predict_probability(
+        self, x: Union[torch.Tensor, np.ndarray]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.predict(x, probability_space=True)
+
     def update(self, train_x: torch.Tensor, train_y: torch.Tensor, **kwargs):
         """Perform a warm-start update of the model from previous fit."""
         return self.fit(

--- a/aepsych/models/monotonic_rejection_gp.py
+++ b/aepsych/models/monotonic_rejection_gp.py
@@ -279,6 +279,11 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
 
         return mean, variance
 
+    def predict_probability(
+        self, x: Union[torch.Tensor, np.ndarray]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return self.predict(x, probability_space=True)
+
     def _augment_with_deriv_index(self, x: Tensor, indx):
         return torch.cat(
             (x, indx * torch.ones(x.shape[0], 1)),

--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -142,6 +142,13 @@ class PairwiseProbitModel(PairwiseGP, AEPsychMixin):
         else:
             return fmean, fvar
 
+    def predict_probability(
+        self, x, probability_space=False, num_samples=1000, rereference="x_min"
+    ):
+        return self.predict(
+            x, probability_space=True, num_samples=num_samples, rereference=rereference
+        )
+
     def sample(self, x, num_samples, rereference="x_min"):
         if len(x.shape) < 2:
             x = x.reshape(-1, 1)

--- a/tests/models/test_gp_classification.py
+++ b/tests/models/test_gp_classification.py
@@ -14,6 +14,7 @@ import torch
 if "CI" in os.environ or "SANDCASTLE" in os.environ:
     torch.set_num_threads(1)
 
+from functools import partial
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -31,7 +32,6 @@ from gpytorch.distributions import MultivariateNormal
 from scipy.stats import bernoulli, norm, pearsonr
 from sklearn.datasets import make_classification
 from torch.distributions import Normal
-from functools import partial
 from torch.optim import Adam
 
 from ..common import cdf_new_novel_det, f_1d, f_2d
@@ -68,7 +68,7 @@ class GPClassificationSmoketest(unittest.TestCase):
         model.fit(X[:50], y[:50])
 
         # pspace
-        pm, _ = model.predict(X[:50], probability_space=True)
+        pm, _ = model.predict_probability(X[:50])
         pred = (pm > 0.5).numpy()
         npt.assert_allclose(pred, y[:50])
 
@@ -81,7 +81,7 @@ class GPClassificationSmoketest(unittest.TestCase):
         model.update(X, y)
 
         # pspace
-        pm, _ = model.predict(X, probability_space=True)
+        pm, _ = model.predict_probability(X)
         pred = (pm > 0.5).numpy()
         npt.assert_allclose(pred, y)
 
@@ -103,11 +103,14 @@ class GPClassificationSmoketest(unittest.TestCase):
             X[:50],
             y[:50],
             optimizer=fit_gpytorch_mll_torch,
-            optimizer_kwargs={"stopping_criterion":ExpMAStoppingCriterion(maxiter=30),'optimizer':partial(Adam, lr=0.05)}
+            optimizer_kwargs={
+                "stopping_criterion": ExpMAStoppingCriterion(maxiter=30),
+                "optimizer": partial(Adam, lr=0.05),
+            },
         )
 
         # pspace
-        pm, _ = model.predict(X[:50], probability_space=True)
+        pm, _ = model.predict_probability(X[:50])
         pred = (pm > 0.5).numpy()
         npt.assert_allclose(pred, y[:50])
 
@@ -121,11 +124,11 @@ class GPClassificationSmoketest(unittest.TestCase):
             X,
             y,
             optimizer=fit_gpytorch_mll_torch,
-            optimizer_kwargs={"stopping_criterion":ExpMAStoppingCriterion(maxiter=30)}
+            optimizer_kwargs={"stopping_criterion": ExpMAStoppingCriterion(maxiter=30)},
         )
 
         # pspace
-        pm, _ = model.predict(X, probability_space=True)
+        pm, _ = model.predict_probability(X)
         pred = (pm > 0.5).numpy()
         npt.assert_allclose(pred, y)
 
@@ -158,7 +161,7 @@ class GPClassificationSmoketest(unittest.TestCase):
         model.fit(X[:50], y[:50])
 
         # pspace
-        pm, _ = model.predict(X[:50], probability_space=True)
+        pm, _ = model.predict_probability(X[:50])
         pred = (pm > 0.5).numpy()
         npt.assert_allclose(pred, y[:50])
 
@@ -171,7 +174,7 @@ class GPClassificationSmoketest(unittest.TestCase):
         model.update(X, y)
 
         # pspace
-        pm, _ = model.predict(X, probability_space=True)
+        pm, _ = model.predict_probability(X)
         pred = (pm > 0.5).numpy()
         npt.assert_allclose(pred, y)
 
@@ -247,7 +250,7 @@ class GPClassificationSmoketest(unittest.TestCase):
         )
         model.fit(X, y)
 
-        pmean_analytic, pvar_analytic = model.predict(X, probability_space=True)
+        pmean_analytic, pvar_analytic = model.predict_probability(X)
 
         fsamps = model.sample(X, 150000)
         psamps = norm.cdf(fsamps)


### PR DESCRIPTION
Summary: Adding predict_probability methods to legacy models to keep API consistent with Ax models

Differential Revision: D46199100

