### PR TITLE
enable batch ask and tell by trial index for Ax backend

### DIFF
--- a/aepsych/server/message_handlers/handle_ask.py
+++ b/aepsych/server/message_handlers/handle_ask.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
+from collections.abc import Mapping
 
 import aepsych.utils_logging as utils_logging
 
@@ -21,7 +22,12 @@ def handle_ask(server, request):
     if server._pregen_asks:
         params = server._pregen_asks.pop()
     else:
-        params = ask(server)
+        # Some clients may still send "message" as an empty string, so we need to check if its a dict or not.
+        msg = request["message"]
+        if isinstance(msg, Mapping):
+            params = ask(server, **msg)
+        else:
+            params = ask(server)
 
     new_config = {"config": params, "is_finished": server.strat.finished}
     if not server.is_performing_replay:
@@ -31,7 +37,7 @@ def handle_ask(server, request):
     return new_config
 
 
-def ask(server):
+def ask(server, num_points=1):
     """get the next point to query from the model
     Returns:
         dict -- new config dict (keys are strings, values are floats)
@@ -49,5 +55,5 @@ def ask(server):
         next_x = server.strat.gen()[0]
         return server._tensor_to_config(next_x)
 
-    next_x = server.strat.gen()
+    next_x = server.strat.gen(num_points)
     return next_x

--- a/clients/python/aepsych_client/client.py
+++ b/clients/python/aepsych_client/client.py
@@ -7,13 +7,15 @@
 import json
 import socket
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from aepsych.server import AEPsychServer
 
+
 class ServerError(RuntimeError):
     pass
+
 
 class AEPsychClient:
     def __init__(
@@ -55,7 +57,7 @@ class AEPsychClient:
         """Loads the config index when server is not None"""
         self.configs = []
         for i in range(self.server.n_strats):
-                    self.configs.append(i)
+            self.configs.append(i)
 
     def connect(self, ip: str, port: int) -> None:
         """Connect to the server.
@@ -87,17 +89,57 @@ class AEPsychClient:
 
         return response
 
-    def ask(self) -> Dict[str, Any]:
+    def ask(
+        self, num_points: int = 1
+    ) -> Union[Dict[str, List[float]], Dict[int, Dict[str, Any]]]:
         """Get next configuration from server.
 
+        Args:
+            num_points[int]: Number of points to return.
+
         Returns:
-            Dict[str, str]: Next configuration to evaluate.
+            Dict[int, Dict[str, Any]]: Next configuration(s) to evaluate.
+            If using the legacy backend, this is formatted as a dictionary where keys are parameter names and values
+            are lists of parameter values.
+            If using the Ax backend, this is formatted as a dictionary of dictionaries where the outer keys are trial indices,
+            the inner keys are parameter names, and the values are parameter values.
         """
-        request = {"message": "", "type": "ask", "version": "0.01"}
+        request = {"message": {"num_points": num_points}, "type": "ask"}
         response = self._send_recv(request)
         if isinstance(response, str):
             response = json.loads(response)
         return response
+
+    def tell_trial_by_index(
+        self,
+        trial_index: int,
+        outcome: int,
+        model_data: bool = True,
+        **metadata: Dict[str, Any],
+    ) -> None:
+        """Update the server on a trial that already has a trial index, as provided by `ask`.
+
+        Args:
+            outcome (int): Outcome that was obtained.
+            model_data (bool): If True, the data will be recorded in the db and included in the server's model. If False,
+                the data will be recorded in the db, but will not be used by the model. Defaults to True.
+            trial_index (int): The associated trial index of the config.
+            metadata (optional kwargs) is passed to the extra_info field on the server.
+
+        Raises:
+            AssertionError if server failed to acknowledge the tell.
+        """
+
+        request = {
+            "type": "tell",
+            "message": {
+                "outcome": outcome,
+                "model_data": model_data,
+                "trial_index": trial_index,
+            },
+            "extra_info": metadata,
+        }
+        self._send_recv(request)
 
     def tell(
         self,
@@ -106,7 +148,8 @@ class AEPsychClient:
         model_data: bool = True,
         **metadata: Dict[str, Any],
     ) -> None:
-        """Update the server on a configuration that was executed.
+        """Update the server on a configuration that was executed. Use this method when using the legacy backend or for
+        manually-generated trials without an associated trial_index when uding the Ax backend.
 
         Args:
             config (Dict[str, str]): Config that was evaluated.
@@ -121,7 +164,11 @@ class AEPsychClient:
 
         request = {
             "type": "tell",
-            "message": {"config": config, "outcome": outcome, "model_data": model_data},
+            "message": {
+                "config": config,
+                "outcome": outcome,
+                "model_data": model_data,
+            },
             "extra_info": metadata,
         }
         self._send_recv(request)
@@ -151,7 +198,6 @@ class AEPsychClient:
             ), "if config_str is passed, don't pass config_path"
         request = {
             "type": "setup",
-            "version": "0.01",
             "message": {"config_str": config_str},
         }
         idx = int(self._send_recv(request))
@@ -183,7 +229,6 @@ class AEPsychClient:
             config_id = self.config_names[config_name]
         request = {
             "type": "resume",
-            "version": "0.01",
             "message": {"strat_id": config_id},
         }
         self._send_recv(request)

--- a/configs/multi_outcome_example.ini
+++ b/configs/multi_outcome_example.ini
@@ -30,11 +30,11 @@ threshold = -6  # The worst possible value for this outcome that would be accept
 # before we start doing model-based acquisition.
 [init_strat]
 generator = SobolGenerator # Start trial generation with sobol samples.
-min_total_tells = 10 # Number of data points required to complete this strategy. For a real experiment, you will want
+min_total_tells = 2 # Number of data points required to complete this strategy. For a real experiment, you will want
                     # 5-10 initialization trials per parameter.
 
 # Configuration for the optimization strategy, our model-based acquisition strategy.
 [opt_strat]
 generator = MultiOutcomeOptimizationGenerator # After sobol, do model-based active-learning for multiple outcomes.
-min_total_tells = 15 # Finish the experiment after 3 total data points have been collected. Depending on how noisy
+min_total_tells = 3 # Finish the experiment after 3 total data points have been collected. Depending on how noisy
                      # your problem is, you may need several dozen points per parameter to get an accurate model.

--- a/tests/generators/test_completion_criteria.py
+++ b/tests/generators/test_completion_criteria.py
@@ -46,10 +46,10 @@ class CompletionCriteriaTestCase(unittest.TestCase):
 
         self.assertFalse(criterion.is_met(self.strat.experiment))
 
-        self.strat.add_data({"x": [0.0]}, 0.0)
+        self.strat.complete_new_trial({"x": 0.0}, 0.0)
         self.assertFalse(criterion.is_met(self.strat.experiment))
 
-        self.strat.add_data({"x": [1.0]}, 0.0)
+        self.strat.complete_new_trial({"x": 1.0}, 0.0)
         self.assertFalse(criterion.is_met(self.strat.experiment))
 
         self.strat.gen()
@@ -75,10 +75,10 @@ class CompletionCriteriaTestCase(unittest.TestCase):
         self.strat.gen()
         self.assertFalse(criterion.is_met(self.strat.experiment))
 
-        self.strat.add_data({"x": [0.0]}, 0.0)
+        self.strat.complete_new_trial({"x": 0.0}, 0.0)
         self.assertFalse(criterion.is_met(self.strat.experiment))
 
-        self.strat.add_data({"x": [1.0]}, 0.0)
+        self.strat.complete_new_trial({"x": 1.0}, 0.0)
         self.assertTrue(criterion.is_met(self.strat.experiment))
 
     def test_min_total_outcome_occurences(self):
@@ -91,16 +91,16 @@ class CompletionCriteriaTestCase(unittest.TestCase):
         criterion = MinTotalOutcomeOccurrences.from_config(config, "test_strat")
         self.assertEqual(criterion.threshold, 2)
 
-        self.strat.add_data({"x": [0.0]}, 0.0)
+        self.strat.complete_new_trial({"x": 0.0}, 0.0)
         self.assertFalse(criterion.is_met(self.strat.experiment))
 
-        self.strat.add_data({"x": [1.0]}, 0.0)
+        self.strat.complete_new_trial({"x": 1.0}, 0.0)
         self.assertFalse(criterion.is_met(self.strat.experiment))
 
-        self.strat.add_data({"x": [0.0]}, 1.0)
+        self.strat.complete_new_trial({"x": 0.0}, 1.0)
         self.assertFalse(criterion.is_met(self.strat.experiment))
 
-        self.strat.add_data({"x": [1.0]}, 1.0)
+        self.strat.complete_new_trial({"x": 1.0}, 1.0)
         self.assertTrue(criterion.is_met(self.strat.experiment))
 
     def run_indefinitely(self):

--- a/tests/test_multioutcome.py
+++ b/tests/test_multioutcome.py
@@ -25,7 +25,7 @@ branin_currin = BraninCurrin(negate=True).to(
 
 def evaluate(parameters):
     evaluation = branin_currin(
-        torch.tensor([parameters.get("x1")[0], parameters.get("x2")[0]])
+        torch.tensor([parameters.get("x1"), parameters.get("x2")])
     )
     # In our case, standard error is 0, since we are computing a synthetic function.
     # Set standard error to None if the noise level is unknown.
@@ -74,8 +74,9 @@ class MultiOutcomeTestCase(unittest.TestCase):
     def test_ask_tell(self):
         while not self.client.server.strat.finished:
             trial_params = self.client.ask()
-            outcome = evaluate(trial_params["config"])
-            self.client.tell(trial_params["config"], outcome)
+            for trial in trial_params["config"]:
+                outcome = evaluate(trial_params["config"][trial])
+                self.client.tell_trial_by_index(trial, outcome)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: This enables the client to ask the server for multiple points when using the ax backend, and enables the client to send a trial index in tell messages to tell the server which Ax trial should be completed, getting rid of the clunky process that existed before. This requires changes to the message formatting, so new methods have been implemented on the client side.

Differential Revision: D46535504

