### PR TITLE
implement can_fit for Ax backend

### DIFF
--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -27,6 +27,7 @@ from aepsych.utils import (
     make_scaled_sobol,
 )
 from aepsych.utils_logging import getLogger
+from ax.core.base_trial import TrialStatus
 from ax.modelbridge.generation_strategy import GenerationStrategy
 from ax.plot.contour import interact_contour
 from ax.plot.slice import plot_slice
@@ -574,6 +575,13 @@ class AEPsychStrategy(ConfigurableMixin):
     @property
     def strat(self):
         return self.ax_client.generation_strategy
+
+    @property
+    def can_fit(self):
+        return (
+            self.strat.model is not None
+            and len(self.experiment.trial_indices_by_status[TrialStatus.COMPLETED]) > 0
+        )
 
     def _warn_on_outcome_mismatch(self):
         ax_model = self.ax_client.generation_strategy.model

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -14,7 +14,7 @@ with open(path.join(this_directory, "Readme.md"), encoding="utf-8") as f:
 
 setup(
     name="aepsych_client",
-    version="0.2.0",
+    version="0.3.0",
     packages=find_packages(),
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pandas
 tqdm
 pathos
 plotly>=2.2.1
-aepsych_client>=0.2.0
+aepsych_client==0.3.0
 voila==0.3.6
 ipywidgets==7.6.5
 ax-platform==0.3.1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     "pandas",
     "tqdm",
     "pathos",
-    "aepsych_client>=0.2.0",
+    "aepsych_client==0.3.0",
     "voila==0.3.6",
     "ipywidgets==7.6.5",
     "statsmodels",

--- a/tests/test_ax_integration.py
+++ b/tests/test_ax_integration.py
@@ -58,6 +58,7 @@ class AxIntegrationTestCase(unittest.TestCase):
         cls.config_file = os.path.join(os.path.dirname(__file__), cls.config_file)
         cls.client.configure(cls.config_file)
 
+        cls.can_fit_at_start = cls.client.server.strat.can_fit
         while not cls.client.server.strat.finished:
             # Ask the server what the next parameter values to test should be.
             trial_params = cls.client.ask()
@@ -74,6 +75,8 @@ class AxIntegrationTestCase(unittest.TestCase):
 
         # Add an extra ask to make sure we can generate trials endlessly
         trial_params = cls.client.ask(cls.n_extra_asks)
+
+        cls.can_fit_at_end = cls.client.server.strat.can_fit
 
         cls.df = exp_to_df(cls.client.server.strat.experiment)
 
@@ -141,6 +144,10 @@ class AxIntegrationTestCase(unittest.TestCase):
         self.assertEqual(n_sobol, correct_n_sobol)
         self.assertEqual(n_opt, correct_n_opt)
         self.assertEqual(n_manual, 1)
+
+    def test_can_fit(self):
+        self.assertFalse(self.can_fit_at_start)
+        self.assertTrue(self.can_fit_at_end)
 
 
 @unittest.skip("Base integration tests already cover most of these")


### PR DESCRIPTION
Summary: Implements `can_fit` for the ax backend, which is necessary for the Unity client.

Differential Revision: D46658409

