### PR TITLE
various speed ups

### DIFF
--- a/aepsych/generators/__init__.py
+++ b/aepsych/generators/__init__.py
@@ -16,7 +16,6 @@ from .multi_outcome_generator import MultiOutcomeOptimizationGenerator
 from .optimize_acqf_generator import AxOptimizeAcqfGenerator, OptimizeAcqfGenerator
 from .pairwise_optimize_acqf_generator import PairwiseOptimizeAcqfGenerator
 from .pairwise_sobol_generator import PairwiseSobolGenerator
-from .random_generator import RandomGenerator
 from .random_generator import AxRandomGenerator, RandomGenerator
 from .semi_p import IntensityAwareSemiPGenerator
 from .sobol_generator import AxSobolGenerator, SobolGenerator

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -6,20 +6,26 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
+import warnings
+
 from typing import List, Mapping, Optional, Tuple, Union
 
 import numpy as np
 import torch
 from botorch.acquisition import PosteriorMean
+from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.model import Model
 from botorch.models.utils.inducing_point_allocators import GreedyVarianceReduction
 from botorch.optim import optimize_acqf
+from botorch.posteriors import GPyTorchPosterior
 from botorch.utils.sampling import draw_sobol_samples
+from gpytorch.distributions import MultivariateNormal
 from gpytorch.kernels import Kernel
 from gpytorch.likelihoods import BernoulliLikelihood
 from scipy.cluster.vq import kmeans2
 from scipy.special import owens_t
 from scipy.stats import norm
+from torch import Tensor
 from torch.distributions import Normal
 
 
@@ -104,7 +110,9 @@ def get_probability_space(likelihood, posterior):
         a_star = fmean / torch.sqrt(1 + fvar)
         pmean = Normal(0, 1).cdf(a_star)
         t_term = torch.tensor(
-            owens_t(a_star.numpy(), 1 / np.sqrt(1 + 2 * fvar.numpy())),
+            owens_t(
+                a_star.detach().numpy(), 1 / np.sqrt(1 + 2 * fvar.detach().numpy())
+            ),
             dtype=a_star.dtype,
         )
         pvar = pmean - 2 * t_term - pmean.square()
@@ -125,17 +133,27 @@ def get_extremum(
     bounds: torch.Tensor,
     locked_dims: Optional[Mapping[int, List[float]]],
     n_samples: int,
+    posterior_transform: Optional[PosteriorTransform] = None,
+    max_time: Optional[float] = None,
 ) -> Tuple[float, np.ndarray]:
     """Return the extremum (min or max) of the modeled function
     Args:
-        extremum_type (str): type of extremum (currently 'min' or 'max'
-        n_samples int: number of coarse grid points to sample for optimization estimate.
+        extremum_type (str): Type of extremum (currently 'min' or 'max'.
+        bounds (tensor): Lower and upper bounds of the search space.
+        locked_dims (Mapping[int, List[float]]): Dimensions to fix, so that the
+            inverse is along a slice of the full surface.
+        n_samples (int): number of coarse grid points to sample for optimization estimate.
+        max_time (float): Maximum amount of time in seconds to spend optimizing.
     Returns:
         Tuple[float, np.ndarray]: Tuple containing the min and its location (argmin).
     """
     locked_dims = locked_dims or {}
 
-    acqf = PosteriorMean(model=model, maximize=(extremum_type == "max"))
+    acqf = PosteriorMean(
+        model=model,
+        maximize=(extremum_type == "max"),
+        posterior_transform=posterior_transform,
+    )
     best_point, best_val = optimize_acqf(
         acq_function=acqf,
         bounds=bounds,
@@ -143,9 +161,81 @@ def get_extremum(
         num_restarts=10,
         raw_samples=n_samples,
         fixed_features=locked_dims,
+        timeout_sec=max_time,
     )
 
     # PosteriorMean flips the sign on minimize, we flip it back
     if extremum_type == "min":
         best_val = -best_val
     return best_val, best_point.squeeze(0)
+
+
+def inv_query(
+    model: Model,
+    y: float,
+    bounds: torch.Tensor,
+    locked_dims: Optional[Mapping[int, List[float]]] = None,
+    probability_space: bool = False,
+    n_samples: int = 1000,
+    max_time: Optional[float] = None,
+) -> Tuple[float, Union[torch.Tensor, np.ndarray]]:
+    """Query the model inverse.
+    Return nearest x such that f(x) = queried y, and also return the
+        value of f at that point.
+    Args:
+        y (float): Points at which to find the inverse.
+        bounds (tensor): Lower and upper bounds of the search space.
+        locked_dims (Mapping[int, List[float]]): Dimensions to fix, so that the
+            inverse is along a slice of the full surface.
+        probability_space (bool): Is y (and therefore the
+            returned nearest_y) in probability space instead of latent
+            function space? Defaults to False.
+        n_samples (int): number of coarse grid points to sample for optimization estimate.
+        max_time float: Maximum amount of time in seconds to spend optimizing.
+    Returns:
+        Tuple[float, np.ndarray]: Tuple containing the value of f
+            nearest to queried y and the x position of this value.
+    """
+    locked_dims = locked_dims or {}
+    if probability_space:
+        warnings.warn(
+            "Inverse querying with probability_space=True assumes that the model uses Probit-Bernoulli likelihood!"
+        )
+        posterior_transform = TargetProbabilityDistancePosteriorTransform(y)
+    else:
+        posterior_transform = TargetDistancePosteriorTransform(y)
+    val, arg = get_extremum(
+        model, "min", bounds, locked_dims, n_samples, posterior_transform, max_time
+    )
+    return val, arg
+
+
+class TargetDistancePosteriorTransform(PosteriorTransform):
+    def __init__(self, target_value: float):
+        super().__init__()
+        self.target_value = target_value
+
+    def evaluate(self, Y: Tensor) -> Tensor:
+        return (Y - self.target_value) ** 2
+
+    def _forward(self, mean, var):
+        q = mean.shape[-2]
+        batch_shape = mean.shape[:-2]
+
+        new_mean = ((mean - self.target_value) ** 2).view(*batch_shape, q)
+        mvn = MultivariateNormal(new_mean, var)
+        return GPyTorchPosterior(mvn)
+
+    def forward(self, posterior: GPyTorchPosterior) -> GPyTorchPosterior:
+        mean = posterior.mean
+        var = posterior.variance
+        return self._forward(mean, var)
+
+
+# Requires botorch approximate model to accept posterior transforms
+class TargetProbabilityDistancePosteriorTransform(TargetDistancePosteriorTransform):
+    def forward(self, posterior: GPyTorchPosterior) -> GPyTorchPosterior:
+        pmean, pvar = get_probability_space(BernoulliLikelihood(), posterior)
+        pmean = pmean.unsqueeze(-1).unsqueeze(-1)
+        pvar = pvar.unsqueeze(-1).unsqueeze(-1)
+        return self._forward(pmean, pvar)

--- a/aepsych/server/message_handlers/handle_query.py
+++ b/aepsych/server/message_handlers/handle_query.py
@@ -30,6 +30,7 @@ def query(
     x=None,
     y=None,
     constraints=None,
+    max_time=None,
 ):
     if server.skip_computations:
         return None
@@ -41,11 +42,11 @@ def query(
         "constraints": constraints,
     }
     if query_type == "max":
-        fmax, fmax_loc = server.strat.get_max(constraints)
+        fmax, fmax_loc = server.strat.get_max(constraints, max_time)
         response["y"] = fmax.item()
         response["x"] = server._tensor_to_config(fmax_loc)
     elif query_type == "min":
-        fmin, fmin_loc = server.strat.get_min(constraints)
+        fmin, fmin_loc = server.strat.get_min(constraints, max_time)
         response["y"] = fmin.item()
         response["x"] = server._tensor_to_config(fmin_loc)
     elif query_type == "prediction":
@@ -62,7 +63,7 @@ def query(
         # expect constraints to be a dictionary; values are float arrays size 1 (exact) or 2 (upper/lower bnd)
         constraints = {server.parnames.index(k): v for k, v in constraints.items()}
         nearest_y, nearest_loc = server.strat.inv_query(
-            y, constraints, probability_space=probability_space
+            y, constraints, probability_space=probability_space, max_time=max_time
         )
         response["y"] = nearest_y
         response["x"] = server._tensor_to_config(nearest_loc)

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -228,19 +228,21 @@ class Strategy(object):
         return self.generator.gen(num_points, self.model)
 
     @ensure_model_is_fresh
-    def get_max(self, constraints=None):
+    def get_max(self, constraints=None, max_time=None):
         constraints = constraints or {}
-        return self.model.get_max(constraints)
+        return self.model.get_max(constraints, max_time=max_time)
 
     @ensure_model_is_fresh
-    def get_min(self, constraints=None):
+    def get_min(self, constraints=None, max_time=None):
         constraints = constraints or {}
-        return self.model.get_min(constraints)
+        return self.model.get_min(constraints, max_time=max_time)
 
     @ensure_model_is_fresh
-    def inv_query(self, y, constraints=None, probability_space=False):
+    def inv_query(self, y, constraints=None, probability_space=False, max_time=None):
         constraints = constraints or {}
-        return self.model.inv_query(y, constraints, probability_space)
+        return self.model.inv_query(
+            y, constraints, probability_space, max_time=max_time
+        )
 
     @ensure_model_is_fresh
     def predict(self, x, probability_space=False):

--- a/clients/python/aepsych_client/client.py
+++ b/clients/python/aepsych_client/client.py
@@ -233,5 +233,28 @@ class AEPsychClient:
         }
         self._send_recv(request)
 
+    def query(
+        self,
+        query_type="max",
+        probability_space=False,
+        x=None,
+        y=None,
+        constraints=None,
+        max_time=None,
+    ):
+        request = {
+            "type": "query",
+            "message": {
+                "query_type": query_type,
+                "probability_space": probability_space,
+                "x": x,
+                "y": y,
+                "constraints": constraints,
+                "max_time": max_time,
+            },
+        }
+        resp = self._send_recv(request)
+        return resp["y"], resp["x"]
+
     def __del___(self):
         self.finalize()

--- a/configs/ax_example.ini
+++ b/configs/ax_example.ini
@@ -62,3 +62,6 @@ value = 123 # Value of the fixed parameter, par6. Can be a float or string.
 
 [par7]
 value = placeholder # Value of the fixed parameter, par7. Can be a float or string.
+
+[OptimizeAcqfGenerator]
+max_gen_time = 0.1

--- a/configs/single_lse_example.ini
+++ b/configs/single_lse_example.ini
@@ -44,6 +44,10 @@ acqf = EAVC
 # Use GPClassificationModel or GPRegressionModel for single or PairwiseProbitModel for pairwise.
 model = GPClassificationModel
 
+max_gen_time = 0.1 # Maximum amount of time to spend optimizing the acquisition function each
+                   # trial. Lower values can lead to faster trials at the expense of possibly
+                   # sampling less informative points.
+
 ## Below this section are configurations of all the classes defined in the section above,
 ## matching the API in the code.
 
@@ -57,6 +61,9 @@ inducing_size = 100
 # GPClassificationModel) and song_mean_covar_factory (for the linear-additive model of some
 # previous work).
 mean_covar_factory = default_mean_covar_factory
+
+max_fit_time = 1.0 # Maximum amount of time to spend fitting the model each trial. Lowering this value
+                   # can lead to faster trials at the expense of model quality.
 
 
 ## OptimizeAcqfGenerator model settings.

--- a/tests/generators/test_optimize_acqf_generator.py
+++ b/tests/generators/test_optimize_acqf_generator.py
@@ -106,9 +106,9 @@ class TestOptimizeAcqfGenerator(unittest.TestCase):
 
                 [OptimizeAcqfGenerator]
                 acqf = MCLevelSetEstimation
-                max_gen_time = 1
-                restarts = 1
-                samps = 100
+                max_gen_time = 0.1
+                num_restarts = 1
+                raw_samples = 100
 
                 [MCLevelSetEstimation]
                 beta = 1
@@ -123,8 +123,24 @@ class TestOptimizeAcqfGenerator(unittest.TestCase):
         self.assertEqual(
             gen.model_kwargs["surrogate"].botorch_model_class, ContinuousRegressionGP
         )
-        self.assertEqual(gen.model_gen_kwargs["restarts"], 1)
-        self.assertEqual(gen.model_gen_kwargs["samps"], 100)
+        self.assertEqual(
+            gen.model_gen_kwargs["model_gen_options"]["optimizer_kwargs"][
+                "num_restarts"
+            ],
+            1,
+        )
+        self.assertEqual(
+            gen.model_gen_kwargs["model_gen_options"]["optimizer_kwargs"][
+                "raw_samples"
+            ],
+            100,
+        )
+        self.assertEqual(
+            gen.model_gen_kwargs["model_gen_options"]["optimizer_kwargs"][
+                "timeout_sec"
+            ],
+            0.1,
+        )
         self.assertEqual(gen.model_kwargs["acquisition_options"]["target"], 0.5)
         self.assertEqual(gen.model_kwargs["acquisition_options"]["beta"], 1.0)
         # TODO: Implement max_gen_time


### PR DESCRIPTION
Summary:
Made AEPsych faster in the following ways:
- Now takes advantage of optimize_acqf's timeout_sec argument to more reliably limit the amount of time spent optimizing the acqf using the max_gen_time option in configs.

- Changes the optimization algorithm for inverse model querying to use botorch's optimize_acqf, which should be faster and more accurate than scipy.minimize.

- "max_time" can be sent in query messages to limit the amount of time, in seconds, the model will spend searching for the queried value (using the aforementioned timeout_sec arg).

A query method was added to the python client to test these new features.

Differential Revision: D49388668


