### PR TITLE
fixing incorrect copyright headers

### DIFF
--- a/clients/matlab/AEPsychClient.m
+++ b/clients/matlab/AEPsychClient.m
@@ -1,5 +1,5 @@
  %{
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+// Copyright (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 // @lint-ignore-every LICENSELINT
 %}
 

--- a/website/pages/demos/ParticleEffectDemo.js
+++ b/website/pages/demos/ParticleEffectDemo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/pages/demos/ThrowOptimizerDemo.js
+++ b/website/pages/demos/ThrowOptimizerDemo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/pages/demos/YannyLaurelDemo.js
+++ b/website/pages/demos/YannyLaurelDemo.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary: Copyright headers were flagged as incorrect. Fixing them.

Reviewed By: jailby

Differential Revision: D51074527


