### PR TITLE
Remove usage of MinimumTrialsInStatus in AEPsych

### DIFF
--- a/aepsych/generators/completion_criterion/min_total_tells.py
+++ b/aepsych/generators/completion_criterion/min_total_tells.py
@@ -9,12 +9,15 @@ from typing import Any, Dict
 
 from aepsych.config import Config, ConfigurableMixin
 from ax.core.base_trial import TrialStatus
-from ax.modelbridge.completion_criterion import MinimumTrialsInStatus
+from ax.modelbridge.transition_criterion import MinTrials
 
 
-class MinTotalTells(MinimumTrialsInStatus, ConfigurableMixin):
+class MinTotalTells(MinTrials, ConfigurableMixin):
     @classmethod
     def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]:
         min_total_tells = config.getint(name, "min_total_tells", fallback=1)
-        options = {"status": TrialStatus.COMPLETED, "threshold": min_total_tells}
+        options = {
+            "only_in_statuses": [TrialStatus.COMPLETED],
+            "threshold": min_total_tells,
+        }
         return options


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/Ax/pull/2134

We have replaced the more limited MinimumTrialsInStatus with the more flexible TransitionCriterion `MinTrials`. This diff is the first in a set of diffs intended to update the legacy usage of CompletionCriterion in AEPsych.

In following diffs we will:
- Completely remove the completion criterion file
- update all four completion criterion defined in aepsych code here: https://www.internalfb.com/code/fbsource/[409e3dfb01ec5c613d34e58c491d63e8051d10d9]/fbcode/frl/ae/aepsych/tests/generators/test_completion_criteria.py?lines=12-15
- revisit storage
- remove all todos in gennode, genstrat, and transitioncriterion classes related to maintaining this deprecated code
- update AEPsych GSs as needed
- determine if run indefinetly can be replaced by simply having gen_unlimited_trials = true

Additional info: https://docs.google.com/document/d/1JWaD20ux8dRVWom3VhTBkh4_1v170XNJ3Xf7EdWsMc8/edit?usp=sharing

Differential Revision: D52848140

