### PR TITLE
Update all instances of MinimumPreferenceOccurances to directly use TransitionCriterion

### DIFF
--- a/aepsych/generators/completion_criterion/min_total_outcome_occurrences.py
+++ b/aepsych/generators/completion_criterion/min_total_outcome_occurrences.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 
 from aepsych.config import Config, ConfigurableMixin
 
-from ax.modelbridge.completion_criterion import MinimumPreferenceOccurances
+from ax.modelbridge.transition_criterion import MinimumPreferenceOccurances
 
 
 class MinTotalOutcomeOccurrences(MinimumPreferenceOccurances, ConfigurableMixin):


### PR DESCRIPTION
Summary:
We have replaced the more limited MinimumTrialsInStatus with the more flexible TransitionCriterion MinTrials. This diff updates MinimumPreferenceOccurances to directly inherit from its source in TransitionCriterion file

In following diffs we will:
- Completely remove the completion criterion file
- update all four completion criterion defined in aepsych code here: https://www.internalfb.com/code/fbsource/[409e3dfb01ec5c613d34e58c491d63e8051d10d9]/fbcode/frl/ae/aepsych/tests/generators/test_completion_criteria.py?lines=12-15
- revisit storage
- remove all todos in gennode, genstrat, and transitioncriterion classes related to maintaining this deprecated code
- update AEPsych GSs as needed
- determine if run indefinetly can be replaced by simply having gen_unlimited_trials = true

Additional info: https://docs.google.com/document/d/1JWaD20ux8dRVWom3VhTBkh4_1v170XNJ3Xf7EdWsMc8/edit?usp=sharing

Differential Revision: D52852317


