### PR TITLE
Update run_indefinetly to directly inherit from TransitionCriterion

### DIFF
--- a/aepsych/generators/completion_criterion/min_asks.py
+++ b/aepsych/generators/completion_criterion/min_asks.py
@@ -5,20 +5,29 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict
-
-from ax.core.experiment import Experiment
-from ax.modelbridge.completion_criterion import CompletionCriterion
+from typing import Any, Dict, Optional, Set
 
 from aepsych.config import Config, ConfigurableMixin
 
+from ax.core.experiment import Experiment
+from ax.modelbridge.transition_criterion import TransitionCriterion
 
-class MinAsks(CompletionCriterion, ConfigurableMixin):
+
+class MinAsks(TransitionCriterion, ConfigurableMixin):
     def __init__(self, threshold: int) -> None:
         self.threshold = threshold
 
     def is_met(self, experiment: Experiment) -> bool:
         return experiment.num_asks >= self.threshold
+
+    def block_continued_generation_error(
+        self,
+        node_name: Optional[str],
+        model_name: Optional[str],
+        experiment: Optional[Experiment],
+        trials_from_node: Optional[Set[int]] = None,
+    ) -> None:
+        pass
 
     @classmethod
     def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]:

--- a/aepsych/generators/completion_criterion/min_total_outcome_occurrences.py
+++ b/aepsych/generators/completion_criterion/min_total_outcome_occurrences.py
@@ -9,7 +9,7 @@ from typing import Any, Dict
 
 from aepsych.config import Config, ConfigurableMixin
 
-from ax.modelbridge.completion_criterion import MinimumPreferenceOccurances
+from ax.modelbridge.transition_criterion import MinimumPreferenceOccurances
 
 
 class MinTotalOutcomeOccurrences(MinimumPreferenceOccurances, ConfigurableMixin):

--- a/aepsych/generators/completion_criterion/run_indefinitely.py
+++ b/aepsych/generators/completion_criterion/run_indefinitely.py
@@ -5,19 +5,28 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Set
 
 from aepsych.config import Config, ConfigurableMixin
 from ax.core import Experiment
-from ax.modelbridge.completion_criterion import CompletionCriterion
+from ax.modelbridge.transition_criterion import TransitionCriterion
 
 
-class RunIndefinitely(CompletionCriterion, ConfigurableMixin):
+class RunIndefinitely(TransitionCriterion, ConfigurableMixin):
     def __init__(self, run_indefinitely: bool) -> None:
         self.run_indefinitely = run_indefinitely
 
     def is_met(self, experiment: Experiment) -> bool:
         return not self.run_indefinitely
+
+    def block_continued_generation_error(
+        self,
+        node_name: Optional[str],
+        model_name: Optional[str],
+        experiment: Optional[Experiment],
+        trials_from_node: Optional[Set[int]] = None,
+    ) -> None:
+        pass
 
     @classmethod
     def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]:


### PR DESCRIPTION
Summary:
We have replaced the more limited MinimumTrialsInStatus with the more flexible TransitionCriterion MinTrials. This diff we update the 4 of 4 aepsych completion criterion to directly rely on transitioncriterion

In following diffs we will:
- Completely remove the completion criterion file
- revisit storage
- remove all todos in gennode, genstrat, and transitioncriterion classes related to maintaining this deprecated code
- update AEPsych GSs as needed
- determine if run indefinetly can be replaced by simply having gen_unlimited_trials = true
- determine if additional updates to min_asks and run_indefinetly are necessary

Differential Revision: D52853023


