### PR TITLE
Fix GenerationStrategy and GenerataionNode todos

### DIFF
--- a/aepsych/generators/completion_criterion/min_asks.py
+++ b/aepsych/generators/completion_criterion/min_asks.py
@@ -14,10 +14,21 @@ from ax.modelbridge.transition_criterion import TransitionCriterion
 
 
 class MinAsks(TransitionCriterion, ConfigurableMixin):
-    def __init__(self, threshold: int) -> None:
+    def __init__(
+        self,
+        threshold: int,
+        block_transition_if_unmet: Optional[bool] = True,
+        block_gen_if_met: Optional[bool] = False,
+    ) -> None:
         self.threshold = threshold
+        super().__init__(
+            block_transition_if_unmet=block_transition_if_unmet,
+            block_gen_if_met=block_gen_if_met,
+        )
 
-    def is_met(self, experiment: Experiment) -> bool:
+    def is_met(
+        self, experiment: Experiment, trials_from_node: Optional[Set[int]] = None
+    ) -> bool:
         return experiment.num_asks >= self.threshold
 
     def block_continued_generation_error(
@@ -32,5 +43,7 @@ class MinAsks(TransitionCriterion, ConfigurableMixin):
     @classmethod
     def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]:
         min_asks = config.getint(name, "min_asks", fallback=1)
-        options = {"threshold": min_asks}
+        options = {
+            "threshold": min_asks,
+        }
         return options

--- a/aepsych/generators/completion_criterion/run_indefinitely.py
+++ b/aepsych/generators/completion_criterion/run_indefinitely.py
@@ -13,10 +13,19 @@ from ax.modelbridge.transition_criterion import TransitionCriterion
 
 
 class RunIndefinitely(TransitionCriterion, ConfigurableMixin):
-    def __init__(self, run_indefinitely: bool) -> None:
+    def __init__(
+        self,
+        run_indefinitely: bool,
+        block_transition_if_unmet: Optional[bool] = False,
+        block_gen_if_met: Optional[bool] = False,
+    ) -> None:
         self.run_indefinitely = run_indefinitely
+        self.block_transition_if_unmet = block_transition_if_unmet
+        self.block_gen_if_met = block_gen_if_met
 
-    def is_met(self, experiment: Experiment) -> bool:
+    def is_met(
+        self, experiment: Experiment, trials_from_node: Optional[Set[int]] = None
+    ) -> bool:
         return not self.run_indefinitely
 
     def block_continued_generation_error(


### PR DESCRIPTION
Summary:
In this diff we update the Ax GenerationStrategy code to remove all todos related to aepsych, and use the standard GS code flow for aepsych usecases. This required some minimal updates to the aepsych criterion and one of the storage tests.

In following diffs we will:
- revisit storage
- update AEPsych GSs as needed
- determine if run indefinetly can be replaced by simply having gen_unlimited_trials = true

Differential Revision: D52898268


