### PR TITLE
Support experiment level TrialBasedCriterion

### DIFF
--- a/aepsych/generators/completion_criterion/min_total_tells.py
+++ b/aepsych/generators/completion_criterion/min_total_tells.py
@@ -19,5 +19,6 @@ class MinTotalTells(MinTrials, ConfigurableMixin):
         options = {
             "only_in_statuses": [TrialStatus.COMPLETED],
             "threshold": min_total_tells,
+            "use_all_trials_in_exp": True,
         }
         return options

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -22,9 +22,9 @@ from aepsych.generators.sobol_generator import AxSobolGenerator, SobolGenerator
 from aepsych.models.base import ModelProtocol
 from aepsych.utils import (
     _process_bounds,
+    get_bounds,
     get_objectives,
     get_parameters,
-    get_bounds,
     make_scaled_sobol,
 )
 from aepsych.utils_logging import getLogger
@@ -556,7 +556,7 @@ class AEPsychStrategy(ConfigurableMixin):
 
     @property
     def finished(self) -> bool:
-        if self.is_finished:
+        if self.is_finished or self.strat.optimization_complete:
             return True
 
         self.strat._maybe_move_to_next_step()


### PR DESCRIPTION
Summary:
Some criterion require an experiment level view instead of only reviewing trials generated from the node associated with that criterion. This enables that capability as an attribute on TrialBasedCriterion, defaults to false since only folks who know what they are doing should use experiment level view (could cause confusing behavior othewise)

In the process of updating the AEPsych usecase, after landing the primary change in D52898268, we broke test_ask_tell in test_multioutcome, this fixes that.

Differential Revision: D53439656


