### PR TITLE
fix manual generator bugs

### DIFF
--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -36,6 +36,7 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
     _requires_model = True
     baseline_requiring_acqfs = [qNoisyExpectedImprovement, NoisyExpectedImprovement]
     stimuli_per_trial = 1
+    max_asks = None
 
     def __init__(
         self,

--- a/aepsych/generators/manual_generator.py
+++ b/aepsych/generators/manual_generator.py
@@ -38,10 +38,10 @@ class ManualGenerator(AEPsychGenerator):
             shuffle (bool): Whether or not to shuffle the order of the points. True by default.
         """
         self.lb, self.ub, self.dim = _process_bounds(lb, ub, dim)
-        self.points = points
+        self.points = torch.tensor(points)
         if shuffle:
             np.random.shuffle(points)
-        self.finished = False
+        self.max_asks = len(self.points)
         self._idx = 0
 
     def gen(
@@ -62,8 +62,6 @@ class ManualGenerator(AEPsychGenerator):
             )
         points = self.points[self._idx : self._idx + num_points]
         self._idx += num_points
-        if self._idx >= len(self.points):
-            self.finished = True
         return points
 
     @classmethod

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -139,7 +139,7 @@ class Strategy(object):
         self.run_indefinitely = run_indefinitely
         self.lb, self.ub, self.dim = _process_bounds(lb, ub, dim)
         self.min_total_outcome_occurrences = min_total_outcome_occurrences
-        self.max_asks = max_asks
+        self.max_asks = max_asks or generator.max_asks
         self.keep_most_recent = keep_most_recent
 
         self.min_post_range = min_post_range


### PR DESCRIPTION
Summary:
Fixed 2 bugs related to ManualGenerator
1. The experiment could crash if the manually-specified points were interpreted as numpy arrays instead of tensors. They are now explicitly casted to tensors during initialization.
2. ManualGenerator would never correctly move to the next strategy during replay if skip_computations were true. This has been fixed by changing the logic to check if a strategy is finished.

Reviewed By: phigua

Differential Revision: D54865037


