### PR TITLE
Fix integration test

### DIFF
--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -530,6 +530,7 @@ class AEPsychStrategy(ConfigurableMixin):
         # Add an extra step at the end that we can `ask` endlessly.
         final_step = copy(step)
         final_step.completion_criteria = []
+        final_step._transition_criteria = []
         final_step.num_trials = -1
         steps.append(final_step)
 

--- a/tests/test_ax_integration.py
+++ b/tests/test_ax_integration.py
@@ -20,7 +20,6 @@ from ax.service.utils.report_utils import exp_to_df
 from parameterized import parameterized_class
 
 
-@unittest.skip("Test is flaky. Skipping for now.")
 @parameterized_class(
     ("config_file", "should_ignore"),
     [


### PR DESCRIPTION
Summary:
Previously the integration test was failing due to not allowing unlimited trials on the last step. This is because the final step was copied from the exisiting botorch step (which contains transition criterion). If transition criterion exist on the step/node, we default to using those for determining the state of the node. 

This fixes the test by manually unsetting the transition criterion arg for the aepsych strategy.py.

We also re-enable the test

Differential Revision: D54960088


