### PR TITLE
Update deprecated usage of base_samples with GPyTorchPosterior.rsample

### DIFF
--- a/aepsych/models/semi_p.py
+++ b/aepsych/models/semi_p.py
@@ -111,11 +111,13 @@ class SemiPPosterior(GPyTorchPosterior):
         sample_shape: Optional[torch.Size] = None,
         base_samples: Optional[torch.Tensor] = None,
     ):
-        kcsamps = (
-            super()
-            .rsample(sample_shape=sample_shape, base_samples=base_samples)
-            .squeeze(-1)
-        )
+        if base_samples is None:
+            samps_ = super().rsample(sample_shape=sample_shape)
+        else:
+            samps_ = super().rsample_from_base_samples(
+                sample_shape=sample_shape, base_samples=base_samples
+            )
+        kcsamps = samps_.squeeze(-1)
         # fsamps is of shape nsamp x 2 x n, or nsamp x b x 2 x n
         return kcsamps
 


### PR DESCRIPTION
Summary: The base_samples argument of GPyTorchPosterior.rsample has been deprecated for a while and will soon be reaped. This PR updates the usage to `rsample_from_base_samples`, which does permit the `base_samples` argument. This is not risk-free, because `rsample` permitted a wider variety of shapes of `base_samples` and would attempt to correct input dimensions, while `rsample_from_base_samples` is more restrictive.

Differential Revision: D55040610


