### PR TITLE
fix bug when semip is passed None for likelihood

### DIFF
--- a/aepsych/models/semi_p.py
+++ b/aepsych/models/semi_p.py
@@ -280,8 +280,10 @@ class SemiParametricGPModel(GPClassificationModel):
 
         if hasattr(likelihood_cls, "from_config"):
             likelihood = likelihood_cls.from_config(config)
-        else:
+        elif likelihood_cls is not None:
             likelihood = likelihood_cls()
+        else:
+            likelihood = None
 
         stim_dim = config.getint(classname, "stim_dim", fallback=0)
 


### PR DESCRIPTION
Summary: Adds a check to make sure likelihood class is not None when constructing the likelihood of SemiP from a config

Reviewed By: mshvartsman

Differential Revision: D57624855


