### PR TITLE
change default optimization acqf to qLogNoisyExpectedImprovement

### DIFF
--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -14,6 +14,8 @@ from botorch.acquisition import (
     AcquisitionFunction,
     NoisyExpectedImprovement,
     qNoisyExpectedImprovement,
+    LogNoisyExpectedImprovement,
+    qLogNoisyExpectedImprovement,
 )
 
 
@@ -31,7 +33,12 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
     """Abstract base class for generators, which are responsible for generating new points to sample."""
 
     _requires_model = True
-    baseline_requiring_acqfs = [qNoisyExpectedImprovement, NoisyExpectedImprovement]
+    baseline_requiring_acqfs = [
+        qNoisyExpectedImprovement,
+        NoisyExpectedImprovement,
+        qLogNoisyExpectedImprovement,
+        LogNoisyExpectedImprovement,
+    ]
     stimuli_per_trial = 1
     max_asks: Optional[int] = None
 

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -14,15 +14,28 @@ from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator
 from aepsych.models.base import ModelProtocol
 from aepsych.utils_logging import getLogger
-from botorch.acquisition import AcquisitionFunction
 from botorch.acquisition.preference import AnalyticExpectedUtilityOfBestOption
 from botorch.optim import optimize_acqf
+from botorch.acquisition import (
+    AcquisitionFunction,
+    NoisyExpectedImprovement,
+    qNoisyExpectedImprovement,
+    LogNoisyExpectedImprovement,
+    qLogNoisyExpectedImprovement,
+)
 
 logger = getLogger()
 
 
 class OptimizeAcqfGenerator(AEPsychGenerator):
     """Generator that chooses points by minimizing an acquisition function."""
+
+    baseline_requiring_acqfs = [
+        NoisyExpectedImprovement,
+        LogNoisyExpectedImprovement,
+        qNoisyExpectedImprovement,
+        qLogNoisyExpectedImprovement,
+    ]
 
     def __init__(
         self,
@@ -57,9 +70,7 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
             return self.acqf(pref_model=model)
 
         if self.acqf in self.baseline_requiring_acqfs:
-            return self.acqf(
-                model=model, X_baseline=model.train_inputs[0], **self.acqf_kwargs
-            )
+            return self.acqf(model, model.train_inputs[0], **self.acqf_kwargs)
         else:
             return self.acqf(model=model, **self.acqf_kwargs)
 

--- a/clients/unity/Packages/com.frl.aepsych/Runtime/ConfigGenerator.cs
+++ b/clients/unity/Packages/com.frl.aepsych/Runtime/ConfigGenerator.cs
@@ -1,10 +1,4 @@
-﻿/*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- * All rights reserved.
- *
- * This source code is licensed under the license found in the
- * LICENSE file in the root directory of this source tree.
- */
+﻿// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 using System.Collections;
 using System.Collections.Generic;
@@ -170,7 +164,7 @@ public class ConfigGenerator: MonoBehaviour
                 {
                     combo[2] = method;
 
-                    // ensure last modified value remains intact 
+                    // ensure last modified value remains intact
                     combo[lastChanged] = lastChangedVal;
 
                     // Check combo validity
@@ -264,7 +258,7 @@ public class ConfigGenerator: MonoBehaviour
                 init_generator = "SobolGenerator";
                 opt_generator = "OptimizeAcqfGenerator";
                 outcome_type = "binary";
-                acqf = "qNoisyExpectedImprovement";
+                acqf = "qLogNoisyExpectedImprovement";
                 model = "GPClassificationModel";
                 mean_covar_factory = "default_mean_covar_factory";
                 objective = "ProbitObjective";
@@ -284,7 +278,7 @@ public class ConfigGenerator: MonoBehaviour
                 init_generator = "SobolGenerator";
                 opt_generator = "OptimizeAcqfGenerator";
                 outcome_type = "continuous";
-                acqf = "qNoisyExpectedImprovement";
+                acqf = "qLogNoisyExpectedImprovement";
                 model = "GPRegressionModel";
                 target = -1f;
                 specifyAcqf = false;
@@ -302,7 +296,7 @@ public class ConfigGenerator: MonoBehaviour
                 init_generator = "PairwiseSobolGenerator";
                 opt_generator = "PairwiseOptimizeAcqfGenerator";
                 outcome_type = "binary";
-                acqf = "qNoisyExpectedImprovement";
+                acqf = "qLogNoisyExpectedImprovement";
                 model = "PairwiseProbitModel";
                 mean_covar_factory = "default_mean_covar_factory";
                 objective = "ProbitObjective";
@@ -398,7 +392,7 @@ public class ConfigGenerator: MonoBehaviour
                 sb.Append("beta = " + beta + "\n");
             sb.Append("objective = " + objective + "\n");
         }
-        
+
         return sb.ToString();
     }
 
@@ -413,7 +407,7 @@ public class ConfigGenerator: MonoBehaviour
             finalPath = Path.Combine(Application.streamingAssetsPath, "configs/" + experimentName + ".ini");
             relativePath = Path.Combine("Assets/StreamingAssets/configs/" + experimentName + ".ini");
         }
-            
+
         else
             finalPath = Path.Combine(Application.streamingAssetsPath, GetManualConfigPath());
 

--- a/configs/nonmonotonic_optimization_example.ini
+++ b/configs/nonmonotonic_optimization_example.ini
@@ -42,9 +42,9 @@ generator = OptimizeAcqfGenerator # The generator class used to generate new par
 model = GPClassificationModel
 
 # Acquisition function: the objective we use to decide where to sample next. We recommend
-# EAVC or GlobalMI for threshold finding or qNoisyExpectedImprovement for optimization.
+# EAVC or GlobalMI for threshold finding or qLogNoisyExpectedImprovement for optimization.
 # For other options, check out the botorch and aepsych docs.
-acqf = qNoisyExpectedImprovement
+acqf = qLogNoisyExpectedImprovement
 
 ## GPClassificationModel model settings.
 [GPClassificationModel]
@@ -63,5 +63,5 @@ restarts = 10 # number of restarts for acquisition function optimization.
 samps = 1000 # number of samples for quasi-random initialization of the acquisition function optimizer
 
 ## Acquisition function settings; we recommend not changing this.
-[qNoisyExpectedImprovement]
+[qLogNoisyExpectedImprovement]
 objective = ProbitObjective # The transformation of the latent function before threshold estimation.

--- a/configs/pairwise_opt_example.ini
+++ b/configs/pairwise_opt_example.ini
@@ -35,10 +35,10 @@ refit_every = 5
 generator = OptimizeAcqfGenerator # The generator class used to generate new parameter values
 
 # Acquisition function: the objective we use to decide where to sample next. We recommend
-# PairwiseMCPosteriorVariance for global exploration, and qNoisyExpectedImprovement for
+# PairwiseMCPosteriorVariance for global exploration, and qLogNoisyExpectedImprovement for
 # optimization. For other options, check out the botorch and aepsych docs, though note
 # that in the pairwise setting not all acquisition functions will make sense
-acqf = qNoisyExpectedImprovement
+acqf = qLogNoisyExpectedImprovement
 
 # The model, which must conform to the stimuli_per_trial and outcome_types settings above.
 # Use GPClassificationModel or GPRegressionModel for single or PairwiseProbitModel for pairwise.
@@ -72,5 +72,5 @@ restarts = 10 # number of restarts for acquisition function optimization.
 samps = 1000 # number of samples for quasi-random initialization of the acquisition function optimizer
 
 ## Acquisition function settings; we recommend not changing this.
-[qNoisyExpectedImprovement]
+[qLogNoisyExpectedImprovement]
 objective = ProbitObjective # The transformation of the latent function before threshold estimation.

--- a/configs/single_lse_example.ini
+++ b/configs/single_lse_example.ini
@@ -36,7 +36,7 @@ refit_every = 5
 generator = OptimizeAcqfGenerator # The generator class used to generate new parameter values
 
 # Acquisition function: the objective we use to decide where to sample next. We recommend
-# EAVC or GlobalMI for threshold finding or qNoisyExpectedImprovement for optimization.
+# EAVC or GlobalMI for threshold finding or qLogNoisyExpectedImprovement for optimization.
 # For other options, check out the botorch and aepsych docs.
 acqf = EAVC
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,7 +30,7 @@ from aepsych.models import (
 from aepsych.server import AEPsychServer
 from aepsych.strategy import SequentialStrategy, Strategy
 from aepsych.version import __version__
-from botorch.acquisition import qNoisyExpectedImprovement
+from botorch.acquisition import qLogNoisyExpectedImprovement
 from botorch.acquisition.active_learning import PairwiseMCPosteriorVariance
 
 from aepsych.server.message_handlers.handle_setup import configure
@@ -178,7 +178,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(
             isinstance(strat.strat_list[1].generator, OptimizeAcqfGenerator)
         )
-        self.assertTrue(strat.strat_list[1].generator.acqf is qNoisyExpectedImprovement)
+        self.assertTrue(strat.strat_list[1].generator.acqf is qLogNoisyExpectedImprovement)
         self.assertTrue(
             set(strat.strat_list[1].generator.acqf_kwargs.keys()) == {"objective"}
         )
@@ -540,7 +540,7 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(strat.strat_list[0].model is None)
 
         self.assertTrue(isinstance(strat.strat_list[1].model, PairwiseProbitModel))
-        self.assertTrue(strat.strat_list[1].generator.acqf is qNoisyExpectedImprovement)
+        self.assertTrue(strat.strat_list[1].generator.acqf is qLogNoisyExpectedImprovement)
         self.assertTrue(
             set(strat.strat_list[1].generator.acqf_kwargs.keys()) == {"objective"}
         )


### PR DESCRIPTION
Summary: Due to some changes in botorch, qNoisyExpectedImprovement no longer works with AEPsych's OptimizeAcqfGenerator. qLogNoisyExpectedImprovement is supposed to provide better results anyway, so I'm changing that to the default.

Differential Revision: D57397518


