### PR TITLE
modify the generator object to process np.array argument (and convert from string to list)

### DIFF
--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 import abc
 import ast
+import re
 import configparser
 import json
 import warnings
@@ -163,7 +164,9 @@ class Config(configparser.ConfigParser):
             del self["experiment"]
 
     def _str_to_list(self, v: str, element_type: _T = float) -> List[_T]:
-        if v[0] == "[" and v[-1] == "]":
+        v = re.sub(r"\n ", ",", v)
+        v = re.sub(r"(?<!,)\s+", ",", v)
+        if re.search(r"^\[.*\]$", v, flags=re.DOTALL):
             if v == "[]":  # empty list
                 return []
             else:

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -6,6 +6,7 @@
 import abc
 from inspect import signature
 from typing import Any, Dict, Generic, Protocol, runtime_checkable, TypeVar, Optional
+import re
 
 import torch
 from aepsych.config import Config
@@ -73,9 +74,14 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
                 for k in acqf_args_expected:
                     # if this thing is configured
                     if k in full_section.keys():
+                        v = config.get(acqf_name, k)
                         # if it's an object make it an object
                         if full_section[k] in Config.registered_names.keys():
                             extra_acqf_args[k] = config.getobj(acqf_name, k)
+                        elif re.search(
+                            r"^\[.*\]$", v, flags=re.DOTALL
+                        ):  # use regex to check if the value is a list
+                            extra_acqf_args[k] = config._str_to_list(v) # type: ignore
                         else:
                             # otherwise try a float
                             try:


### PR DESCRIPTION
Summary:
We modified the generator object to process np.array argument: In the config dictionary, we specify the target argument of any child class of the `LookaheadAcquisitionFunction` class as a numpy array. The config processed the numpy array as a string using self.from_dict.

We have modified (1) the `_str_to_list` function of the Config class in config.py to accept a broader range of string representations of lists, including those with "\n" escape characters and white spaces. The function will properly convert these strings to list. (2) the `_get_acqf_options` function of the `AEPsychGenerator` class in base.py. The function uses regex to detect list argument in a string for any acquisition arguments and calls the `_str_to_list` function to convert it to a list.

Reviewed By: crasanders

Differential Revision: D58163715


