### PR TITLE
small bugfix of the _str_to_list function in the Config class

### DIFF
--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -166,6 +166,7 @@ class Config(configparser.ConfigParser):
     def _str_to_list(self, v: str, element_type: _T = float) -> List[_T]:
         v = re.sub(r"\n ", ",", v)
         v = re.sub(r"(?<!,)\s+", ",", v)
+        v = re.sub(r",]", "]", v)
         if re.search(r"^\[.*\]$", v, flags=re.DOTALL):
             if v == "[]":  # empty list
                 return []


### PR DESCRIPTION
Summary: we added another edge case for preprocessing a string and converting it to a list: some numpy array ended with an extra comma before the closing bracket.

Reviewed By: crasanders

Differential Revision: D59067746
