### PR TITLE
Remove polyfill.io from AEPsych

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -93,7 +93,6 @@ const siteConfig = {
     "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js",
     `${baseUrl}js/cookie_consent.js`,
     // Mathjax for rendering math content
-    'https://polyfill.io/v3/polyfill.min.js?features=es6',
     'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'
   ],
 


### PR DESCRIPTION
Summary:
These polyfills shouldn't really be needed for modern browsers, but that's not the main problem...

The main problems though is that `polyfill.io` was recently sold to a betting firm who are now using it to XSS attack any site that uses the CDN tags. Hence, I'm going through and removing references from all surfaces within in our codebase.

[More info from The Register](https://www.theregister.com/2024/06/25/polyfillio_china_crisis/).

Differential Revision: D59106272
