### PR TITLE
modify the problem classes to record brier score on multiple thresholds

### DIFF
--- a/aepsych/benchmark/example_problems.py
+++ b/aepsych/benchmark/example_problems.py
@@ -19,15 +19,17 @@ by Letham et al. 2022."""
 class DiscrimLowDim(LSEProblemWithEdgeLogging):
     name = "discrim_lowdim"
     bounds = torch.tensor([[-1, 1], [-1, 1]], dtype=torch.double).T
-    threshold = 0.75
+
+    def __init__(self, thresholds=None):
+        thresholds = 0.75 if thresholds is None else thresholds
+        super().__init__(thresholds=thresholds)
 
     def f(self, x: torch.Tensor) -> torch.Tensor:
-        return novel_discrimination_testfun(x).to(torch.double) # type: ignore
+        return novel_discrimination_testfun(x).to(torch.double)  # type: ignore
 
 
 class DiscrimHighDim(LSEProblemWithEdgeLogging):
     name = "discrim_highdim"
-    threshold = 0.75
     bounds = torch.tensor(
         [
             [-1, 1],
@@ -42,19 +44,26 @@ class DiscrimHighDim(LSEProblemWithEdgeLogging):
         dtype=torch.double,
     ).T
 
+    def __init__(self, thresholds=None):
+        thresholds = 0.75 if thresholds is None else thresholds
+        super().__init__(thresholds=thresholds)
+
     def f(self, x: torch.Tensor) -> torch.Tensor:
         return torch.tensor(discrim_highdim(x), dtype=torch.double)
 
 
 class Hartmann6Binary(LSEProblemWithEdgeLogging):
     name = "hartmann6_binary"
-    threshold = 0.5
     bounds = torch.stack(
         (
             torch.zeros(6, dtype=torch.double),
             torch.ones(6, dtype=torch.double),
         )
     )
+
+    def __init__(self, thresholds=None):
+        thresholds = 0.5 if thresholds is None else thresholds
+        super().__init__(thresholds=thresholds)
 
     def f(self, X: torch.Tensor) -> torch.Tensor:
         y = torch.tensor([modified_hartmann6(x) for x in X], dtype=torch.double)
@@ -68,13 +77,14 @@ class ContrastSensitivity6d(LSEProblemWithEdgeLogging):
     """
 
     name = "contrast_sensitivity_6d"
-    threshold = 0.75
     bounds = torch.tensor(
         [[-1.5, 0], [-1.5, 0], [0, 20], [0.5, 7], [1, 10], [0, 10]],
         dtype=torch.double,
     ).T
 
-    def __init__(self):
+    def __init__(self, thresholds=None):
+        thresholds = 0.75 if thresholds is None else thresholds
+        super().__init__(thresholds=thresholds)
 
         # Load the data
         self.data = np.loadtxt(

--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -378,4 +378,7 @@ class AEPsychMixin(GPyTorchModel):
 
     def p_below_threshold(self, x, f_thresh) -> np.ndarray:
         f, var = self.predict(x)
+        f_thresh = f_thresh.reshape(-1, 1)
+        f = f.reshape(1, -1)
+        var = var.reshape(1, -1)
         return norm.cdf((f_thresh - f.detach().numpy()) / var.sqrt().detach().numpy())


### PR DESCRIPTION
Summary:
The`LSEProblem`, `LSEProblemWithEdgeLogging`, and some example problem classes are modified to allow user to pass in a list of thresholds to record the brier score and misclassification error. Rather than assessing brier score w.r.t the one default threshold set by the problem class, we allow more flexible benchmarking on different contour lines.

The following functions are changed to vectorize calculation of brier score w.r.t. the threshold and misclassification error rate on the threshold: `p_below_threshold` function in the `AEPsychMixin` class in `base.py`, the `f_threshold` function and `true_below_threshold` property in the `LSEProblem` class.

All classes now have an explicit __ini__ function to take in user provided argument of "thresholds" for benchmark recording

The `test_benchmark.py` script was modified to reflect the changes.

Reviewed By: crasanders

Differential Revision: D59613531
