### PR TITLE
Pin numpy<2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ import os
 from setuptools import find_packages, setup
 
 REQUIRES = [
+    "numpy<2.0, >=1.20",
     "matplotlib",
     "torch",
     "scipy",
@@ -27,7 +28,6 @@ DEV_REQUIRES = BENCHMARK_REQUIRES + [
     "coverage",
     "flake8",
     "black",
-    "numpy>=1.20",
     "sqlalchemy-stubs",  # for mypy stubs
     "mypy",
     "parameterized",


### PR DESCRIPTION
Summary:
Numpy version>=2.0 break various dependencies. When importing aepsych, BoTorch throws an error first, but other packages are likely affected.

Pinned the version to be below 2.0 to ensure compatability.

Differential Revision: D63354305
