### PR TITLE
Increase workflow os/python version test coverage

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -32,11 +32,12 @@ jobs:
 
   build-test:
 
-    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
+        os: [macos-latest, windows-latest, macos-13]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Summary:
Added different windows and macos-13 to the os's test matrix in build-lint-test workflow. Also added python 3.11, creating a 3x3 matrix.

macos-13 is important to ensure compatability with intel macs, macos-latest will cover M1 Macs.

Currently hangs on testing on windows (all version of Python) but this is a failed test that should have been caught all along.

Differential Revision: D63403529
