### PR TITLE
Bump botorch and python version dependencies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 AEPsych is a framework and library for adaptive experimetation in psychophysics and related domains.
 
 ## Installation
-`AEPsych` only supports python 3.8+. We recommend installing `AEPsych` under a virtual environment like
+`AEPsych` only supports python 3.10+. We recommend installing `AEPsych` under a virtual environment like
 [Anaconda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html).
 Once you've created a virtual environment for `AEPsych` and activated it, you can install `AEPsych` using pip:
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIRES = [
     "pandas",
     "aepsych_client==0.3.0",
     "statsmodels",
-    "botorch==0.11.0",
+    "botorch==0.12.0",
 ]
 
 BENCHMARK_REQUIRES = ["tqdm", "pathos", "multiprocess"]
@@ -51,7 +51,7 @@ with open(os.path.join("aepsych", "version.py"), "r") as fh:
 setup(
     name="aepsych",
     version=version,
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     packages=find_packages(),
     description="Adaptive experimetation for psychophysics",
     long_description=long_description,


### PR DESCRIPTION
Summary:
BoTorch requires >=3.10, while lower versions of python seem to work, we shouldn't expect them to.

Botorch version bumped to latest at 0.12.0.

Differential Revision: D63420727
