### PR TITLE
add sleep to unittests to ensure dbs can be deleted

### DIFF
--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -11,6 +11,7 @@ import select
 import unittest
 import uuid
 from unittest.mock import MagicMock
+import time
 
 import aepsych.server as server
 import aepsych.utils_logging as utils_logging
@@ -61,6 +62,9 @@ class BaseServerTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.s.cleanup()
+
+        # sleep to ensure db is closed
+        time.sleep(0.1)
 
         # cleanup the db
         if self.s.db is not None:


### PR DESCRIPTION
Summary:
Added a 100ms sleep between turning off the test server and deleting the test db.

Server-related unittests sometimes fail (seen when running tests in Windows) when trying to delete the test db, likely due to the db's not fully released by the server yet.

This bug is inconsistent when it appears, but so far only on Windows OS and only consistently in Github Workflows with specific combinations of dependencies and OS versions.

Theoretically could happen outside of tests but it is rare to stop a server and delete the related db one after another. A more careful fix could add checks in place for this.

Differential Revision: D63486690
