### PR TITLE
Fix deprecated Matplotlib grid argument in AEPsych tutorial

### DIFF
--- a/examples/data_collection_analysis_tutorial.ipynb
+++ b/examples/data_collection_analysis_tutorial.ipynb
@@ -22,6 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "ef0c3012",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +49,7 @@
     "        verticalalignment='center',\n",
     "        transform=ax.transAxes)\n",
     "    ax.axis('off')\n",
-    "    ax.grid(b=None)\n",
+    "    ax.grid()\n",
     "    plt.show()\n",
     "\n",
     "# Evaluate the gabor filter function at an x,y position\n",
@@ -73,7 +74,7 @@
     "    M = ((M - M.min())) / (M.max() - M.min())\n",
     "\n",
     "    ax.axis('off')\n",
-    "    ax.grid(b=None)\n",
+    "    ax.grid()\n",
     "    ax.imshow(M.T, cmap=cm.Greys_r)\n",
     "\n",
     "\n",
@@ -116,6 +117,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ce0cb286",
    "metadata": {},
    "source": [
     "On each trial of the experiment, the participant will first see a white box with fixation cross for 1 second. The box looks like this:"
@@ -124,6 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "a60a322a",
    "metadata": {},
    "outputs": [
     {
@@ -143,6 +146,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a8363f0c",
    "metadata": {},
    "source": [
     "After 1 second, the fixation cross will disappear, and two gabor patches will appear side-by-side. One patch will be the foil with a vertical orientation, and one will be the target with an angled orientation. The position of the target and whether the angle is measured clockwise or counterclockwise is randomized each trial. An example foil and target are shown below:"
@@ -151,6 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "61a205c5",
    "metadata": {},
    "outputs": [
     {
@@ -174,6 +179,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d125887f",
    "metadata": {},
    "source": [
     "After 0.5 seconds, the patches will disappear, and the participant will be prompted to report which one was the target by typing \"F\" for left or \"J\" for right, and then hitting enter. Try running the code block below to experience a trial for yourself. The `run_trial` function takes an angle and a trial number as input and returns whether or not you were correct (1 for correct, 0 for incorrect), as well as the side which the target was actually on. "
@@ -182,6 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "5249bf61",
    "metadata": {},
    "outputs": [
     {
@@ -208,6 +215,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3c161824",
    "metadata": {},
    "source": [
     "## Starting the AEPsych Server and Client\n",
@@ -217,6 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "75f2a50f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,6 +238,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5169c6ce",
    "metadata": {},
    "source": [
     "Alternatively, you can also connect to a remote server by specifying a port and the IP address, as demonstrated below. The server could even be instantiated in a different Python process or on a different machine as the client."
@@ -251,6 +261,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3073bbd3",
    "metadata": {},
    "source": [
     "We tell the server what kind of experiment we are running by sending it a configure message (see the [configs folder](https://github.com/facebookresearch/aepsych/tree/main/configs) for some examples. The gist of the config here is that it is telling the server that our experiment will have one parameter called \"angle\", which will range from 0.1 to 5 degrees. (If you run this experiment on yourself and find that this range of angles makes the experiment too easy or too hard, you can adjust the `lb` and `ub` values in the string below). This experiment will last for 50 trials. The parameter values from the first 10 trials will be drawn from the [Sobol sequence](https://en.wikipedia.org/wiki/Sobol_sequence), to provide some initial data to initialize AEPsych's model; the following 40 trials will be drawn from that model. In this case, the model will be a classification [Gaussian Process](https://en.wikipedia.org/wiki/Gaussian_process) (GP). \n",
@@ -263,6 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "98986550",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,6 +308,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9bca8704",
    "metadata": {},
    "source": [
     "Now that we have set up our client and configured our server, we can start collecting data. The basic loop of the experiment is as follows:\n",
@@ -311,6 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "43f18c8f",
    "metadata": {},
    "outputs": [
     {
@@ -330,6 +344,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b1610666",
    "metadata": {},
    "source": [
     "We tell AEPsych about the parameter values we have tried by calling client.tell(). This method has two required arguments. The first, config, is a dictionary representing the set of parameter values you would like to tell AEPsych about, and takes the same format as the 'config' entry from client.ask(). The second argument is the binary outcome of a trial, indicated by 0 (the participant did not identify the target) or 1 (the participant did identify the target). This method also optionally takes other keyword arguments that will be stored as metadata in AEPsych's database. For our experiment, we will record which side the target was on."
@@ -338,6 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "de90214d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,6 +362,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "299830f9",
    "metadata": {},
    "source": [
     "The code below asks AEPsych for parameter values and runs trials until the experiment is completed:"
@@ -354,6 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "f841383d",
    "metadata": {},
    "outputs": [
     {
@@ -378,6 +396,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6db8d9cd",
    "metadata": {},
    "source": [
     "Note that even after the number of trials specified in the config have completed, you can still ask for more parameter values and conduct more trials:"
@@ -386,6 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "dc59de67",
    "metadata": {},
    "outputs": [
     {
@@ -405,6 +425,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "795369cf",
    "metadata": {},
    "source": [
     "You are also not restricted to only using the parameter values that AEPsych suggests. You can tell it the outcome of any parameter values that you would like:"
@@ -413,6 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "e0e90a6a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,6 +443,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1bd48358",
    "metadata": {},
    "source": [
     "Once you are done collecting data, you can close the server by calling `client.finalize()`"
@@ -429,6 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "5d78306a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,6 +461,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8a1bf82b",
    "metadata": {},
    "source": [
     "## Replaying the Experiment and Analyzing Data\n",
@@ -446,6 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
+   "id": "a89a5ff8",
    "metadata": {},
    "outputs": [
     {
@@ -462,6 +488,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4ce01537",
    "metadata": {},
    "source": [
     "The database is made of a set of experiments, which have unique experiment UUIDs. Every time the server is started (e.g. from the command line), a new experiment id is generated. For a list of all experiment ids:"
@@ -470,6 +497,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
+   "id": "05180cf2",
    "metadata": {},
    "outputs": [
     {
@@ -487,6 +515,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3d5757ad",
    "metadata": {},
    "source": [
     "The above indicates that there is only 1 experiment_id in this database.\n",
@@ -497,6 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
+   "id": "a05dbc90",
    "metadata": {},
    "outputs": [
     {
@@ -626,6 +656,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6d493637",
    "metadata": {},
    "source": [
     "The data has been loaded into the servers list of strategies, which we can access through `serv._strats`. Per our config string, we have two strategies, the first being the model-less initialization strategy, and the second being the model-based threshold-finding strategy. We can see the model-based strategy's data using its `x` and `y` properties:"
@@ -634,6 +665,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
+   "id": "e990cccc",
    "metadata": {},
    "outputs": [
     {
@@ -705,6 +737,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1ee0de8a",
    "metadata": {},
    "source": [
     "Since we passed `skip_computations = True` into the replay method before, we will have to manually refit the strategy's model:"
@@ -713,6 +746,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
+   "id": "5a38b499",
    "metadata": {},
    "outputs": [
     {
@@ -730,6 +764,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f00724cf",
    "metadata": {},
    "source": [
     "We can now plot the posterior of the fitted model:"
@@ -738,6 +773,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
+   "id": "18c786fd",
    "metadata": {},
    "outputs": [
     {
@@ -772,11 +808,9 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "445720f8fdcbba65d997174e9b6315f32a9c0fb7d8d99a631746a7b63e54ff16"
-  },
   "kernelspec": {
-   "display_name": "Python 3.9.7 64-bit",
+   "display_name": "aep",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -789,7 +823,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/examples/data_collection_analysis_tutorial.ipynb
+++ b/examples/data_collection_analysis_tutorial.ipynb
@@ -22,7 +22,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "ef0c3012",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +116,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce0cb286",
    "metadata": {},
    "source": [
     "On each trial of the experiment, the participant will first see a white box with fixation cross for 1 second. The box looks like this:"
@@ -126,7 +124,6 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a60a322a",
    "metadata": {},
    "outputs": [
     {
@@ -146,7 +143,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8363f0c",
    "metadata": {},
    "source": [
     "After 1 second, the fixation cross will disappear, and two gabor patches will appear side-by-side. One patch will be the foil with a vertical orientation, and one will be the target with an angled orientation. The position of the target and whether the angle is measured clockwise or counterclockwise is randomized each trial. An example foil and target are shown below:"
@@ -155,7 +151,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "61a205c5",
    "metadata": {},
    "outputs": [
     {
@@ -179,7 +174,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d125887f",
    "metadata": {},
    "source": [
     "After 0.5 seconds, the patches will disappear, and the participant will be prompted to report which one was the target by typing \"F\" for left or \"J\" for right, and then hitting enter. Try running the code block below to experience a trial for yourself. The `run_trial` function takes an angle and a trial number as input and returns whether or not you were correct (1 for correct, 0 for incorrect), as well as the side which the target was actually on. "
@@ -188,7 +182,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "5249bf61",
    "metadata": {},
    "outputs": [
     {
@@ -215,7 +208,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c161824",
    "metadata": {},
    "source": [
     "## Starting the AEPsych Server and Client\n",
@@ -225,7 +217,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75f2a50f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +229,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5169c6ce",
    "metadata": {},
    "source": [
     "Alternatively, you can also connect to a remote server by specifying a port and the IP address, as demonstrated below. The server could even be instantiated in a different Python process or on a different machine as the client."
@@ -261,7 +251,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3073bbd3",
    "metadata": {},
    "source": [
     "We tell the server what kind of experiment we are running by sending it a configure message (see the [configs folder](https://github.com/facebookresearch/aepsych/tree/main/configs) for some examples. The gist of the config here is that it is telling the server that our experiment will have one parameter called \"angle\", which will range from 0.1 to 5 degrees. (If you run this experiment on yourself and find that this range of angles makes the experiment too easy or too hard, you can adjust the `lb` and `ub` values in the string below). This experiment will last for 50 trials. The parameter values from the first 10 trials will be drawn from the [Sobol sequence](https://en.wikipedia.org/wiki/Sobol_sequence), to provide some initial data to initialize AEPsych's model; the following 40 trials will be drawn from that model. In this case, the model will be a classification [Gaussian Process](https://en.wikipedia.org/wiki/Gaussian_process) (GP). \n",
@@ -274,7 +263,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "98986550",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +296,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bca8704",
    "metadata": {},
    "source": [
     "Now that we have set up our client and configured our server, we can start collecting data. The basic loop of the experiment is as follows:\n",
@@ -324,7 +311,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "43f18c8f",
    "metadata": {},
    "outputs": [
     {
@@ -344,7 +330,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1610666",
    "metadata": {},
    "source": [
     "We tell AEPsych about the parameter values we have tried by calling client.tell(). This method has two required arguments. The first, config, is a dictionary representing the set of parameter values you would like to tell AEPsych about, and takes the same format as the 'config' entry from client.ask(). The second argument is the binary outcome of a trial, indicated by 0 (the participant did not identify the target) or 1 (the participant did identify the target). This method also optionally takes other keyword arguments that will be stored as metadata in AEPsych's database. For our experiment, we will record which side the target was on."
@@ -353,7 +338,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "de90214d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,7 +346,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "299830f9",
    "metadata": {},
    "source": [
     "The code below asks AEPsych for parameter values and runs trials until the experiment is completed:"
@@ -371,7 +354,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "f841383d",
    "metadata": {},
    "outputs": [
     {
@@ -396,7 +378,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6db8d9cd",
    "metadata": {},
    "source": [
     "Note that even after the number of trials specified in the config have completed, you can still ask for more parameter values and conduct more trials:"
@@ -405,7 +386,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "dc59de67",
    "metadata": {},
    "outputs": [
     {
@@ -425,7 +405,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "795369cf",
    "metadata": {},
    "source": [
     "You are also not restricted to only using the parameter values that AEPsych suggests. You can tell it the outcome of any parameter values that you would like:"
@@ -434,7 +413,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "e0e90a6a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,7 +421,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1bd48358",
    "metadata": {},
    "source": [
     "Once you are done collecting data, you can close the server by calling `client.finalize()`"
@@ -452,7 +429,6 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "5d78306a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +437,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8a1bf82b",
    "metadata": {},
    "source": [
     "## Replaying the Experiment and Analyzing Data\n",
@@ -471,7 +446,6 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "a89a5ff8",
    "metadata": {},
    "outputs": [
     {
@@ -488,7 +462,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4ce01537",
    "metadata": {},
    "source": [
     "The database is made of a set of experiments, which have unique experiment UUIDs. Every time the server is started (e.g. from the command line), a new experiment id is generated. For a list of all experiment ids:"
@@ -497,7 +470,6 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "05180cf2",
    "metadata": {},
    "outputs": [
     {
@@ -515,7 +487,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3d5757ad",
    "metadata": {},
    "source": [
     "The above indicates that there is only 1 experiment_id in this database.\n",
@@ -526,7 +497,6 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "a05dbc90",
    "metadata": {},
    "outputs": [
     {
@@ -656,7 +626,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d493637",
    "metadata": {},
    "source": [
     "The data has been loaded into the servers list of strategies, which we can access through `serv._strats`. Per our config string, we have two strategies, the first being the model-less initialization strategy, and the second being the model-based threshold-finding strategy. We can see the model-based strategy's data using its `x` and `y` properties:"
@@ -665,7 +634,6 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "e990cccc",
    "metadata": {},
    "outputs": [
     {
@@ -737,7 +705,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ee0de8a",
    "metadata": {},
    "source": [
     "Since we passed `skip_computations = True` into the replay method before, we will have to manually refit the strategy's model:"
@@ -746,7 +713,6 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "5a38b499",
    "metadata": {},
    "outputs": [
     {
@@ -764,7 +730,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f00724cf",
    "metadata": {},
    "source": [
     "We can now plot the posterior of the fitted model:"
@@ -773,7 +738,6 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "18c786fd",
    "metadata": {},
    "outputs": [
     {
@@ -808,11 +772,13 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "aep",
-   "language": "python",
-   "name": "python3"
-  },
+    "interpreter": {
+     "hash": "445720f8fdcbba65d997174e9b6315f32a9c0fb7d8d99a631746a7b63e54ff16"
+    },
+    "kernelspec": {
+     "display_name": "Python 3.9.7 64-bit",
+     "name": "python3"
+    },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -823,7 +789,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### PR Description:
This pull request fixes issue #372, which involves the use of the deprecated `ax.grid(b=None)` in the AEPsych tutorial. As per the [Matplotlib 3.9.0 API updates](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.9.0.html), the `b=None` argument has been removed, causing a `ValueError` in recent versions (3.9.0 and above).

To address this, the `b=None` argument has been removed from two lines in the notebook, ensuring compatibility with Matplotlib 3.9.2 and higher.

The database-related error has already been resolved in PR #295, so no further changes are necessary regarding that.

This PR resolves the compatibility issue and ensures the tutorial runs correctly with the latest version of Matplotlib.