### PR TITLE
implement parameter transforms as generator/model wrappers

### DIFF
--- a/aepsych/__init__.py
+++ b/aepsych/__init__.py
@@ -11,7 +11,16 @@ import torch
 
 from gpytorch.likelihoods import BernoulliLikelihood, GaussianLikelihood
 
-from . import acquisition, config, factory, generators, models, strategy, utils
+from . import (
+    acquisition,
+    config,
+    factory,
+    generators,
+    models,
+    strategy,
+    transforms,
+    utils,
+)
 from .config import Config
 from .likelihoods import BernoulliObjectiveLikelihood
 from .models import GPClassificationModel
@@ -26,6 +35,7 @@ __all__ = [
     "factory",
     "models",
     "strategy",
+    "transforms",
     "utils",
     "generators",
     # classes

--- a/aepsych/benchmark/benchmark.py
+++ b/aepsych/benchmark/benchmark.py
@@ -77,6 +77,7 @@ class Benchmark:
             List[dict[str, float]]: List of dictionaries, each of which can be passed
                 to aepsych.config.Config.
         """
+
         # This could be a generator but then we couldn't
         # know how many params we have, tqdm wouldn't work, etc,
         # so we materialize the full list.
@@ -154,6 +155,9 @@ class Benchmark:
         np.random.seed(seed)
         config_dict["common"]["lb"] = str(problem.lb.tolist())
         config_dict["common"]["ub"] = str(problem.ub.tolist())
+        config_dict["common"]["parnames"] = str(
+            [f"par{i}" for i in range(len(problem.ub.tolist()))]
+        )
         config_dict["problem"] = problem.metadata
         materialized_config = self.materialize_config(config_dict)
 

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -23,7 +23,6 @@ from typing import (
     Sequence,
     TypeVar,
 )
-
 import botorch
 import gpytorch
 import numpy as np

--- a/aepsych/config.pyi
+++ b/aepsych/config.pyi
@@ -7,10 +7,24 @@
 
 import abc
 import configparser
-from typing import Any, ClassVar, Dict, List, Mapping, Optional, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    TypeVar,
+    Union,
+)
 
 import numpy as np
 import torch
+from botorch.models.transforms.input import (
+    ChainedInputTransform,
+    ReversibleInputTransform,
+)
 
 _T = TypeVar("_T")
 _ET = TypeVar("_ET")
@@ -50,7 +64,7 @@ class Config(configparser.ConfigParser):
         raw: bool = ...,
         vars: Optional[Mapping[str, str]] = ...,
         fallback: _T = ...,
-        element_type: _ET = ...,
+        element_type: Callable[[_ET], _ET] = ...,
     ) -> Union[_T, List[_ET]]: ...
     def getarray(
         self,
@@ -61,10 +75,29 @@ class Config(configparser.ConfigParser):
         vars: Optional[Mapping[str, str]] = ...,
         fallback: _T = ...,
     ) -> Union[np.ndarray, _T]: ...
+    def getboolean(
+        self,
+        section: str,
+        option: str,
+        *,
+        raw: bool = ...,
+        vars: Mapping[str, str] | None = ...,
+        fallback: _T = ...,
+    ) -> bool | _T: ...
+    def getfloat(
+        self,
+        section: str,
+        option: str,
+        *,
+        raw: bool = ...,
+        vars: Mapping[str, str] | None = ...,
+        fallback: _T = ...,
+    ) -> float | _T: ...
     @classmethod
     def register_module(cls: _T, module): ...
     def jsonifyMetadata(self) -> str: ...
     def jsonifyAll(self) -> str: ...
+    def to_dict(self, deduplicate: bool = ...) -> Dict[str, Any]: ...
 
 class ConfigurableMixin(abc.ABC):
     @classmethod
@@ -76,8 +109,8 @@ class ConfigurableMixin(abc.ABC):
     ) -> Dict[str, Any]: ...
     @classmethod
     def from_config(
-        cls,
+        cls: type[_T],
         config: Config,
         name: Optional[str] = None,
         options: Optional[Dict[str, Any]] = None,
-    ): ...
+    ) -> _T: ...

--- a/aepsych/config.pyi
+++ b/aepsych/config.pyi
@@ -68,6 +68,16 @@ class Config(configparser.ConfigParser):
 
 class ConfigurableMixin(abc.ABC):
     @classmethod
-    def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]: ...
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]: ...
     @classmethod
-    def from_config(cls, config: Config, name: Optional[str] = None): ...
+    def from_config(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ): ...

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -4,19 +4,19 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 import abc
-from inspect import signature
-from typing import Any, Dict, Generic, Protocol, runtime_checkable, TypeVar, Optional
 import re
+from inspect import signature
+from typing import Any, Dict, Generic, Optional, Protocol, runtime_checkable, TypeVar
 
 import torch
 from aepsych.config import Config
 from aepsych.models.base import AEPsychMixin
 from botorch.acquisition import (
     AcquisitionFunction,
-    NoisyExpectedImprovement,
-    qNoisyExpectedImprovement,
     LogNoisyExpectedImprovement,
+    NoisyExpectedImprovement,
     qLogNoisyExpectedImprovement,
+    qNoisyExpectedImprovement,
 )
 
 
@@ -43,6 +43,9 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
     stimuli_per_trial = 1
     max_asks: Optional[int] = None
 
+    acqf: AcquisitionFunction
+    acqf_kwargs: Dict[str, Any]
+
     def __init__(
         self,
     ) -> None:
@@ -58,7 +61,9 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
         pass
 
     @classmethod
-    def _get_acqf_options(cls, acqf: AcquisitionFunction, config: Config) -> Dict[str, Any]:
+    def _get_acqf_options(
+        cls, acqf: AcquisitionFunction, config: Config
+    ) -> Dict[str, Any]:
         if acqf is not None:
             acqf_name = acqf.__name__
 
@@ -81,7 +86,7 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
                         elif re.search(
                             r"^\[.*\]$", v, flags=re.DOTALL
                         ):  # use regex to check if the value is a list
-                            extra_acqf_args[k] = config._str_to_list(v) # type: ignore
+                            extra_acqf_args[k] = config._str_to_list(v)  # type: ignore
                         else:
                             # otherwise try a float
                             try:

--- a/aepsych/generators/manual_generator.py
+++ b/aepsych/generators/manual_generator.py
@@ -10,12 +10,12 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 import torch
-from torch.quasirandom import SobolEngine
 
 from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator
 from aepsych.models.base import AEPsychMixin
 from aepsych.utils import _process_bounds
+from torch.quasirandom import SobolEngine
 
 
 class ManualGenerator(AEPsychGenerator):
@@ -70,7 +70,9 @@ class ManualGenerator(AEPsychGenerator):
         return points
 
     @classmethod
-    def from_config(cls, config: Config, name: Optional[str] = None) -> 'ManualGenerator':
+    def from_config(
+        cls, config: Config, name: Optional[str] = None
+    ) -> "ManualGenerator":
         return cls(**cls.get_config_options(config, name))
 
     @classmethod

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -55,23 +55,17 @@ class SobolGenerator(AEPsychGenerator):
         Args:
             num_points (int, optional): Number of points to query.
         Returns:
-            torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
+            torch.Tensor: Next set of point(s) to evaluate, [num_points x dim] or [num_points x dim x stimuli_per_trial] if stimuli_per_trial != 1.
         """
         grid = self.engine.draw(num_points)
         grid = self.lb + (self.ub - self.lb) * grid
         if self.stimuli_per_trial == 1:
             return grid
 
-        return torch.tensor(
-            np.moveaxis(
-                grid.reshape(num_points, self.stimuli_per_trial, -1).numpy(),
-                -1,
-                -self.stimuli_per_trial,
-            )
-        )
+        return grid.reshape(num_points, self.stimuli_per_trial, -1).swapaxes(-1, -2)
 
     @classmethod
-    def from_config(cls, config: Config) -> 'SobolGenerator':
+    def from_config(cls, config: Config) -> "SobolGenerator":
         classname = cls.__name__
 
         lb = config.gettensor(classname, "lb")

--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -69,7 +69,7 @@ class ModelProtocol(Protocol):
     def device(self) -> torch.device:
         pass
 
-    def posterior(self, x: torch.Tensor) -> GPyTorchPosterior:
+    def posterior(self, X: torch.Tensor) -> GPyTorchPosterior:
         pass
 
     def predict(self, x: torch.Tensor, **kwargs) -> torch.Tensor:
@@ -108,7 +108,9 @@ class ModelProtocol(Protocol):
     ) -> None:
         pass
 
-    def p_below_threshold(self, x, f_thresh) -> torch.Tensor:
+    def p_below_threshold(
+        self, x: torch.Tensor, f_thresh: torch.Tensor
+    ) -> torch.Tensor:
         pass
 
 

--- a/aepsych/transforms/__init__.py
+++ b/aepsych/transforms/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .parameters import (
+    ParameterTransformedGenerator,
+    ParameterTransformedModel,
+    ParameterTransforms,
+    transform_options,
+)
+
+__all__ = [
+    "ParameterTransformedGenerator",
+    "ParameterTransformedModel",
+    "ParameterTransforms",
+    "transform_options",
+]

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -1,0 +1,874 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+import ast
+import warnings
+from abc import ABC
+from configparser import NoOptionError
+from copy import deepcopy
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union
+
+import numpy as np
+import torch
+from aepsych.config import Config, ConfigurableMixin
+from aepsych.generators.base import AEPsychGenerator
+from aepsych.models.base import AEPsychMixin, ModelProtocol
+from botorch.acquisition import AcquisitionFunction
+from botorch.models.transforms.input import ChainedInputTransform, Log10
+from botorch.models.transforms.utils import subset_transform
+from botorch.posteriors import Posterior
+from torch import Tensor
+
+_TRANSFORMABLE = [
+    "lb",
+    "ub",
+    "points",
+    "window",
+]
+
+
+class ParameterTransforms(ChainedInputTransform, ConfigurableMixin):
+    """
+    Holds set of transformations to be applied to parameters. The ParameterTransform
+    objects can be used by themselves to transform values or can be passed to Generator
+    or Model wrappers to consistently transform parameters. ParameterTransforms can
+    transform values into transformed space and also untransform values from transformed
+    space back into raw space.
+    """
+
+    def _temporary_reshape(func: Callable) -> Callable:
+        # Decorator to reshape tensors to the expected 2D shape, even if the input was
+        # 1D or 3D and after the transform reshape it back to the original.
+        def wrapper(self, X: Tensor) -> Tensor:
+            squeeze = False
+            if len(X.shape) == 1:  # For 1D inputs, primarily for transforming arguments
+                X = X.unsqueeze(0)
+                squeeze = True
+
+            reshape = False
+            if len(X.shape) > 2:  # For multi stimuli experiments
+                batch, dim, stim = X.shape
+                X = X.swapaxes(-2, -1).reshape(-1, dim)
+                reshape = True
+
+            X = func(self, X)
+
+            if reshape:
+                X = X.reshape(batch, stim, -1).swapaxes(-1, -2)
+
+            if squeeze:  # Not actually squeeze since we still want one dim
+                X = X[0]
+
+            return X
+
+        return wrapper
+
+    @_temporary_reshape
+    def transform(self, X: Tensor) -> Tensor:
+        r"""Transform the inputs to a model.
+
+        Individual transforms are applied in sequence.
+
+        Args:
+            X: A tensor of inputs. Either `[dim]`, `[batch, dim]`, or `[batch, dim, stimuli]`.
+
+        Returns:
+            A tensor of transformed inputs with the same shape as the input.
+        """
+        return super().transform(X)
+
+    @_temporary_reshape
+    def untransform(self, X: Tensor) -> Tensor:
+        r"""Un-transform the inputs to a model.
+
+        Un-transforms of the individual transforms are applied in reverse sequence.
+
+        Args:
+            X: A tensor of inputs. Either `[dim]`, `[batch, dim]`, or `[batch, dim, stimuli]`.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of un-transformed inputs.
+        """
+        return super().untransform(X)
+
+    @classmethod
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Return a dictionary of transforms in the order that they should be in, this
+        dictionary can be used to initialize a ParameterTransforms.
+
+        Args:
+            config (Config): Config to look for options in.
+            name (str, optional): Name is ignored as transforms for all parameters will
+                be made. Maintained for API conformity.
+            options (Dict[str, Any], optional): options is ignored as all transforms
+                will be reinitialized to ensure it is in the right order. To create
+                transforms in an arbitrary order, initialize from the __init__.
+
+
+        Return:
+            Dict[str, Any]: A dictionary of transforms to initialize this class.
+        """
+        if options is not None:
+            warnings.warn(
+                "options argument is set but we will ignore it to create an entirely new options dictionary to ensure transforms are applied in the right order."
+            )
+
+        transform_options = {}
+        transform_options["bounds"] = get_bounds(config)
+
+        parnames = config.getlist("common", "parnames", element_type=str)
+
+        # This is the "options" dictionary, transform options is only for maintaining the right transforms
+        transform_dict = {}
+        for par in parnames:
+            # This is the order that transforms are potentially applied, order matters
+
+            # Log scale
+            if config.getboolean(par, "log_scale", fallback=False):
+                transform_dict[f"{par}_Log10Plus"] = Log10Plus.from_config(
+                    config=config, name=par, options=transform_options
+                )
+
+        return transform_dict
+
+
+class ParameterTransformWrapper(ABC):
+    """
+    Abstract base class for parameter transform wrappers. __getattr__ is overridden to
+    allow base object attributes to be surfaced smoothly. Methods that require the
+    transforms should be overridden in the wrapper class to apply the transform
+    operations.
+    """
+
+    transforms: ChainedInputTransform
+    _base_obj: object = None
+
+    def __getattr__(self, name):
+        return getattr(self._base_obj, name)
+
+
+class ParameterTransformedGenerator(ParameterTransformWrapper, ConfigurableMixin):
+    """
+    Wraps a generator such that parameter inputs are transformed and generated
+    parameters are untransformed back to the raw parameter space.
+    """
+
+    _base_obj: AEPsychGenerator
+
+    def __init__(
+        self,
+        generator: Type | AEPsychGenerator,
+        transforms: ChainedInputTransform = ChainedInputTransform(**{}),
+        **kwargs: Any,
+    ) -> None:
+        r"""Wraps a Generator with parameter transforms. This will transform any relevant
+        generator arguments (e.g., bounds) to be transformed into the transformed space
+        and ensure all generator outputs to be untransformed into raw space. The wrapper
+        surfaces critical components of the API of the generator such that the wrapper
+        can be used much like the raw generator.
+
+        Bounds are returned in the transformed space, this is necessary to handle
+        parameters that would not have sensible raw parameter space. If bounds are
+        manually set (e.g., `Wrapper(**kwargs).lb = lb)`, ensure that they are
+        correctly transformed and in a correctly shaped Tensor. If the bounds are
+        being set in init (e.g., `Wrapper(Type, lb=lb, ub=ub)`, `lb` and `ub`
+        should be in the raw parameter space.
+
+        Args:
+            model (Type | AEPsychGenerator): Generator to wrap, this could either be a
+                completely initialized generator or just the generator class. An
+                initialized generator is expected to have been initialized in the
+                transformed parameter space (i.e., bounds are transformed). If a
+                generator class is passed, **kwargs will be used to initialize the
+                generator, note that the bounds are expected to be in raw parameter
+                space, thus the transforms are applied to it.
+            transforms (ChainedInputTransform, optional): A set of transforms to apply
+                to parameters of this generator. If no transforms are passed, it will
+                default to an identity transform.
+            **kwargs: Keyword arguments to pass to the model to initialize it if model
+                is a class.
+        """
+        # Figure out what we need to do with generator
+        if isinstance(generator, type):
+            if "lb" in kwargs:
+                kwargs["lb"] = transforms.transform(kwargs["lb"].float())
+            if "ub" in kwargs:
+                kwargs["ub"] = transforms.transform(kwargs["ub"].float())
+            _base_obj = generator(**kwargs)
+        else:
+            _base_obj = generator
+
+        self._base_obj = _base_obj
+        self.transforms = transforms
+
+        # This lets us emit we're the class we're wrapping
+        self.__class__ = type(
+            f"ParameterTransformed{_base_obj.__class__.__name__}",
+            (self.__class__, _base_obj.__class__),
+            {},
+        )
+
+        # Copy all of the class attributes with defaults from _base_obj
+        # and don't just let it use AEPsychGenerator defaults
+        self._requires_model = self._base_obj._requires_model
+        self.stimuli_per_trial = self._base_obj.stimuli_per_trial
+        self.max_asks = self._base_obj.max_asks
+
+    def gen(self, num_points: int = 1, model: Optional[AEPsychMixin] = None) -> Tensor:
+        r"""Query next point(s) to run from the generator and return them untransformed.
+
+        Args:
+            num_points (int, optional): Number of points to query, defaults to 1.
+            model (AEPsychMixin, optional): The model to use to generate points, can be
+                None if no model is needed.
+        Returns:
+            torch.Tensor: Next set of point(s) to evaluate, `[num_points x dim]` or
+            `[num_points x dim x stimuli_per_trial]` if `self.stimuli_per_trial != 1`,
+            which will be untransformed.
+        """
+        x = self._base_obj.gen(num_points, model)
+        return self.transforms.untransform(x)
+
+    def _get_acqf_options(self, acqf: AcquisitionFunction, config: Config):
+        return self._base_obj._get_acqf_options(acqf, config)
+
+    @property
+    def acqf(self) -> AcquisitionFunction | None:
+        return self._base_obj.acqf
+
+    @acqf.setter
+    def acqf(self, value: AcquisitionFunction):
+        self._base_obj.acqf = value
+
+    @property
+    def acqf_kwargs(self) -> dict | None:
+        return self._base_obj.acqf_kwargs
+
+    @acqf_kwargs.setter
+    def acqf_kwargs(self, value: dict):
+        self._base_obj.acqf_kwargs = value
+
+    @classmethod
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return a dictionary of the relevant options to initialize a generator wrapped
+        with a parameter transform.
+
+        Args:
+            config (Config): Config to look for options in.
+            name (str): Strategy to look for the Generator and find options for.
+            options (Dict[str, Any]): Options to override from the config.
+
+        Returns:
+            Dict[str, Any]: A diciontary of options to initialize this class with.
+        """
+        if options is None:
+            options = {}
+        else:
+            options = deepcopy(options)
+
+        if name is None:
+            raise ValueError("name of strategy must be set to initialize a generator")
+        else:
+            gen_cls = config.getobj(name, "generator")
+
+        if "transforms" not in options:
+            options["transforms"] = ParameterTransforms.from_config(config)
+
+        # Transform config
+        transformed_config = transform_options(config, options["transforms"])
+
+        options["generator"] = gen_cls.from_config(transformed_config)
+
+        return options
+
+
+class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
+    """
+    Wraps a model such that it can work entirely in transformed space by transforming
+    all parameter inputs (e.g., training data) to the model. This wrapper also
+    untransforms any outputs from the model back to raw parameter space.
+    """
+
+    _base_obj: ModelProtocol
+
+    def __init__(
+        self,
+        model: Type | ModelProtocol,
+        transforms: ChainedInputTransform = ChainedInputTransform(**{}),
+        **kwargs: Any,
+    ) -> None:
+        f"""Wraps a Model with parameter transforms. This will transform any relevant
+        model arguments (e.g., bounds) and model data (e.g., training data, x) to be
+        transformed into the transformed space. The wrapper surfaces the API of the
+        raw model such that the wrapper can be used like a raw model.
+
+        Bounds are returned in the transformed space, this is necessary to handle
+        parameters that would not have sensible raw parameter space. If bounds are
+        manually set (e.g., `Wrapper(**kwargs).lb = lb)`, ensure that they are
+        correctly transformed and in a correctly shaped Tensor. If the bounds are
+        being set in init (e.g., `Wrapper(Type, lb=lb, ub=ub)`, `lb` and `ub`
+        should be in the raw parameter space.
+
+        Args:
+            model (Type | ModelProtocol): Model to wrap, this could either be a
+                completely initialized model or just the model class. An initialized
+                model is expected to have been initialized in the transformed
+                parameter space (i.e., bounds are transformed). If a model class is
+                passed, **kwargs will be used to initialize the model. Note that the
+                bounds in this case are expected to be in raw parameter space, thus the
+                transforms are applied to it.
+            transforms (ChainedInputTransform, optional): A set of transforms to apply
+                to parameters of this model. If no transforms are passed, it will
+                default to an identity transform.
+            **kwargs: Keyword arguments to be passed to the model if the model is a
+                class.
+        """
+        # Alternative instantiation method for analysis (and not live)
+        if isinstance(model, type):
+            if "lb" in kwargs:
+                kwargs["lb"] = transforms.transform(kwargs["lb"].float())
+            if "ub" in kwargs:
+                kwargs["ub"] = transforms.transform(kwargs["ub"].float())
+            _base_obj = model(**kwargs)
+        else:
+            _base_obj = model
+
+        self._base_obj = _base_obj
+        self.transforms = transforms
+
+        # This lets us emit we're the class we're wrapping
+        self.__class__ = type(
+            f"ParameterTransformed{_base_obj.__class__.__name__}",
+            (self.__class__, _base_obj.__class__),
+            {},
+        )
+
+    @staticmethod
+    def _promote_1d(func: Callable) -> Callable:
+        # Decorator to reshape model Xs into 2d if they're 1d. Assumes that the Tensor
+        # is the first argument
+        def wrapper(self, *args, **kwargs) -> Tensor:
+            if len(args) > 0 and isinstance(args[0], torch.Tensor):
+                x = args[0]
+                if len(x.shape) == 1:
+                    x = x.unsqueeze(-1)
+                return func(self, x, *args[1:], **kwargs)
+
+            else:
+                key, value = list(kwargs.items())[0]
+                if isinstance(value, torch.Tensor) and len(value.shape) == 1:
+                    kwargs[key] = value.unsqueeze(-1)
+
+                return func(self, **kwargs)
+
+        return wrapper
+
+    @_promote_1d
+    def predict(self, x: Tensor, **kwargs: Any) -> Tensor | Tuple[Tensor]:
+        """Query the model on its posterior given transformed x.
+
+        Args:
+            x (torch.Tensor): Points at which to predict from the model, which will
+                be transformed.
+            **kwargs: Keyword arguments to pass to the model.predict() call.
+
+        Returns:
+            Tensor | Tuple[Tensor]: At least one Tensor will be returned.
+        """
+        x = self.transforms.transform(x)
+        return self._base_obj.predict(x, **kwargs)
+
+    @_promote_1d
+    def predict_probability(self, x: Tensor, **kwargs: Any) -> Tensor:
+        """Query the model on its posterior given transformed x and return units in
+        response probability space.
+
+        Args:
+            x (torch.Tensor): Points at which to predict from the model, which will be
+                transformed.
+            **kwargs: Keyword arguments to pass to the model.predict() call.
+
+        Returns:
+            Tensor | Tuple[Tensor]: At least one Tensor will be returned.
+        """
+        x = self.transforms.transform(x)
+        return self._base_obj.predict_probability(x, **kwargs)
+
+    @_promote_1d
+    def sample(self, x: Tensor, num_samples: int) -> Tensor:
+        """Sample from underlying model given transformed x.
+
+        Args:
+            x (torch.Tensor): Points at which to sample, which will be transformed.
+            num_samples (int): Number of samples to return.
+
+        Returns:
+            torch.Tensor: Posterior samples [num_samples x dim]
+        """
+        x = self.transforms.transform(x)
+        return self._base_obj.sample(x, num_samples)
+
+    def posterior(self, X: Tensor, **kwargs: Any) -> Posterior:
+        """Return the model's posterior given a transformed X. Notice that this specific
+        method requires transformed inputs.
+
+        Args:
+            X (torch.Tensor): The points to evaluate, which will be transformed.
+            **kwargs: The keyword arguments to pass to the underlying model's posterior
+                method.
+
+        Returns:
+            Posterior: The posterior of the model.
+        """
+        # This ensures X is a tensor with the right shape and dtype (this seemingly
+        # does nothing, but it somehow solves test errors).
+        X = Tensor(X)
+        return self._base_obj.posterior(X=X, **kwargs)
+
+    def dim_grid(self, gridsize: int = 30) -> Tensor:
+        """Returns an untransformed grid based on the model's bounds and dimensionality.
+
+        Args:
+            gridsize (int, optional): How many points to form the grid with, defaults to
+            30.
+
+        Returns:
+            Tensor: A grid based on the model's bounds and dimensionality with the
+                number of points requested, which will be untransformed.
+        """
+        grid = self._base_obj.dim_grid(gridsize)
+        return self.transforms.untransform(grid)
+
+    @_promote_1d
+    def fit(self, train_x: Tensor, train_y: Tensor, **kwargs: Any) -> None:
+        """Fit underlying model.
+
+        Args:
+            train_x (torch.Tensor): Inputs to fit on.
+            train_y (torch.LongTensor): Responses to fit on.
+            warmstart_hyperparams (bool): Whether to reuse the previous hyperparameters
+                (True) or fit from scratch (False). Defaults to False.
+            warmstart_induc (bool): Whether to reuse the previous inducing points or fit
+                from scratch (False). Defaults to False.
+            **kwargs: Keyword arguments to pass to the underlying model's fit method.
+        """
+        train_x = self.transforms.transform(train_x)
+        self._base_obj.fit(train_x, train_y, **kwargs)
+
+    @_promote_1d
+    def update(self, train_x: Tensor, train_y: Tensor, **kwargs: Any) -> None:
+        """Perform a warm-start update of the model from previous fit.
+
+        Args:
+            train_x (torch.Tensor): Inputs to fit on.
+            train_y (torch.LongTensor): Responses to fit on.
+            **kwargs: Keyword arguments to pass to the underlying model's fit method.
+        """
+        train_x = self.transforms.transform(train_x)
+        self._base_obj.update(train_x, train_y, **kwargs)
+
+    def get_max(
+        self,
+        locked_dims: Optional[Mapping[int, List[float]]] = None,
+        probability_space: bool = False,
+        n_samples: int = 1000,
+        max_time: Optional[float] = None,
+    ) -> Tuple[float, torch.Tensor]:
+        """Return the maximum of the modeled function, subject to constraints
+
+        Args:
+            locked_dims (Mapping[int, List[float]], optional): Dimensions to fix, so that the
+                inverse is along a slice of the full surface. Defaults to None.
+            probability_space (bool): Is y (and therefore the returned nearest_y) in
+                probability space instead of latent function space? Defaults to False.
+            n_samples (int): number of coarse grid points to sample for optimization estimate.
+            max_time (float, optional): Maximum time to spend optimizing. Defaults to None.
+
+        Returns:
+            Tuple[float, torch.Tensor]: Tuple containing the max and its untransformed
+                location (argmax).
+        """
+        max_, loc = self._base_obj.get_max(  # type: ignore
+            locked_dims=locked_dims,
+            probability_space=probability_space,
+            n_samples=n_samples,
+            max_time=max_time,
+        )
+        loc = self.transforms.untransform(loc)
+
+        return max_, loc
+
+    def get_min(
+        self,
+        locked_dims: Optional[Mapping[int, List[float]]] = None,
+        probability_space: bool = False,
+        n_samples: int = 1000,
+        max_time: Optional[float] = None,
+    ) -> Tuple[float, torch.Tensor]:
+        """Return the minimum of the modeled function, subject to constraints
+
+        Args:
+            locked_dims (Mapping[int, List[float]], optional): Dimensions to fix, so that the
+                inverse is along a slice of the full surface.
+            probability_space (bool): Is y (and therefore the returned nearest_y) in
+                probability space instead of latent function space? Defaults to False.
+            n_samples (int): number of coarse grid points to sample for optimization estimate.
+            max_time (float, optional): Maximum time to spend optimizing. Defaults to None.
+
+        Returns:
+            Tuple[float, torch.Tensor]: Tuple containing the min and its untransformed location (argmin).
+        """
+        min_, loc = self._base_obj.get_min(  # type: ignore
+            locked_dims=locked_dims,
+            probability_space=probability_space,
+            n_samples=n_samples,
+            max_time=max_time,
+        )
+        loc = self.transforms.untransform(loc)
+
+        return min_, loc
+
+    def inv_query(
+        self,
+        y: float,
+        locked_dims: Optional[Mapping[int, List[float]]] = None,
+        probability_space: bool = False,
+        n_samples: int = 1000,
+        max_time: Optional[float] = None,
+        weights: Optional[torch.Tensor] = None,
+    ) -> Tuple[float, torch.Tensor]:
+        """Query the model inverse.
+
+        Return nearest untransformed x such that f(x) = queried y, and also return the
+            value of f at that point.
+
+        Args:
+            y (float): Points at which to find the inverse.
+            locked_dims (Mapping[int, List[float]], optional): Dimensions to fix, so that the
+                inverse is along a slice of the full surface.
+            probability_space (bool): Is y (and therefore the returned nearest_y) in
+                probability space instead of latent function space? Defaults to False.
+            n_samples (int): number of coarse grid points to sample for optimization estimate. Defaults to 1000.
+            max_time (float, optional): Maximum time to spend optimizing. Defaults to None.
+            weights (torch.Tensor, optional): Weights for the optimization. Defaults to None.
+
+        Returns:
+            Tuple[float, torch.Tensor]: Tuple containing the value of f
+                nearest to queried y and the untransformed x position of this value.
+        """
+        val, loc = self._base_obj.inv_query(  # type: ignore
+            y=y,
+            locked_dims=locked_dims,
+            probability_space=probability_space,
+            n_samples=n_samples,
+            max_time=max_time,
+            weights=weights,
+        )
+
+        loc = self.transforms.untransform(loc)
+        return val, loc
+
+    def get_jnd(
+        self,
+        grid: Optional[Union[np.ndarray, torch.Tensor]] = None,
+        cred_level: Optional[float] = None,
+        intensity_dim: int = -1,
+        confsamps: int = 500,
+        method: str = "step",
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+        """Calculate the JND.
+
+        Note that JND can have multiple plausible definitions
+        outside of the linear case, so we provide options for how to compute it.
+        For method="step", we report how far one needs to go over in stimulus
+        space to move 1 unit up in latent space (this is a lot of people's
+        conventional understanding of the JND).
+        For method="taylor", we report the local derivative, which also maps to a
+        1st-order Taylor expansion of the latent function. This is a formal
+        generalization of JND as defined in Weber's law.
+        Both definitions are equivalent for linear psychometric functions.
+
+        Args:
+            grid (torch.Tensor, optional): Untransformed mesh grid over which to find the JND.
+                Defaults to a square grid of size as determined by aepsych.utils.dim_grid.
+            cred_level (float, optional): Credible level for computing an interval.
+                Defaults to None, computing no interval.
+            intensity_dim (int): Dimension over which to compute the JND.
+                Defaults to -1.
+            confsamps (int): Number of posterior samples to use for
+                computing the credible interval. Defaults to 500.
+            method (str): "taylor" or "step" method (see docstring).
+                Defaults to "step".
+
+        Returns:
+            Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]: either the
+                mean JND, or a median, lower, upper tuple of the JND posterior. All values
+                are in the untransformed space.
+        """
+        jnds = self._base_obj.get_jnd(  # type: ignore
+            grid=grid,
+            cred_level=cred_level,
+            intensity_dim=intensity_dim,
+            confsamps=confsamps,
+            method=method,
+        )
+
+        if isinstance(jnds, torch.Tensor):
+            jnds = self.transforms.untransform(jnds)
+        else:
+            jnds = [self.transforms.untransform(jnd) for jnd in jnds]
+            jnds = tuple(jnds)
+
+        return jnds
+
+    def p_below_threshold(self, x: Tensor, f_thresh: torch.Tensor) -> torch.Tensor:
+        """Compute the probability that the latent function is below a threshold.
+
+        Args:
+            x (torch.Tensor): Points at which to evaluate the probability.
+            f_thresh (torch.Tensor): Threshold value.
+
+        Returns:
+            torch.Tensor: Probability that the latent function is below the threshold.
+        """
+        x = self.transforms.transform(x)
+        return self._base_obj.p_below_threshold(x, f_thresh)
+
+    @classmethod
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Return a dictionary of the relevant options to initialize a model wrapped with
+        a parameter transform
+
+        Args:
+            config (Config): Config to look for options in.
+            name (str): Strategy to find options for.
+            options (Dict[str, Any]): Options to override from the config.
+
+        Returns:
+            Dict[str, Any]: A diciontary of options to initialize this class with.
+        """
+        if options is None:
+            options = {}
+        else:
+            options = deepcopy(options)
+
+        if name is None:
+            raise ValueError("name of strategy must be set to initialize a model")
+        else:
+            model_cls = config.getobj(name, "model")
+
+        if "transforms" not in options:
+            options["transforms"] = ParameterTransforms.from_config(config)
+
+        # Transform config
+        transformed_config = transform_options(config, options["transforms"])
+
+        options["model"] = model_cls.from_config(transformed_config)
+
+        return options
+
+
+class Log10Plus(Log10, ConfigurableMixin):
+    """Base-10 log transform that we add a constant to the values"""
+
+    def __init__(
+        self,
+        indices: list[int],
+        constant: float = 0.0,
+        transform_on_train: bool = True,
+        transform_on_eval: bool = True,
+        transform_on_fantasize: bool = True,
+        reverse: bool = False,
+        **kwargs,
+    ) -> None:
+        """Initalize transform
+
+        Args:
+            indices: The indices of the parameters to log transform.
+            constant: The constant to add to inputs before log transforming. Defaults to
+                0.0.
+            transform_on_train: A boolean indicating whether to apply the
+                transforms in train() mode. Default: True.
+            transform_on_eval: A boolean indicating whether to apply the
+                transform in eval() mode. Default: True.
+            transform_on_fantasize: A boolean indicating whether to apply the
+                transform when called from within a `fantasize` call. Default: True.
+            reverse: A boolean indicating whether the forward pass should untransform
+                the inputs.
+            **kwargs: Accepted to conform to API.
+        """
+        super().__init__(
+            indices=indices,
+            transform_on_train=transform_on_train,
+            transform_on_eval=transform_on_eval,
+            transform_on_fantasize=transform_on_fantasize,
+            reverse=reverse,
+        )
+        self.register_buffer("constant", torch.tensor(constant, dtype=torch.long))
+
+    @subset_transform
+    def _transform(self, X: Tensor) -> Tensor:
+        r"""Add the constant then log transform the inputs.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of transformed inputs.
+        """
+        X = X + (torch.ones_like(X) * self.constant)
+        return X.log10()
+
+    @subset_transform
+    def _untransform(self, X: Tensor) -> Tensor:
+        r"""Reverse the log transformation then subtract the constant.
+
+        Args:
+            X: A `batch_shape x n x d`-dim tensor of transformed inputs.
+
+        Returns:
+            A `batch_shape x n x d`-dim tensor of untransformed inputs.
+        """
+        X = 10.0**X
+        return X - (torch.ones_like(X) * self.constant)
+
+    @classmethod
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return a dictionary of the relevant options to initialize a Log10Plus
+        transform for the named parameter within the config.
+
+        Args:
+            config (Config): Config to look for options in.
+            name (str): Parameter to find options for.
+            options (Dict[str, Any]): Options to override from the config.
+
+        Returns:
+            Dict[str, Any]: A diciontary of options to initialize this class with,
+                including the transformed bounds.
+        """
+        if name is None:
+            raise ValueError(f"{name} must be set to initialize a transform.")
+
+        if options is None:
+            options = {}
+        else:
+            options = deepcopy(options)
+
+        # Figure out the index of this parameter
+        parnames = config.getlist("common", "parnames", element_type=str)
+        idx = parnames.index(name)
+
+        # Make sure we have bounds ready
+        if "bounds" not in options:
+            options["bounds"] = get_bounds(config)
+
+        if "constant" not in options:
+            lb = options["bounds"][0, idx]
+            if lb < 0.0:
+                constant = np.abs(lb) + 1.0
+            elif lb < 1.0:
+                constant = 1.0
+            else:
+                constant = 0.0
+
+            options["constant"] = constant
+
+        if "indices" not in options:
+            options["indices"] = [idx]
+
+        return options
+
+
+def transform_options(
+    config: Config, transforms: Optional[ChainedInputTransform] = None
+) -> Config:
+    """Return a copy of the config with the options transformed.
+
+    Args:
+        config (Config): The config to be transformed.
+
+    Returns:
+        Config: A copy of the original config with relevant options transformed.
+    """
+    if transforms is None:
+        transforms = ParameterTransforms.from_config(config)
+
+    configClone = deepcopy(config)
+
+    # Can't use self.sections() to avoid default section behavior
+    for section, options in config.to_dict().items():
+        for option, value in options.items():
+            if option in _TRANSFORMABLE:
+                value = ast.literal_eval(value)
+                value = np.array(value, dtype=float)
+                value = torch.tensor(value).to(torch.float64)
+
+                value = transforms.transform(value)
+
+                def _arr_to_list(iter):
+                    if hasattr(iter, "__iter__"):
+                        iter = list(iter)
+                        iter = [_arr_to_list(element) for element in iter]
+                        return iter
+                    return iter
+
+                # Recursively turn back into str
+                configClone[section][option] = str(_arr_to_list(value.numpy()))
+
+    return configClone
+
+
+def get_bounds(config: Config) -> torch.Tensor:
+    r"""Return the bounds for all parameters in config.
+
+    Args:
+        config (Config): The config to find the bounds from.
+
+    Returns:
+        torch.Tensor: A `[2, d]` tensor with the lower and upper bounds for each
+            parameter.
+    """
+    parnames = config.getlist("common", "parnames", element_type=str)
+
+    # Try to build a full array of bounds based on parameter-specific bounds
+    try:
+        _lower_bounds = torch.tensor(
+            [config.getfloat(par, "lower_bound") for par in parnames]
+        )
+        _upper_bounds = torch.tensor(
+            [config.getfloat(par, "upper_bound") for par in parnames]
+        )
+
+        bounds = torch.stack((_lower_bounds, _upper_bounds))
+
+    except NoOptionError:  # Look for general lb/ub array
+        _lb = config.gettensor("common", "lb")
+        _ub = config.gettensor("common", "ub")
+        bounds = torch.stack((_lb, _ub))
+
+    return bounds

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -154,6 +154,9 @@ def get_lse_interval(
         dim=-1,
     ).reshape(-1, model.dim)
 
+    if model.transforms is not None:
+        xgrid = model.transforms.untransform(xgrid)
+
     samps = model.sample(xgrid, num_samples=n_samps, **kwargs)
     samps = [s.reshape((gridsize,) * model.dim) for s in samps]
 

--- a/configs/parameter_settings_example.ini
+++ b/configs/parameter_settings_example.ini
@@ -6,9 +6,10 @@ target = 0.75
 strategy_names = [init_strat, opt_strat]
 
 [contPar]
-par_type = continuous
-lower_bound = 0
-upper_bound = 1
+par_type = continuous # we only support continuous right now
+lower_bound = 0 # lower bound for this parameter in raw parameter space
+upper_bound = 1 # upper bound for this parameter in raw parameter space
+log_scale = True # this parameter will be transformed to log-scale space for the model
 
 # Strategy blocks below
 [init_strat]

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,0 +1,60 @@
+---
+id: parameters
+title: Advanced Parameter Configuration
+---
+
+This page provides an overview of additional controls for parameters, including
+parameter transformations. Generally, parameters should be defined in the natural raw
+parameter space and AEPsych will handle transforming the parameters into a form usable
+by the models. This means that the server will always suggest parameters in response to
+an `ask` in raw parameter space and you should always `tell` the server the
+results of a trial also in the raw parameter space. This remains true no matter
+what parameter types are used and whatever transformations are used.
+
+<h2>Parameter types</h2>
+Currently, we only support continuous parameters. More parameter types soon to come!
+
+<h3>Continuous<h3>
+
+```ini
+[parameter]
+par_type = continuous
+lower_bound = 0 # any real number
+upper_bound = 1 # any real number
+```
+
+Continuous parameters requires a lower bound and an upper bound to be set. Continuous
+parameters can have any non-infinite ranges. This means that continuous parameters can
+include negative values (e.g., lower bound = -1, upper bound = 1) or have very large
+ranges (e.g., lower bound = 0, upper bound = 1,000,000).
+
+<h2>Parameter Transformations</h2>
+Currently, we only support a log scale transformation to parameters. More parameter
+transformations to come! In general, you can define your parameters in the raw
+parameter space and AEPsych will handle the transformations for you seamlessly.
+
+<h3>Log scale</h3>
+The log scale transformation can be applied to parameters as an extra option in a
+parameter-specific block.
+
+```ini
+[parameter]
+par_type = continuous
+lower_bound = 1 # any real number
+upper_bound = 100 # any real number
+log_scale = True # turn it on with any of true/yes/on, turn it off with any of false/no/off; case insensitive
+```
+
+You can log scale a parameter by adding the `log_scale` option to a parameter-specific
+block and setting it to True (or true, yes, on). Log scaling is by default off. This
+will transform this parameter by applying a `Log10(x)` operation to it to get to the
+transformed space and apply a `10^x` operation to transformed parameters to get back to
+raw parameter space.
+
+If you use the log scale transformation on a parameter that includes values less than 1
+(e.g., lower bound = -1), we will add a constant to the parameter right before we
+apply the Log10 operation and subtract that constant when untransforming the parameter.
+For parameters with lower bounds that are positive but still less 1, we will always use
+a constant value of 1 (i.e., `Log10(x + 1)` and `10 ^ (x - 1)`). For parameters with
+lower bounds that are negative, we will use a constant value of the absolute value of
+the lower bound + 1 (i.e., `Log10(x + |lb| + 1)` and `10 ^ (x - |lb| - 1)`).

--- a/tests/generators/test_manual_generator.py
+++ b/tests/generators/test_manual_generator.py
@@ -12,6 +12,7 @@ import numpy.testing as npt
 
 from aepsych.config import Config
 from aepsych.generators import ManualGenerator, SampleAroundPointsGenerator
+from aepsych.transforms import ParameterTransformedGenerator
 
 
 class TestManualGenerator(unittest.TestCase):
@@ -35,12 +36,15 @@ class TestManualGenerator(unittest.TestCase):
         self.assertEqual(acq4.shape, (4, 3))
 
     def test_manual_generator(self):
-        points = [[0, 0], [0, 1], [1, 0], [1, 1]]
+        points = [[10, 10], [10, 11], [11, 10], [11, 11]]
         config_str = f"""
                 [common]
-                lb = [0, 0]
-                ub = [1, 1]
+                lb = [10, 10]
+                ub = [11, 11]
                 parnames = [par1, par2]
+
+                [init_strat]
+                generator = ManualGenerator
 
                 [ManualGenerator]
                 points = {points}
@@ -48,9 +52,10 @@ class TestManualGenerator(unittest.TestCase):
                 """
         config = Config()
         config.update(config_str=config_str)
-        gen = ManualGenerator.from_config(config)
-        npt.assert_equal(gen.lb.numpy(), np.array([0, 0]))
-        npt.assert_equal(gen.ub.numpy(), np.array([1, 1]))
+        # gen = ManualGenerator.from_config(config)
+        gen = ParameterTransformedGenerator.from_config(config, "init_strat")
+        npt.assert_equal(gen.lb.numpy(), np.array([10, 10]))
+        npt.assert_equal(gen.ub.numpy(), np.array([11, 11]))
         self.assertFalse(gen.finished)
 
         p1 = list(gen.gen()[0])

--- a/tests/models/test_monotonic_projection_gp.py
+++ b/tests/models/test_monotonic_projection_gp.py
@@ -17,6 +17,7 @@ if "CI" in os.environ or "SANDCASTLE" in os.environ:
 import numpy as np
 from aepsych.config import Config
 from aepsych.models.monotonic_projection_gp import MonotonicProjectionGP
+from aepsych.transforms import ParameterTransformedModel
 from sklearn.datasets import make_classification
 
 
@@ -38,7 +39,7 @@ class MonotonicProjectionGPtest(unittest.TestCase):
         X, y = self.X, self.y
         config_str = """
         [common]
-        parnames = [x, y]
+        parnames = [x, y, z]
         lb = [-4, -4, -4]
         ub = [4, 4, 4]
         stimuli_per_trial = 1
@@ -59,7 +60,7 @@ class MonotonicProjectionGPtest(unittest.TestCase):
         fixed_kernel_amplitude = False
         """
         config = Config(config_str=config_str)
-        model = MonotonicProjectionGP.from_config(config)
+        model = ParameterTransformedModel.from_config(config, "init_strat")
         model.fit(X, y)
 
         # Check that it is monotonic in both dims
@@ -78,7 +79,7 @@ class MonotonicProjectionGPtest(unittest.TestCase):
         # Check that min_f_val is respected
         config_str = """
         [common]
-        parnames = [x, y]
+        parnames = [x, y, z]
         lb = [-4, -4, -4]
         ub = [4, 4, 4]
         stimuli_per_trial = 1
@@ -100,7 +101,7 @@ class MonotonicProjectionGPtest(unittest.TestCase):
         fixed_kernel_amplitude = False
         """
         config = Config(config_str=config_str)
-        model = MonotonicProjectionGP.from_config(config)
+        model = ParameterTransformedModel.from_config(config, "init_strat")
         post = model.posterior(Xtest)
         mu = post.mean.squeeze()
         self.assertTrue(mu.min().item() >= 4.9)

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -628,7 +628,9 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
             self.assertEqual(len(server2._strats), len(server._strats))
             for strat1, strat2 in zip(server._strats, server2._strats):
                 self.assertEqual(type(strat1), type(strat2))
-                self.assertEqual(type(strat1.model), type(strat2.model))
+                self.assertEqual(
+                    type(strat1.model._base_obj), type(strat2.model._base_obj)
+                )
                 self.assertTrue(torch.equal(strat1.x, strat2.x))
                 self.assertTrue(torch.equal(strat1.y, strat2.y))
 
@@ -693,7 +695,9 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
             self.assertEqual(len(server2._strats), len(server._strats))
             for strat1, strat2 in zip(server._strats, server2._strats):
                 self.assertEqual(type(strat1), type(strat2))
-                self.assertEqual(type(strat1.model), type(strat2.model))
+                self.assertEqual(
+                    type(strat1.model._base_obj), type(strat2.model._base_obj)
+                )
                 self.assertTrue(torch.equal(strat1.x, strat2.x))
                 self.assertTrue(torch.equal(strat1.y, strat2.y))
         except Exception:
@@ -703,7 +707,7 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
         config_str = """
             [common]
             lb = [-1]
-            ub = [1]
+            ub = [0]
             stimuli_per_trial=2
             outcome_types=[binary]
             parnames = [x]
@@ -739,8 +743,8 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
 
         config_str = """
             [common]
-            lb = [-1, -1]
-            ub = [1, 1]
+            lb = [-1, 0]
+            ub = [0, 1]
             stimuli_per_trial=2
             outcome_types=[binary]
             parnames = [x, y]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+import unittest
+
+import numpy as np
+import torch
+from aepsych.config import Config
+from aepsych.generators import SobolGenerator
+from aepsych.models import GPClassificationModel
+from aepsych.strategy import SequentialStrategy
+from aepsych.transforms import (
+    ParameterTransformedGenerator,
+    ParameterTransformedModel,
+    ParameterTransforms,
+)
+from aepsych.transforms.parameters import Log10Plus
+
+
+class TransformsConfigTest(unittest.TestCase):
+    def setUp(self):
+        config_str = """
+            [common]
+            parnames = [signal1, signal2]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+            target = 0.75
+            strategy_names = [init_strat, opt_strat]
+
+            [signal1]
+            par_type = continuous
+            lower_bound = 1
+            upper_bound = 100
+            log_scale = false
+
+            [signal2]
+            par_type = continuous
+            lower_bound = 1
+            upper_bound = 100
+            log_scale = true
+
+            [init_strat]
+            min_total_tells = 10
+            generator = SobolGenerator
+            
+            [SobolGenerator]
+            seed = 12345
+
+            [opt_strat]
+            min_total_tells = 50
+            refit_every = 5
+            generator = OptimizeAcqfGenerator
+            acqf = MCLevelSetEstimation
+            model = GPClassificationModel
+            """
+
+        config = Config()
+        config.update(config_str=config_str)
+
+        self.strat = SequentialStrategy.from_config(config)
+
+    def test_generator_init_equivalent(self):
+        config_gen = self.strat.strat_list[0].generator
+
+        class_gen = ParameterTransformedGenerator(
+            generator=SobolGenerator,
+            lb=torch.tensor([1, 1]),
+            ub=torch.tensor([100, 100]),
+            seed=12345,
+            transforms=self.strat.strat_list[0].transforms,
+        )
+
+        self.assertTrue(type(config_gen._base_obj) is type(class_gen._base_obj))
+        self.assertTrue(torch.equal(config_gen.lb, class_gen.lb))
+        self.assertTrue(torch.equal(config_gen.ub, class_gen.ub))
+
+        config_points = config_gen.gen(10)
+        obj_points = class_gen.gen(10)
+        self.assertTrue(torch.equal(config_points, obj_points))
+
+        self.assertEqual(
+            len(config_gen.transforms.values()), len(class_gen.transforms.values())
+        )
+
+    def test_model_init_equivalent(self):
+        config_model = self.strat.strat_list[1].model
+
+        obj_model = ParameterTransformedModel(
+            model=GPClassificationModel,
+            lb=torch.tensor([1, 1]),
+            ub=torch.tensor([100, 100]),
+            transforms=self.strat.strat_list[1].transforms,
+        )
+
+        self.assertTrue(type(config_model._base_obj) is type(obj_model._base_obj))
+        self.assertTrue(torch.equal(config_model.bounds, obj_model.bounds))
+        self.assertTrue(torch.equal(config_model.bounds, obj_model.bounds))
+
+        self.assertEqual(
+            len(config_model.transforms.values()), len(obj_model.transforms.values())
+        )
+
+    def test_transforms_in_strategy(self):
+        for _strat in self.strat.strat_list:
+            for strat_transform, gen_transform in zip(
+                _strat.transforms.items(), _strat.generator.transforms.items()
+            ):
+                self.assertTrue(strat_transform[0] == gen_transform[0])
+                self.assertTrue(type(strat_transform[1]) is type(gen_transform[1]))
+
+
+class TransformsLog10Test(unittest.TestCase):
+    def test_transform_reshape(self):
+        x = torch.rand(4, 3, 2) + 1.0
+
+        transforms = ParameterTransforms(Log10Plus=Log10Plus(indices=[0, 1, 2]))
+
+        transformed_x = transforms.transform(x)
+        untransformed_x = transforms.untransform(transformed_x)
+
+        self.assertTrue(torch.allclose(x, untransformed_x))
+
+    def test_log_transform(self):
+        config_str = """
+            [common]
+            parnames = [signal1, signal2]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+
+            [signal1]
+            par_type = continuous
+            lower_bound = -10
+            upper_bound = 10
+            log_scale = false
+
+            [signal2]
+            par_type = continuous
+            lower_bound = 1
+            upper_bound = 100
+            log_scale = true
+        """
+        config = Config()
+        config.update(config_str=config_str)
+
+        transforms = ParameterTransforms.from_config(config)
+
+        values = torch.tensor([[1, 100], [-2, 10], [-3.2, 1]])
+        expected = torch.tensor([[1, 2], [-2, 1], [-3.2, 0]])
+        transformed = transforms.transform(values)
+
+        self.assertTrue(torch.allclose(transformed, expected))
+        self.assertTrue(torch.allclose(transforms.untransform(transformed), values))
+
+    def test_log10Plus_transform(self):
+        config_str = """
+            [common]
+            parnames = [signal1]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+
+            [signal1]
+            par_type = continuous
+            lower_bound = -1
+            upper_bound = 1
+            log_scale = on
+        """
+        config = Config()
+        config.update(config_str=config_str)
+
+        transforms = ParameterTransforms.from_config(config)
+
+        values = torch.tensor([[-1, 0, 0.5, 0.1]]).T
+        transformed = transforms.transform(values)
+        untransformed = transforms.untransform(transformed)
+
+        self.assertTrue(torch.all(transformed >= 0))
+        self.assertTrue(torch.allclose(values, untransformed))
+
+    def test_log_model(self):
+        np.random.seed(1)
+        torch.manual_seed(1)
+
+        lower_bound = 1
+        upper_bound = 100
+        target = 0.75
+
+        config_str = f"""
+            [common]
+            parnames = [signal1]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+            target = {target}
+            strategy_names = [init_strat, opt_strat]
+
+            [signal1]
+            par_type = continuous
+            lower_bound = {lower_bound}
+            upper_bound = {upper_bound}
+            log_scale = true
+
+            [init_strat]
+            generator = SobolGenerator
+            min_total_tells = 50
+
+            [SobolGenerator]
+            seed = 1
+
+            [opt_strat]
+            generator = OptimizeAcqfGenerator
+            acqf = MCLevelSetEstimation
+            model = GPClassificationModel
+            min_total_tells = 70
+            """
+
+        config = Config()
+        config.update(config_str=config_str)
+
+        strat = SequentialStrategy.from_config(config)
+
+        while not strat.finished:
+            next_x = strat.gen()
+            response = int(np.random.rand() < (next_x / 100))
+            strat.add_data(next_x, [response])
+
+        x = torch.linspace(lower_bound, upper_bound, 100)
+
+        zhat, _ = strat.predict(x)
+        est_max = x[np.argmin((zhat - target) ** 2)]
+        diff = np.abs(est_max / 100 - target)
+        self.assertTrue(diff < 0.15, f"Diff = {diff}")

--- a/tests_gpu/test_config.py
+++ b/tests_gpu/test_config.py
@@ -30,6 +30,7 @@ class ConfigTestCase(unittest.TestCase):
             
             [gpu_strategy]
             model = GPClassificationModel
+            generator = SobolGenerator
             
             [GPClassificationModel]
             use_gpu = True

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -19,7 +19,7 @@
     ],
     "Advanced topics": [
       "finish_criteria",
-      "ax_backend"
+      "parameters"
     ]
   }
 }


### PR DESCRIPTION
Summary:
Parameter transforms will be handled by wrapping generator and model objects.

The wrappers surfaces the base object API completely and even appears to be the wrapped object upon type inspection. Methods that requires the transformations are overridden by the wrapper to apply the required (un)transforms.

The wrappers expects transforms from BoTorch and new transforms should follow BoTorch's InputTransforms.

As a baseline a log10 transform is implemented.

Differential Revision: D64129439
