### PR TITLE
Fix Strategy class to ensure consistent tensor operations for data normalization

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -2,9 +2,10 @@ name: Build, lint, test
 
 on:
   push:
-    branches: [ main, strategy-normalize_inputs-fix ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, strategy-normalize_inputs-fix ]
+    branches: [ main ]
+
 jobs:
   lint:
     runs-on: macos-latest

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -2,10 +2,9 @@ name: Build, lint, test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, strategy-normalize_inputs-fix ]
   pull_request:
-    branches: [ main ]
-
+    branches: [ main, strategy-normalize_inputs-fix ]
 jobs:
   lint:
     runs-on: macos-latest

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -170,7 +170,7 @@ class Strategy(object):
 
         self.name = name
 
-    def normalize_inputs(self, x, y):
+    def normalize_inputs(self, x:torch.Tensor, y:torch.Tensor):
         """converts inputs into normalized format for this strategy
 
         Args:
@@ -193,14 +193,10 @@ class Strategy(object):
         if x.shape == self.event_shape:
             x = x[None, :]
 
-        if self.x is None:
-            x = x
-        else:
+        if self.x is not None:
             x = torch.cat((self.x, x), dim=0)
 
-        if self.y is None:
-            y = y
-        else:
+        if self.y is not None:
             y = torch.cat((self.y, y), dim=0)
 
         # Ensure the correct dtype
@@ -313,7 +309,7 @@ class Strategy(object):
         )
         return self.min_asks
 
-    def add_data(self, x, y):
+    def add_data(self, x: Union[np.ndarray, torch.Tensor], y: Union[np.ndarray, torch.Tensor]):
         """
         Adds new data points to the strategy, and normalizes the inputs.
 

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -203,6 +203,9 @@ class Strategy(object):
         else:
             y = torch.cat((self.y, y), dim=0)
 
+        # Ensure the correct dtype
+        x = x.to(torch.float64)
+        y = y.to(torch.float64)
         n = y.shape[0]
 
         return x, y, n
@@ -311,10 +314,11 @@ class Strategy(object):
         return self.min_asks
 
     def add_data(self, x, y):
+        # Necessary as sometimes the data is passed in as numpy arrays, torch tensors, or lists.
         if not isinstance(y, torch.Tensor):
-            y = torch.tensor(y, dtype=torch.float32)
+            y = torch.tensor(y, dtype=torch.float64)
         if not isinstance(x, torch.Tensor):
-            x = torch.tensor(x, dtype=torch.float32)
+            x = torch.tensor(x, dtype=torch.float64)
 
         self.x, self.y, self.n = self.normalize_inputs(x, y)
         self._model_is_fresh = False

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -314,7 +314,15 @@ class Strategy(object):
         return self.min_asks
 
     def add_data(self, x, y):
-        # Necessary as sometimes the data is passed in as numpy arrays, torch tensors, or lists.
+        """
+        Adds new data points to the strategy, normalizing the inputs if necessary.
+
+        Args:
+            x (torch.Tensor, np.ndarray): The input data points. Can be a PyTorch tensor or NumPy array.
+            y (torch.Tensor, np.ndarray): The output data points. Can be a PyTorch tensor or NumPy array.
+
+        """
+        # Necessary as sometimes the data is passed in as numpy arrays or torch tensors.
         if not isinstance(y, torch.Tensor):
             y = torch.tensor(y, dtype=torch.float64)
         if not isinstance(x, torch.Tensor):

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -315,7 +315,7 @@ class Strategy(object):
 
     def add_data(self, x, y):
         """
-        Adds new data points to the strategy, normalizing the inputs if necessary.
+        Adds new data points to the strategy, and normalizes the inputs.
 
         Args:
             x (torch.Tensor, np.ndarray): The input data points. Can be a PyTorch tensor or NumPy array.

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -139,8 +139,8 @@ class Strategy(object):
                 lb=self.lb, ub=self.ub, size=self._n_eval_points
             )
 
-        self.x = None
-        self.y = None
+        self.x: Optional[torch.Tensor] = None
+        self.y: Optional[torch.Tensor] = None
         self.n = 0
         self.min_asks = min_asks
         self._count = 0
@@ -170,7 +170,7 @@ class Strategy(object):
 
         self.name = name
 
-    def normalize_inputs(self, x:torch.Tensor, y:torch.Tensor):
+    def normalize_inputs(self, x:torch.Tensor, y:torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, int]:
         """converts inputs into normalized format for this strategy
 
         Args:


### PR DESCRIPTION
This PR addresses the second part of issue #365, focusing on the `Strategy` class and how data is added and normalized, transitioning the process to use tensors instead of NumPy operations.

The changes were made specifically within the `normalize_inputs` method of the `Strategy` class. Previously, this method had mismatched docstrings indicating `np.array` usage. Now, it consistently accepts and returns tensors, performing all operations within tensors.

The `normalize_inputs` method is called in `add_data()` (where the confusion arises), as the data passed can vary (either tensors or `np.array`). To resolve this, the method now acts as the first step, accepting both formats and then converting everything to tensors for consistent operations (model fitting later on). It’s also crucial to ensure the data type is `float64`, as `gpytorch` does not support other data types.

Additionally, a detailed docstring was added to clarify the method's expectations and ensure its proper use going forward.
