### PR TITLE
Fix Mypy Linter Errors in plotting.py

### DIFF
--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -158,6 +158,8 @@ def _plot_strat_1d(
         grid = strat.model.dim_grid(gridsize=gridsize)
         samps = norm.cdf(strat.model.sample(grid, num_samples=10000).detach())
         phimean = samps.mean(0)
+    else:
+        raise RuntimeError("No model to plot!")
 
     ax.plot(np.squeeze(grid), phimean)
     if cred_level is not None:
@@ -260,6 +262,8 @@ def _plot_strat_2d(
         grid = strat.model.dim_grid(gridsize=gridsize)
         fmean, _ = strat.model.predict(grid)
         phimean = norm.cdf(fmean.reshape(gridsize, gridsize).detach().numpy()).T
+    else:
+        raise RuntimeError("No model to plot!")
 
     extent = np.r_[strat.lb[0], strat.ub[0], strat.lb[1], strat.ub[1]]
     colormap = ax.imshow(

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -159,7 +159,7 @@ def _plot_strat_1d(
         samps = norm.cdf(strat.model.sample(grid, num_samples=10000).detach())
         phimean = samps.mean(0)
     else:
-        raise RuntimeError("No model to plot!")
+        raise RuntimeError("Cannot plot without a model!")
 
     ax.plot(np.squeeze(grid), phimean)
     if cred_level is not None:
@@ -263,7 +263,7 @@ def _plot_strat_2d(
         fmean, _ = strat.model.predict(grid)
         phimean = norm.cdf(fmean.reshape(gridsize, gridsize).detach().numpy()).T
     else:
-        raise RuntimeError("No model to plot!")
+        raise RuntimeError("Cannot plot without a model!")
 
     extent = np.r_[strat.lb[0], strat.ub[0], strat.lb[1], strat.ub[1]]
     colormap = ax.imshow(

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -154,8 +154,9 @@ def _plot_strat_1d(
     x, y = strat.x, strat.y
     assert x is not None and y is not None, "No data to plot!"
 
-    grid = strat.model.dim_grid(gridsize=gridsize)
-    samps = norm.cdf(strat.model.sample(grid, num_samples=10000).detach())
+    if strat.model is not None:
+        grid = strat.model.dim_grid(gridsize=gridsize)
+        samps = norm.cdf(strat.model.sample(grid, num_samples=10000).detach())
     phimean = samps.mean(0)
 
     ax.plot(np.squeeze(grid), phimean)
@@ -215,14 +216,14 @@ def _plot_strat_1d(
     ax.scatter(
         x[y == 0, 0],
         np.zeros_like(x[y == 0, 0]),
-        marker=3,
+        marker="3",
         color="r",
         label=no_label,
     )
     ax.scatter(
         x[y == 1, 0],
         np.zeros_like(x[y == 1, 0]),
-        marker=3,
+        marker="3",
         color="b",
         label=yes_label,
     )
@@ -253,11 +254,12 @@ def _plot_strat_2d(
     assert x is not None and y is not None, "No data to plot!"
 
     # make sure the model is fit well if we've been limiting fit time
-    strat.model.fit(train_x=x, train_y=y, max_fit_time=None)
+    if strat.model is not None:
+        strat.model.fit(train_x=x, train_y=y, max_fit_time=None)
 
-    grid = strat.model.dim_grid(gridsize=gridsize)
-    fmean, _ = strat.model.predict(grid)
-    phimean = norm.cdf(fmean.reshape(gridsize, gridsize).detach().numpy()).T
+        grid = strat.model.dim_grid(gridsize=gridsize)
+        fmean, _ = strat.model.predict(grid)
+        phimean = norm.cdf(fmean.reshape(gridsize, gridsize).detach().numpy()).T
 
     extent = np.r_[strat.lb[0], strat.ub[0], strat.lb[1], strat.ub[1]]
     colormap = ax.imshow(
@@ -277,7 +279,7 @@ def _plot_strat_2d(
 
     # hacky relabel to be in logspace
     if logx:
-        locs = np.arange(strat.lb[0], strat.ub[0])
+        locs: np.ndarray = np.arange(strat.lb[0], strat.ub[0])
         ax.set_xticks(ticks=locs)
         ax.set_xticklabels(2.0**locs)
 

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -157,7 +157,7 @@ def _plot_strat_1d(
     if strat.model is not None:
         grid = strat.model.dim_grid(gridsize=gridsize)
         samps = norm.cdf(strat.model.sample(grid, num_samples=10000).detach())
-    phimean = samps.mean(0)
+        phimean = samps.mean(0)
 
     ax.plot(np.squeeze(grid), phimean)
     if cred_level is not None:

--- a/tests/acquisition/test_lse.py
+++ b/tests/acquisition/test_lse.py
@@ -15,7 +15,7 @@ from botorch.utils.testing import MockModel, MockPosterior
 from scipy.stats import norm
 
 
-class TestLSE(unittest.TestCase): # checking if actions work as expected
+class TestLSE(unittest.TestCase):
     def setUp(self):
         f = torch.ones(1) * 1.7
         var = torch.ones(1) * 2.3

--- a/tests/acquisition/test_lse.py
+++ b/tests/acquisition/test_lse.py
@@ -15,7 +15,7 @@ from botorch.utils.testing import MockModel, MockPosterior
 from scipy.stats import norm
 
 
-class TestLSE(unittest.TestCase):
+class TestLSE(unittest.TestCase): # checking if actions work as expected
     def setUp(self):
         f = torch.ones(1) * 1.7
         var = torch.ones(1) * 2.3


### PR DESCRIPTION


This PR resolves mypy linter issues in `plotting.py` by adding `None` checks for `strat.model`, providing a missing type hint for the `locs` variable, and updating `matplotlib.markers` to use a string digit instead of an integer. 

This was done because adding more strict type hints in other parts of the code revealed these errors, which need to be fixed before proceeding with #403 .





