### PR TITLE
add sleep to more db tests

### DIFF
--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -8,10 +8,10 @@
 import json
 import logging
 import select
+import time
 import unittest
 import uuid
 from unittest.mock import MagicMock
-import time
 
 import aepsych.server as server
 import aepsych.utils_logging as utils_logging
@@ -64,11 +64,14 @@ class BaseServerTestCase(unittest.TestCase):
         self.s.cleanup()
 
         # sleep to ensure db is closed
-        time.sleep(0.1)
+        time.sleep(0.2)
 
         # cleanup the db
         if self.s.db is not None:
-            self.s.db.delete_db()
+            try:
+                self.s.db.delete_db()
+            except PermissionError as e:
+                print("Failed to deleted database: ", e)
 
     def dummy_create_setup(self, server, request=None):
         request = request or {"test": "test request"}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -8,6 +8,7 @@
 import json
 import os
 import shutil
+import time
 import unittest
 import uuid
 from configparser import DuplicateOptionError
@@ -26,6 +27,7 @@ class DBTestCase(unittest.TestCase):
         self._database = db.Database(db_path=self._dbname)
 
     def tearDown(self):
+        time.sleep(0.1)
         self._database.delete_db()
 
     def test_db_create(self):
@@ -129,6 +131,9 @@ class DBTestCase(unittest.TestCase):
         shutil.copy(str(db_path), str(dst_db_path))
         self.assertTrue(dst_db_path.is_file())
 
+        # add sleep to ensure file is ready
+        time.sleep(0.1)
+
         # open the new db
         test_database = db.Database(db_path=dst_db_path.as_posix())
 
@@ -169,6 +174,9 @@ class DBTestCase(unittest.TestCase):
         dst_db_path = Path(self._dbname)
         shutil.copy(str(db_path), str(dst_db_path))
         self.assertTrue(dst_db_path.is_file())
+
+        # sleep to ensure db is ready
+        time.sleep(0.1)
 
         # open the new db
         test_database = db.Database(db_path=dst_db_path.as_posix())


### PR DESCRIPTION
Summary: DB tests sometimes fails on Windows because db files are not ready yet. Adding sleeps throughout should guarantee their success.

Differential Revision: D64541706


