### PR TITLE
Refactor test functions for PyTorch tensor support, add type hints, and update related tests

### DIFF
--- a/aepsych/benchmark/test_functions.py
+++ b/aepsych/benchmark/test_functions.py
@@ -112,8 +112,8 @@ def make_songetal_testfun(
     """
     valid_phenotypes = ["Metabolic", "Sensory", "Metabolic+Sensory", "Older-normal"]
     assert phenotype in valid_phenotypes, f"Phenotype must be one of {valid_phenotypes}"
-    x = torch.tensor(dubno_data[dubno_data.phenotype == phenotype].freq.values, dtype=torch.float32)
-    y = torch.tensor(dubno_data[dubno_data.phenotype == phenotype].thresh.values, dtype=torch.float32)
+    x = torch.tensor(dubno_data[dubno_data.phenotype == phenotype].freq.values, dtype=torch.float64)
+    y = torch.tensor(dubno_data[dubno_data.phenotype == phenotype].thresh.values, dtype=torch.float64)
 
     # first, make the threshold fun
     threshfun = make_songetal_threshfun(x, y)
@@ -202,13 +202,13 @@ def modified_hartmann6(X: torch.Tensor) -> torch.Tensor:
     """
     The modified Hartmann6 function used in Lyu et al.
     """
-    C = torch.tensor([0.2, 0.22, 0.28, 0.3], dtype=torch.float32)
+    C = torch.tensor([0.2, 0.22, 0.28, 0.3], dtype=torch.float64)
     a_t = torch.tensor([
         [8, 3, 10, 3.5, 1.7, 6],
         [0.5, 8, 10, 1.0, 6, 9],
         [3, 3.5, 1.7, 8, 10, 6],
         [10, 6, 0.5, 8, 1.0, 9]
-    ], dtype=torch.float32)
+    ], dtype=torch.float64)
 
     p_t = (
         10 ** (-4)
@@ -217,12 +217,12 @@ def modified_hartmann6(X: torch.Tensor) -> torch.Tensor:
             [2329, 4135, 8307, 3736, 1004, 9991],
             [2348, 1451, 3522, 2883, 3047, 6650],
             [4047, 8828, 8732, 5743, 1091, 381]
-        ], dtype=torch.float32)
+        ], dtype=torch.float64)
     )
 
-    y = torch.tensor(0.0, dtype=torch.float32)
+    y = torch.tensor(0.0, dtype=torch.float64)
     for i, C_i in enumerate(C):
-        t = torch.tensor(0.0, dtype=torch.float32)  
+        t = torch.tensor(0.0, dtype=torch.float64)  
         for j in range(6):
             t += a_t[i, j] * ((X[j] - p_t[i, j]) ** 2)
         y += C_i * torch.exp(-t)

--- a/aepsych/benchmark/test_functions.py
+++ b/aepsych/benchmark/test_functions.py
@@ -7,12 +7,12 @@
 
 import io
 import math
-from typing import Callable
+from typing import Callable, Tuple
 
 import numpy as np
 import pandas as pd
 from scipy.interpolate import CubicSpline, interp1d
-from scipy.stats import norm
+import torch
 
 # manually scraped data from doi:10.1007/s10162-013-0396-x fig 2
 raw = """\
@@ -53,40 +53,42 @@ freq,thresh,phenotype
 dubno_data = pd.read_csv(io.StringIO(raw))
 
 
-def make_songetal_threshfun(x: np.ndarray, y: np.ndarray) -> Callable[[float], float]:
+def make_songetal_threshfun(x: torch.Tensor, y: torch.Tensor) -> Callable[[torch.Tensor], torch.Tensor]:
     """Generate a synthetic threshold function by interpolation of real data.
 
     Real data is from Dubno et al. 2013, and procedure follows Song et al. 2017, 2018.
     See make_songetal_testfun for more detail.
 
     Args:
-        x (np.ndarray): Frequency
-        y (np.ndarray): Threshold
+        x (torch.Tensor): Frequency
+        y (torch.Tensor): Threshold
 
     Returns:
-        Callable[[float], float]: Function that interpolates the given
+        Callable[[torch.Tensor], torch.Tensor]: Function that interpolates the given
             frequencies and thresholds and returns threshold as a function
             of frequency.
     """
-    f_interp = CubicSpline(x, y, extrapolate=False)
-    f_extrap = interp1d(x, y, fill_value="extrapolate")
+    x_np = x.cpu().numpy()  
+    y_np = y.cpu().numpy()  
+    # These are not directly implemented in pytorch, so we use scipy for now
+    f_interp = CubicSpline(x_np, y_np, extrapolate=False) 
+    f_extrap = interp1d(x_np, y_np, fill_value="extrapolate")
 
     def f_combo(x):
-        # interpolate first
-        interpolated = f_interp(x)
-        # whatever is nan needs extrapolating
-        interpolated[np.isnan(interpolated)] = f_extrap(x[np.isnan(interpolated)])
-        return interpolated
+        x_np = x.cpu().numpy()
+        interpolated = f_interp(x_np)
+        interpolated[np.isnan(interpolated)] = f_extrap(x_np[np.isnan(interpolated)])
+        return torch.from_numpy(interpolated)
 
     return f_combo
 
 
 def make_songetal_testfun(
     phenotype: str = "Metabolic", beta: float = 1
-) -> Callable[[np.ndarray, bool], np.ndarray]:
+) -> Callable[[torch.Tensor, bool], torch.Tensor]:
     """Make an audiometric test function following Song et al. 2017.
 
-    To do so,we first compute a threshold by interpolation/extrapolation
+    To do so, we first compute a threshold by interpolation/extrapolation
     from real data, then assume a linear psychometric function in intensity
     with slope beta.
 
@@ -97,7 +99,7 @@ def make_songetal_testfun(
         beta (float, optional): Psychometric function slope. Defaults to 1.
 
     Returns:
-        Callable[[np.ndarray, bool], np.ndarray]: A test function taking a [b x 2] array of points and returning the psychometric function value at those points.
+        Callable[[torch.Tensor, bool], torch.Tensor]: A test function taking a [b x 2] tensor of points and returning the psychometric function value at those points.
 
     Raises:
         AssertionError: if an invalid phenotype is passed.
@@ -110,18 +112,19 @@ def make_songetal_testfun(
     """
     valid_phenotypes = ["Metabolic", "Sensory", "Metabolic+Sensory", "Older-normal"]
     assert phenotype in valid_phenotypes, f"Phenotype must be one of {valid_phenotypes}"
-    x = dubno_data[dubno_data.phenotype == phenotype].freq.values
-    y = dubno_data[dubno_data.phenotype == phenotype].thresh.values
+    x = torch.tensor(dubno_data[dubno_data.phenotype == phenotype].freq.values, dtype=torch.float32)
+    y = torch.tensor(dubno_data[dubno_data.phenotype == phenotype].thresh.values, dtype=torch.float32)
+
     # first, make the threshold fun
     threshfun = make_songetal_threshfun(x, y)
 
     # now make it into a test function
-    def song_testfun(x, cdf=False):
+    def song_testfun(x: torch.Tensor, cdf: bool = False) -> torch.Tensor:
         logfreq = x[..., 0]
         intensity = x[..., 1]
-        thresh = threshfun(2**logfreq)
+        thresh = threshfun(2 ** logfreq)
         return (
-            norm.cdf((intensity - thresh) / beta)
+            torch.distributions.Normal(0, 1).cdf((intensity - thresh) / beta)
             if cdf
             else (intensity - thresh) / beta
         )
@@ -129,7 +132,8 @@ def make_songetal_testfun(
     return song_testfun
 
 
-def novel_discrimination_testfun(x: np.ndarray) -> np.ndarray:
+
+def novel_discrimination_testfun(x: torch.Tensor) -> torch.Tensor:
     """Evaluate novel discrimination test function from Owen et al.
 
     The threshold is roughly parabolic with context, and the slope
@@ -138,10 +142,10 @@ def novel_discrimination_testfun(x: np.ndarray) -> np.ndarray:
     to discrimination being at chance at zero stimulus intensity.
 
     Args:
-        x (np.ndarray): Points at which to evaluate.
+        x (torch.Tensor): Points at which to evaluate.
 
     Returns:
-        np.ndarray: Value of function at these points.
+        torch.Tensor: Value of function at these points.
     """
     freq = x[..., 0]
     amp = x[..., 1]
@@ -149,17 +153,17 @@ def novel_discrimination_testfun(x: np.ndarray) -> np.ndarray:
     return 2 * (amp + 1) / context
 
 
-def novel_detection_testfun(x):
+def novel_detection_testfun(x: torch.Tensor) -> torch.Tensor:
     """Evaluate novel detection test function from Owen et al.
 
     The threshold is roughly parabolic with context, and the slope
     varies with the threshold.
 
     Args:
-        x (np.ndarray, torch.Tensor): Points at which to evaluate.
+        x (torch.Tensor): Points at which to evaluate.
 
     Returns:
-        np.ndarray, torch.Tensor: Value of function at these points.
+         torch.Tensor: Value of function at these points.
     """
     freq = x[..., 0]
     amp = x[..., 1]
@@ -167,7 +171,7 @@ def novel_detection_testfun(x):
     return 4 * (amp + 1) / context - 4
 
 
-def discrim_highdim(x):
+def discrim_highdim(x: torch.Tensor) -> torch.Tensor:
     amp = x[..., 0]
     freq = x[..., 1]
     vscale = x[..., 2]
@@ -178,92 +182,95 @@ def discrim_highdim(x):
     period = x[..., 7]
 
     context = (
-        -0.5 * vscale * np.cos(period * 0.6 * math.pi * freq + phase)
+        -0.5 * vscale * torch.cos(period * 0.6 * torch.pi * freq + phase)
         + vscale / 2
         + vshift
     ) * (
-        -1 * asym * np.sin(period * 0.6 * math.pi * 0.5 * freq + phase) + (2 - asym)
+        -1 * asym * torch.sin(period * 0.6 * torch.pi * 0.5 * freq + phase) + (2 - asym)
     ) - 1
+
     z = (amp - context) / (variance + variance * (1 + context))
-    p = norm.cdf(z)
-    p = (1 - 0.5) * p + 0.5  # Floor at p=0.5
-    p = np.clip(p, 0.5, 1 - 1e-5)  # clip so that norm.ppf doesn't go to inf
-    return norm.ppf(p)
+    normal_dist = torch.distributions.Normal(0, 1)
+    p = normal_dist.cdf(z)
+    p = (1 - 0.5) * p + 0.5
+    p = torch.clamp(p, 0.5, 1 - 1e-5)
+
+    return normal_dist.icdf(p)
 
 
-def modified_hartmann6(X):
+def modified_hartmann6(X: torch.Tensor) -> torch.Tensor:
     """
     The modified Hartmann6 function used in Lyu et al.
     """
-    C = np.r_[0.2, 0.22, 0.28, 0.3]
-    a_t = np.c_[
+    C = torch.tensor([0.2, 0.22, 0.28, 0.3], dtype=torch.float32)
+    a_t = torch.tensor([
         [8, 3, 10, 3.5, 1.7, 6],
         [0.5, 8, 10, 1.0, 6, 9],
         [3, 3.5, 1.7, 8, 10, 6],
-        [10, 6, 0.5, 8, 1.0, 9],
-    ].T
+        [10, 6, 0.5, 8, 1.0, 9]
+    ], dtype=torch.float32)
 
     p_t = (
         10 ** (-4)
-        * np.c_[
+        * torch.tensor([
             [1312, 1696, 5569, 124, 8283, 5886],
             [2329, 4135, 8307, 3736, 1004, 9991],
             [2348, 1451, 3522, 2883, 3047, 6650],
-            [4047, 8828, 8732, 5743, 1091, 381],
-        ].T
+            [4047, 8828, 8732, 5743, 1091, 381]
+        ], dtype=torch.float32)
     )
 
-    y = 0.0
+    y = torch.tensor(0.0, dtype=torch.float32)
     for i, C_i in enumerate(C):
-        t = 0
+        t = torch.tensor(0.0, dtype=torch.float32)  
         for j in range(6):
             t += a_t[i, j] * ((X[j] - p_t[i, j]) ** 2)
-        y += C_i * np.exp(-t)
-    return -10 * (float(y) - 0.1)
+        y += C_i * torch.exp(-t)
+    return -10 * (y - 0.1)
 
 
-def f_1d(x, mu=0):
+def f_1d(x: torch.Tensor, mu: float = 0) -> torch.Tensor:
     """
     latent is just a gaussian bump at mu
     """
-    return np.exp(-((x - mu) ** 2))
+    return torch.exp(-((x - mu) ** 2))
 
 
-def f_2d(x):
+def f_2d(x: torch.Tensor) -> torch.Tensor:
     """
-    a gaussian bump at 0 , 0
+    a gaussian bump at 0, 0
     """
-    return np.exp(-np.linalg.norm(x, axis=-1))
+    return torch.exp(-torch.norm(x, dim=-1))
 
 
-def new_novel_det_params(freq, scale_factor=1.0):
+def new_novel_det_params(freq: torch.Tensor, scale_factor: float = 1.0) -> Tuple[torch.Tensor, torch.Tensor]:
     """Get the loc and scale params for 2D synthetic novel_det(frequency) function
         Keyword arguments:
-    freq -- 1D array of frequencies whose thresholds to return
+    freq -- 1D tensor of frequencies whose thresholds to return
     scale factor -- scale for the novel_det function, where higher is steeper/lower SD
-    target -- target threshold
     """
-    locs = 0.66 * np.power(0.8 * freq * (0.2 * freq - 1), 2) + 0.05
+    locs = 0.66 * torch.pow(0.8 * freq * (0.2 * freq - 1), 2) + 0.05
     scale = 2 * locs / (3 * scale_factor)
     loc = -1 + 2 * locs
     return loc, scale
 
 
-def target_new_novel_det(freq, scale_factor=1.0, target=0.75):
+def target_new_novel_det(freq: torch.Tensor, scale_factor: float = 1.0, target: float = 0.75) -> torch.Tensor:
     """Get the target (i.e. threshold) for 2D synthetic novel_det(frequency) function
         Keyword arguments:
-    freq -- 1D array of frequencies whose thresholds to return
+    freq -- 1D tensor of frequencies whose thresholds to return
     scale factor -- scale for the novel_det function, where higher is steeper/lower SD
     target -- target threshold
     """
     locs, scale = new_novel_det_params(freq, scale_factor)
-    return norm.ppf(target, loc=locs, scale=scale)
+    normal_dist = torch.distributions.Normal(locs, scale)
+    return normal_dist.icdf(torch.tensor(target))
 
 
-def new_novel_det(x, scale_factor=1.0):
+def new_novel_det(x: torch.Tensor, scale_factor: float = 1.0) -> torch.Tensor:
     """Get the cdf for 2D synthetic novel_det(frequency) function
         Keyword arguments:
-    x -- array of shape (n,2) of locations to sample;
+    x -- tensor of shape (n,2) of locations to sample;
          x[...,0] is frequency from -1 to 1; x[...,1] is intensity from -1 to 1
     scale factor -- scale for the novel_det function, where higher is steeper/lower SD
     """
@@ -272,120 +279,121 @@ def new_novel_det(x, scale_factor=1.0):
     return (x[..., 1] - locs) / scale
 
 
-def cdf_new_novel_det(x, scale_factor=1.0):
+def cdf_new_novel_det(x: torch.Tensor, scale_factor: float = 1.0) -> torch.Tensor:
     """Get the cdf for 2D synthetic novel_det(frequency) function
         Keyword arguments:
-    x -- array of shape (n,2) of locations to sample;
+    x -- tensor of shape (n,2) of locations to sample;
          x[...,0] is frequency from -1 to 1; x[...,1] is intensity from -1 to 1
     scale factor -- scale for the novel_det function, where higher is steeper/lower SD
     """
-    return norm.cdf(new_novel_det(x, scale_factor))
+    z = new_novel_det(x, scale_factor)
+    normal_dist = torch.distributions.Normal(0, 1)  # Standard normal distribution
+    return normal_dist.cdf(z)
 
 
-def new_novel_det_channels_params(channel, scale_factor=1.0, wave_freq=1, target=0.75):
+def new_novel_det_channels_params(channel: torch.Tensor, scale_factor: float = 1.0, wave_freq: float = 1, target: float = 0.75) -> Tuple[torch.Tensor, torch.Tensor]:
     """Get the target parameters for 2D synthetic novel_det(channel) function
         Keyword arguments:
-    channel -- 1D array of channel locations whose thresholds to return
+    channel -- 1D tensor of channel locations whose thresholds to return
     scale factor -- scale for the novel_det function, where higher is steeper/lower SD
     wave_freq -- frequency of location waveform on [-1,1]
     target -- target threshold
     """
-    locs = -0.3 * np.sin(5 * wave_freq * (channel - 1 / 6) / np.pi) ** 2 - 0.5
+    locs = -0.3 * torch.sin(5 * wave_freq * (channel - 1 / 6) / torch.pi) ** 2 - 0.5
     scale = (
-        1 / (10 * scale_factor) * (0.75 + 0.25 * np.cos(10 * (0.3 + channel) / np.pi))
+        1 / (10 * scale_factor) * (0.75 + 0.25 * torch.cos(10 * (0.3 + channel) / torch.pi))
     )
     return locs, scale
 
 
-def target_new_novel_det_channels(channel, scale_factor=1.0, wave_freq=1, target=0.75):
+def target_new_novel_det_channels(channel: torch.Tensor, scale_factor: float = 1.0, wave_freq: float = 1, target: float = 0.75) -> torch.Tensor:
     """Get the target (i.e. threshold) for 2D synthetic novel_det(channel) function
         Keyword arguments:
-    channel -- 1D array of channel locations whose thresholds to return
+    channel -- 1D tensor of channel locations whose thresholds to return
     scale factor -- scale for the novel_det function, where higher is steeper/lower SD
     wave_freq -- frequency of location waveform on [-1,1]
     target -- target threshold
     """
-    locs, scale = new_novel_det_channels_params(
-        channel, scale_factor, wave_freq, target
-    )
-    return norm.ppf(target, loc=locs, scale=scale)
+    locs, scale = new_novel_det_channels_params(channel, scale_factor, wave_freq, target)
+    normal_dist = torch.distributions.Normal(locs, scale)
+    return normal_dist.icdf(torch.tensor(target))
 
 
-def new_novel_det_channels(x, channel, scale_factor=1.0, wave_freq=1, target=0.75):
+def new_novel_det_channels(x: torch.Tensor, channel: torch.Tensor, scale_factor: float = 1.0, wave_freq: float = 1, target: float = 0.75) -> torch.Tensor:
     """Get the 2D synthetic novel_det(channel) function
         Keyword arguments:
-    x -- array of shape (n,2) of locations to sample;
+    x -- tensor of shape (n,2) of locations to sample;
          x[...,0] is channel from -1 to 1; x[...,1] is intensity from -1 to 1
     scale factor -- scale for the novel_det function, where higher is steeper/lower SD
     wave_freq -- frequency of location waveform on [-1,1]
     """
-    locs, scale = new_novel_det_channels_params(
-        channel, scale_factor, wave_freq, target
-    )
-    return (x - locs) / scale
+    locs, scale = new_novel_det_channels_params(channel, scale_factor, wave_freq, target)
+    return (x[..., 1] - locs) / scale
 
 
-def cdf_new_novel_det_channels(channel, scale_factor=1.0, wave_freq=1, target=0.75):
+def cdf_new_novel_det_channels(x: torch.Tensor, channel: torch.Tensor, scale_factor: float = 1.0, wave_freq: float = 1, target: float = 0.75) -> torch.Tensor:
     """Get the cdf for 2D synthetic novel_det(channel) function
         Keyword arguments:
-    x -- array of shape (n,2) of locations to sample;
+    x -- tensor of shape (n,2) of locations to sample;
          x[...,0] is channel from -1 to 1; x[...,1] is intensity from -1 to 1
     scale factor -- scale for the novel_det function, where higher is steeper/lower SD
     wave_freq -- frequency of location waveform on [-1,1]
     """
-    return norm.cdf(new_novel_det_channels(channel, scale_factor, wave_freq, target))
+    z = new_novel_det_channels(x, channel, scale_factor, wave_freq, target)
+    normal_dist = torch.distributions.Normal(0, 1)  # Standard normal distribution
+    return normal_dist.cdf(z)
 
-
-def new_novel_det_3D_params(x, scale_factor=1.0):
+def new_novel_det_3D_params(x: torch.Tensor, scale_factor: float = 1.0) -> Tuple[torch.Tensor, torch.Tensor]:
     freq = x[..., 0]
     chan = x[..., 1]
-    locs_freq = -0.32 + 2 * (0.66 * np.power(0.8 * freq * (0.2 * freq - 1), 2) + 0.05)
+    locs_freq = -0.32 + 2 * (0.66 * torch.pow(0.8 * freq * (0.2 * freq - 1), 2) + 0.05)
     locs = (
-        0.7 * ((-0.35 * np.sin(5 * (chan - 1 / 6) / np.pi) ** 2) - 0.5)
+        0.7 * ((-0.35 * torch.sin(5 * (chan - 1 / 6) / torch.pi) ** 2) - 0.5)
         + 0.9 * locs_freq
     )
     scale = 0.3 * locs / (3 * scale_factor) * 1 / (10 * scale_factor) + 0.15 * (
-        0.75 + 0.25 * np.cos(10 * (0.6 + chan) / np.pi)
+        0.75 + 0.25 * torch.cos(10 * (0.6 + chan) / torch.pi)
     )
     return locs, scale
 
 
-def new_novel_det_3D(x, scale_factor=1.0):
+def new_novel_det_3D(x: torch.Tensor, scale_factor: float = 1.0) -> torch.Tensor:
     """
-    Get the synthetic 3D novel_det
-    function over freqs,channels and amplitudes
-
+    Get the synthetic 3D novel_det function over freqs, channels, and amplitudes.
     """
     locs, scale = new_novel_det_3D_params(x, scale_factor)
     return (x[..., 2] - locs) / scale
 
 
-def cdf_new_novel_det_3D(x, scale_factor=1.0):
+def cdf_new_novel_det_3D(x: torch.Tensor, scale_factor: float = 1.0) -> torch.Tensor:
     """
     Get the cdf for 3D synthetic novel_det function
 
-    x -- array of shape (n,3) of locations to sample
+    x -- tensor of shape (n,3) of locations to sample
          x[...,0] is frequency, x[...,1] is channel, x[...,2] is intensity
 
     scale factor -- scale for the novel_det function, where higher is steeper/lower SD
     """
-    return norm.cdf(new_novel_det_3D(x, scale_factor))
+    z = new_novel_det_3D(x, scale_factor)
+    normal_dist = torch.distributions.Normal(0, 1)  # Standard normal distribution
+    return normal_dist.cdf(z)
 
 
-def target_new_novel_det_3D(x, scale_factor=1.0, target=0.75):
+def target_new_novel_det_3D(x: torch.Tensor, scale_factor: float = 1.0, target: float = 0.75) -> torch.Tensor:
     """
     Get target for 3D synthetic novel_det function at location x
 
-    x -- array of shape (n,2) of locations to sample
+    x -- tensor of shape (n,2) of locations to sample
          x[...,0] is frequency, x[...,1] is channel,
 
     scale factor -- scale for the novel_det function, where higher is steeper/lower SD
     target -- target threshold
-
     """
     locs, scale = new_novel_det_3D_params(x, scale_factor)
-    return norm.ppf(target, loc=locs, scale=scale)
+    normal_dist = torch.distributions.Normal(locs, scale)
+    return normal_dist.icdf(torch.tensor(target))
 
 
-def f_pairwise(f, x, noise_scale=1):
-    return norm.cdf((f(x[..., 1]) - f(x[..., 0])) / (noise_scale * np.sqrt(2)))
+def f_pairwise(f, x: torch.Tensor, noise_scale: float = 1) -> torch.Tensor:
+    normal_dist = torch.distributions.Normal(0, 1)
+    return normal_dist.cdf((f(x[..., 1]) - f(x[..., 0])) / (noise_scale * torch.sqrt(torch.tensor(2.0))))

--- a/aepsych/benchmark/test_functions.py
+++ b/aepsych/benchmark/test_functions.py
@@ -119,7 +119,7 @@ def make_songetal_testfun(
     threshfun = make_songetal_threshfun(x, y)
 
     # now make it into a test function
-    def song_testfun(x: torch.Tensor, cdf: bool = False) -> torch.Tensor:
+    def song_testfun(x, cdf = False):
         logfreq = x[..., 0]
         intensity = x[..., 1]
         thresh = threshfun(2 ** logfreq)
@@ -291,7 +291,12 @@ def cdf_new_novel_det(x: torch.Tensor, scale_factor: float = 1.0) -> torch.Tenso
     return normal_dist.cdf(z)
 
 
-def new_novel_det_channels_params(channel: torch.Tensor, scale_factor: float = 1.0, wave_freq: float = 1, target: float = 0.75) -> Tuple[torch.Tensor, torch.Tensor]:
+def new_novel_det_channels_params(
+        channel: torch.Tensor, 
+        scale_factor: float = 1.0, 
+        wave_freq: float = 1, 
+        target: float = 0.75
+        ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Get the target parameters for 2D synthetic novel_det(channel) function
         Keyword arguments:
     channel -- 1D tensor of channel locations whose thresholds to return
@@ -394,6 +399,6 @@ def target_new_novel_det_3D(x: torch.Tensor, scale_factor: float = 1.0, target: 
     return normal_dist.icdf(torch.tensor(target))
 
 
-def f_pairwise(f, x: torch.Tensor, noise_scale: float = 1) -> torch.Tensor:
+def f_pairwise(f: Callable, x: torch.Tensor, noise_scale: float = 1) -> torch.Tensor:
     normal_dist = torch.distributions.Normal(0, 1)
     return normal_dist.cdf((f(x[..., 1]) - f(x[..., 0])) / (noise_scale * torch.sqrt(torch.tensor(2.0))))

--- a/tests/acquisition/test_mi.py
+++ b/tests/acquisition/test_mi.py
@@ -69,11 +69,13 @@ class SingleProbitMI(unittest.TestCase):
 
         zhat, _ = strat.predict(x)
 
-        true = f_1d(x.detach().numpy())
-        est = zhat.detach().numpy()
+        true = f_1d(x)
+        est = zhat
 
         # close enough!
-        self.assertTrue((((norm.cdf(est) - true) ** 2).mean()) < 0.25)
+        normal_dist = torch.distributions.Normal(0, 1)
+        self.assertTrue((((normal_dist.cdf(est) - true) ** 2).mean()) < 0.25)
+
 
     def test_1d_single_probit(self):
 
@@ -117,11 +119,12 @@ class SingleProbitMI(unittest.TestCase):
 
         zhat, _ = strat.predict(x)
 
-        true = f_1d(x.detach().numpy())
-        est = zhat.detach().numpy()
+        true = f_1d(x)
+        est = zhat
 
         # close enough!
-        self.assertTrue((((norm.cdf(est) - true) ** 2).mean()) < 0.25)
+        normal_dist = torch.distributions.Normal(0, 1)
+        self.assertTrue((((normal_dist.cdf(est) - true) ** 2).mean()) < 0.25)
 
     def test_mi_acqf(self):
 

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -387,9 +387,12 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
                 next_pair, [bernoulli.rvs(f_pairwise(new_novel_det, next_pair))]
             )
 
-        xy = np.mgrid[-1:1:30j, -1:1:30j].reshape(2, -1).T
+        xy = torch.stack(torch.meshgrid(
+                torch.linspace(-1, 1, 30),
+                torch.linspace(-1, 1, 30)
+            ), dim=-1).view(-1, 2)
 
-        zhat, _ = strat.predict(torch.Tensor(xy))
+        zhat, _ = strat.predict(xy)
 
         ztrue = new_novel_det(xy)
 
@@ -505,7 +508,10 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
 
         for _i in range(n_init + n_opt):
             next_config = ask(server)
-            next_y = bernoulli.rvs(f_pairwise(f_1d, next_config["x"], noise_scale=0.1))
+        
+            next_x = torch.tensor(next_config["x"], dtype=torch.float32)
+            
+            next_y = bernoulli.rvs(f_pairwise(f_1d, next_x, noise_scale=0.1))
             tell(server, config=next_config, outcome=next_y)
 
         x = torch.linspace(-4, 4, 100)
@@ -555,7 +561,7 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
         )
         for _i in range(n_init + n_opt):
             next_config = ask(server)
-            next_pair = np.c_[next_config["x"], next_config["y"]].T
+            next_pair = torch.stack((torch.tensor(next_config["x"]), torch.tensor(next_config["y"])), dim=0)
             next_y = bernoulli.rvs(f_pairwise(f_2d, next_pair, noise_scale=0.1))
             tell(server, config=next_config, outcome=next_y)
 
@@ -607,7 +613,9 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
 
         for _i in range(n_init + n_opt):
             next_config = ask(server)
-            next_y = bernoulli.rvs(f_pairwise(f_1d, next_config["x"]))
+            next_x = torch.tensor(next_config["x"], dtype=torch.float32)
+            
+            next_y = bernoulli.rvs(f_pairwise(f_1d, next_x))
             tell(server, config=next_config, outcome=next_y)
 
         import dill
@@ -669,7 +677,7 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
 
         for _i in range(n_init + n_opt):
             next_config = ask(server)
-            next_pair = np.c_[next_config["x"], next_config["y"]].T
+            next_pair = torch.stack((torch.tensor(next_config["x"]), torch.tensor(next_config["y"])), dim=0)
             next_y = bernoulli.rvs(f_pairwise(f_2d, next_pair))
             tell(server, config=next_config, outcome=next_y)
 

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -509,7 +509,7 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
         for _i in range(n_init + n_opt):
             next_config = ask(server)
         
-            next_x = torch.tensor(next_config["x"], dtype=torch.float32)
+            next_x = torch.tensor(next_config["x"], dtype=torch.float64)
             
             next_y = bernoulli.rvs(f_pairwise(f_1d, next_x, noise_scale=0.1))
             tell(server, config=next_config, outcome=next_y)
@@ -613,7 +613,7 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
 
         for _i in range(n_init + n_opt):
             next_config = ask(server)
-            next_x = torch.tensor(next_config["x"], dtype=torch.float32)
+            next_x = torch.tensor(next_config["x"], dtype=torch.float64)
             
             next_y = bernoulli.rvs(f_pairwise(f_1d, next_x))
             tell(server, config=next_config, outcome=next_y)


### PR DESCRIPTION
Partially Solving #365 :


- Converted all functions in `test_functions.py` to use PyTorch tensors for both inputs and outputs, ensuring compatibility with PyTorch workflows.
- Retained NumPy for specific cases like interpolation in functions such as `make_songetal_threshfun` and `make_songetal_testfun`, as there is no direct PyTorch implementation for `CubicSpline` and `interp1d`, so SciPy is still used with NumPy arrays internally.
- Added type hints to improve overall code robustness and support static linting.
- Made minor changes to `test_pairwise_probit.py` and `test_mi.py` to adapt to the new tensor structures in `test_functions.py` and ensure smooth integration.






