### PR TITLE
set default inducing_size to 99 everywhere in GPClassificationModels

### DIFF
--- a/aepsych/models/gp_classification.py
+++ b/aepsych/models/gp_classification.py
@@ -53,7 +53,7 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP):
         mean_module: Optional[gpytorch.means.Mean] = None,
         covar_module: Optional[gpytorch.kernels.Kernel] = None,
         likelihood: Optional[Likelihood] = None,
-        inducing_size: int = 100,
+        inducing_size: Optional[int] = None,
         max_fit_time: Optional[float] = None,
         inducing_point_method: str = "auto",
     ):
@@ -69,7 +69,7 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP):
                 gamma prior.
             likelihood (gpytorch.likelihood.Likelihood, optional): The likelihood function to use. If None defaults to
                 Bernouli likelihood.
-            inducing_size (int): Number of inducing points. Defaults to 100.
+            inducing_size (int, optional): Number of inducing points. Defaults to 99.
             max_fit_time (float, optional): The maximum amount of time, in seconds, to spend fitting the model. If None,
                 there is no limit to the fitting time.
             inducing_point_method (string): The method to use to select the inducing points. Defaults to "auto".
@@ -80,7 +80,16 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP):
         """
         self.lb, self.ub, self.dim = _process_bounds(lb, ub, dim)
         self.max_fit_time = max_fit_time
-        self.inducing_size = inducing_size
+        self.inducing_size = inducing_size or 99
+
+        if self.inducing_size >= 100:
+            logger.warning(
+                (
+                    "inducing_size in GPClassificationModel is >=100, more inducing points "
+                    "can lead to better fits but slower performance in general. Performance "
+                    "at >=100 inducing points is especially slow."
+                )
+            )
 
         if likelihood is None:
             likelihood = BernoulliLikelihood()
@@ -130,7 +139,7 @@ class GPClassificationModel(AEPsychMixin, ApproximateGP):
         """
 
         classname = cls.__name__
-        inducing_size = config.getint(classname, "inducing_size", fallback=10)
+        inducing_size = config.getint(classname, "inducing_size", fallback=None)
 
         lb = config.gettensor(classname, "lb")
         ub = config.gettensor(classname, "ub")
@@ -310,7 +319,7 @@ class GPBetaRegressionModel(GPClassificationModel):
         mean_module: Optional[gpytorch.means.Mean] = None,
         covar_module: Optional[gpytorch.kernels.Kernel] = None,
         likelihood: Optional[Likelihood] = None,
-        inducing_size: int = 100,
+        inducing_size: Optional[int] = None,
         max_fit_time: Optional[float] = None,
         inducing_point_method: str = "auto",
     ):

--- a/aepsych/models/monotonic_projection_gp.py
+++ b/aepsych/models/monotonic_projection_gp.py
@@ -101,7 +101,7 @@ class MonotonicProjectionGP(GPClassificationModel):
         mean_module: Optional[gpytorch.means.Mean] = None,
         covar_module: Optional[gpytorch.kernels.Kernel] = None,
         likelihood: Optional[Likelihood] = None,
-        inducing_size: int = 100,
+        inducing_size: Optional[int] = None,
         max_fit_time: Optional[float] = None,
         inducing_point_method: str = "auto",
     ):
@@ -189,7 +189,7 @@ class MonotonicProjectionGP(GPClassificationModel):
         """
 
         classname = cls.__name__
-        inducing_size = config.getint(classname, "inducing_size", fallback=10)
+        inducing_size = config.getint(classname, "inducing_size", fallback=None)
 
         lb = config.gettensor(classname, "lb")
         ub = config.gettensor(classname, "ub")

--- a/aepsych/models/semi_p.py
+++ b/aepsych/models/semi_p.py
@@ -181,7 +181,7 @@ class SemiParametricGPModel(GPClassificationModel):
         covar_module: Optional[gpytorch.kernels.Kernel] = None,
         likelihood: Optional[Any] = None,
         slope_mean: float = 2,
-        inducing_size: int = 100,
+        inducing_size: Optional[int] = None,
         max_fit_time: Optional[float] = None,
         inducing_point_method: str = "auto",
     ):
@@ -199,7 +199,7 @@ class SemiParametricGPModel(GPClassificationModel):
                 gamma prior.
             likelihood (gpytorch.likelihood.Likelihood, optional): The likelihood function to use. If None defaults to
                 linear-Bernouli likelihood with probit link.
-            inducing_size (int): Number of inducing points. Defaults to 100.
+            inducing_size (int): Number of inducing points. Defaults to 99.
             max_fit_time (float, optional): The maximum amount of time, in seconds, to spend fitting the model. If None,
                 there is no limit to the fitting time.
             inducing_point_method (string): The method to use to select the inducing points. Defaults to "auto".
@@ -264,7 +264,7 @@ class SemiParametricGPModel(GPClassificationModel):
         """
 
         classname = cls.__name__
-        inducing_size = config.getint(classname, "inducing_size", fallback=100)
+        inducing_size = config.getint(classname, "inducing_size", fallback=None)
 
         lb = config.gettensor(classname, "lb")
         ub = config.gettensor(classname, "ub")
@@ -428,7 +428,7 @@ class HadamardSemiPModel(GPClassificationModel):
         offset_covar_module: Optional[gpytorch.kernels.Kernel] = None,
         likelihood: Optional[Likelihood] = None,
         slope_mean: float = 2,
-        inducing_size: int = 100,
+        inducing_size: Optional[int] = None,
         max_fit_time: Optional[float] = None,
         inducing_point_method: str = "auto",
     ):
@@ -445,7 +445,7 @@ class HadamardSemiPModel(GPClassificationModel):
             offset_mean_module (gpytorch.means.Mean, optional): Mean module to use (default: constant mean) for offset.
             offset_covar_module (gpytorch.kernels.Kernel, optional): Covariance kernel to use (default: scaled RBF) for offset.
             likelihood (gpytorch.likelihood.Likelihood, optional)): defaults to bernoulli with logistic input and a floor of .5
-            inducing_size (int): Number of inducing points. Defaults to 100.
+            inducing_size (int): Number of inducing points. Defaults to 99.
             max_fit_time (float, optional): The maximum amount of time, in seconds, to spend fitting the model. If None,
                 there is no limit to the fitting time.
             inducing_point_method (string): The method to use to select the inducing points. Defaults to "auto".
@@ -554,7 +554,7 @@ class HadamardSemiPModel(GPClassificationModel):
         """
 
         classname = cls.__name__
-        inducing_size = config.getint(classname, "inducing_size", fallback=100)
+        inducing_size = config.getint(classname, "inducing_size", fallback=None)
 
         lb = config.gettensor(classname, "lb")
         ub = config.gettensor(classname, "ub")

--- a/tests/models/test_gp_classification.py
+++ b/tests/models/test_gp_classification.py
@@ -809,7 +809,9 @@ class GPClassificationTest(unittest.TestCase):
             self.assertTrue(name1 == name2)
             self.assertTrue(isinstance(parent1, type(parent2)))
             self.assertTrue(isinstance(prior1, type(prior2)))
-            # no obvious way to test paramtransform equivalence
+            # no obvious way to test paramtransform equivalence)
+
+        self.assertTrue(m1.inducing_size == m2.inducing_size)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
Inducing sizes for GPClassification Models (and it's children) had different defaults, dependent on whether they were initialized via the from_config class method or a normal __init__.

This is changed to always be the same, respecting the default as defined in the __init__.

Additionally, GPClassificationModels now use a default inducing_size of 99. This is because when inducing_size>=100 and the n>=100, model fitting takes extremely long. We warn the user when inducing_size is above 100.

Differential Revision: D64728394


