### PR TITLE
Allow GPClassificationModel to run on GPU + basic GPU prep

### DIFF
--- a/aepsych/models/monotonic_projection_gp.py
+++ b/aepsych/models/monotonic_projection_gp.py
@@ -166,9 +166,7 @@ class MonotonicProjectionGP(GPClassificationModel):
         )
         return GPyTorchPosterior(mvn_proj)
 
-    def sample(
-        self, x: torch.Tensor, num_samples: int
-    ) -> torch.Tensor:
+    def sample(self, x: torch.Tensor, num_samples: int) -> torch.Tensor:
         samps = super().sample(x=x, num_samples=num_samples)
         if self.min_f_val is not None:
             samps = samps.clamp(min=self.min_f_val)

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -13,8 +13,10 @@ from typing import List, Mapping, Optional, Tuple, Union
 import numpy as np
 import torch
 from botorch.acquisition import PosteriorMean
-from botorch.acquisition.objective import PosteriorTransform
-from botorch.acquisition.objective import ScalarizedPosteriorTransform
+from botorch.acquisition.objective import (
+    PosteriorTransform,
+    ScalarizedPosteriorTransform,
+)
 from botorch.models.model import Model
 from botorch.models.utils.inducing_point_allocators import GreedyVarianceReduction
 from botorch.optim import optimize_acqf
@@ -69,9 +71,11 @@ def select_inducing_points(
 
         if method == "sobol":
             assert bounds is not None, "Must pass bounds for sobol inducing points!"
-            inducing_points = draw_sobol_samples(
-                bounds=bounds, n=inducing_size, q=1
-            ).squeeze()
+            inducing_points = (
+                draw_sobol_samples(bounds=bounds, n=inducing_size, q=1)
+                .squeeze()
+                .to(bounds)
+            )
             if len(inducing_points.shape) == 1:
                 inducing_points = inducing_points.reshape(-1, 1)
             return inducing_points
@@ -93,13 +97,13 @@ def select_inducing_points(
                 covar_module=covar_module,
                 num_inducing=inducing_size,
                 input_batch_shape=torch.Size([]),
-            )
+            ).to(X)
         elif method == "kmeans++":
             # initialize using kmeans
             inducing_points = torch.tensor(
-                kmeans2(unique_X.numpy(), inducing_size, minit="++")[0],
+                kmeans2(unique_X.cpu().numpy(), inducing_size, minit="++")[0],
                 dtype=X.dtype,
-            )
+            ).to(X)
         return inducing_points
 
 


### PR DESCRIPTION
Summary:
We should be able to use GPUs easily by ensuring all the right objects are on GPUs when available.

This diff allows GPClassificationModel to run on the GPU as well as adds the facilities to move all other models and generators to GPU in later diffs. As a part of this process, we can begin taking out methods from AEPsychMixin to eventually make the Mixin class sensible (and not do very very different things).

Differential Revision: D64510660


