### PR TITLE
pass transforms around instead of making duplicates

### DIFF
--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -468,11 +468,15 @@ class Strategy(object):
         stimuli_per_trial = config.getint(name, "stimuli_per_trial", fallback=1)
         outcome_types = config.getlist(name, "outcome_types", element_type=str)
 
-        generator = ParameterTransformedGenerator.from_config(config, name)
+        generator = ParameterTransformedGenerator.from_config(
+            config, name, options={"transforms": transforms}
+        )
 
         model_cls = config.getobj(name, "model", fallback=None)
         if model_cls is not None:
-            model = ParameterTransformedModel.from_config(config, name)
+            model = ParameterTransformedModel.from_config(
+                config, name, options={"transforms": transforms}
+            )
             use_gpu_modeling = config.getboolean(
                 model._base_obj.__class__.__name__, "use_gpu", fallback=False
             )

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -183,6 +183,8 @@ class ParameterTransformedGenerator(ParameterTransformWrapper, ConfigurableMixin
         being set in init (e.g., `Wrapper(Type, lb=lb, ub=ub)`, `lb` and `ub`
         should be in the raw parameter space.
 
+        The object's name will be ParameterTransformed<Generator.__name__>.
+
         Args:
             model (Type | AEPsychGenerator): Generator to wrap, this could either be a
                 completely initialized generator or just the generator class. An
@@ -277,16 +279,21 @@ class ParameterTransformedGenerator(ParameterTransformWrapper, ConfigurableMixin
         """
         if options is None:
             options = {}
+            options["transforms"] = ParameterTransforms.from_config(config)
         else:
+            # Check if there's a transform already if so save it to it persists over copying
+            if "transforms" in options:
+                transforms = options["transforms"]
+            else:
+                transforms = ParameterTransforms.from_config(config)
+
             options = deepcopy(options)
+            options["transforms"] = transforms
 
         if name is None:
             raise ValueError("name of strategy must be set to initialize a generator")
         else:
             gen_cls = config.getobj(name, "generator")
-
-        if "transforms" not in options:
-            options["transforms"] = ParameterTransforms.from_config(config)
 
         # Transform config
         transformed_config = transform_options(config, options["transforms"])
@@ -322,6 +329,8 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
         correctly transformed and in a correctly shaped Tensor. If the bounds are
         being set in init (e.g., `Wrapper(Type, lb=lb, ub=ub)`, `lb` and `ub`
         should be in the raw parameter space.
+
+        The object's name will be ParameterTransformed<Model.__name__>.
 
         Args:
             model (Type | ModelProtocol): Model to wrap, this could either be a
@@ -669,16 +678,21 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
         """
         if options is None:
             options = {}
+            options["transforms"] = ParameterTransforms.from_config(config)
         else:
+            # Check if there's a transform already if so save it to it persists over copying
+            if "transforms" in options:
+                transforms = options["transforms"]
+            else:
+                transforms = ParameterTransforms.from_config(config)
+
             options = deepcopy(options)
+            options["transforms"] = transforms
 
         if name is None:
             raise ValueError("name of strategy must be set to initialize a model")
         else:
             model_cls = config.getobj(name, "model")
-
-        if "transforms" not in options:
-            options["transforms"] = ParameterTransforms.from_config(config)
 
         # Transform config
         transformed_config = transform_options(config, options["transforms"])

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -105,6 +105,14 @@ class TransformsConfigTest(unittest.TestCase):
 
     def test_transforms_in_strategy(self):
         for _strat in self.strat.strat_list:
+            # Check if the same transform is passed around everywhere
+            self.assertTrue(id(_strat.transforms) == id(_strat.generator.transforms))
+            if _strat.model is not None:
+                self.assertTrue(
+                    id(_strat.generator.transforms) == id(_strat.model.transforms)
+                )
+
+            # Check all the transform bits are the same
             for strat_transform, gen_transform in zip(
                 _strat.transforms.items(), _strat.generator.transforms.items()
             ):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -111,6 +111,38 @@ class TransformsConfigTest(unittest.TestCase):
                 self.assertTrue(strat_transform[0] == gen_transform[0])
                 self.assertTrue(type(strat_transform[1]) is type(gen_transform[1]))
 
+    def test_options_override(self):
+        config_str = """
+            [common]
+            parnames = [signal1, signal2]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+            target = 0.75
+
+            [signal1]
+            par_type = continuous
+            lower_bound = 0
+            upper_bound = 1
+            log_scale = false
+
+            [signal2]
+            par_type = continuous
+            lower_bound = 1
+            upper_bound = 100
+            log_scale = True
+            """
+        config = Config()
+        config.update(config_str=config_str)
+
+        override = {
+            "indices": [0],
+            "constant": 5,
+        }
+        transform = Log10Plus.from_config(config, "signal2", override)
+
+        self.assertTrue(transform.constant == 5)
+        self.assertTrue(transform.indices[0] == 0)
+
 
 class TransformsLog10Test(unittest.TestCase):
     def test_transform_reshape(self):


### PR DESCRIPTION
Summary: Instead of creating duplicate transforms whenever we need one, we create a single transform from the config and initialize the wrapped model and wrapped generators with that one transform. This passes the same transform object around and allows the transformations to learn parameters and still be synced up across wrapped objects.

Differential Revision: D65155103


