### PR TITLE
Enhance Docstrings in `aepsych/likelihoods`

### DIFF
--- a/aepsych/likelihoods/bernoulli.py
+++ b/aepsych/likelihoods/bernoulli.py
@@ -18,15 +18,35 @@ class BernoulliObjectiveLikelihood(_OneDimensionalLikelihood):
     """
 
     def __init__(self, objective: Callable) -> None:
+        """Initialize BernoulliObjectiveLikelihood.
+        
+        Args:
+            objective (Callable): Objective function that maps function samples to probabilities."""
         super().__init__()
         self.objective = objective
 
     def forward(self, function_samples: torch.Tensor, **kwargs: Any) -> torch.distributions.Bernoulli:
+        """Forward pass for BernoulliObjectiveLikelihood.
+
+        Args:
+            function_samples (torch.Tensor): Function samples.
+
+        Returns:
+            torch.distributions.Bernoulli: Bernoulli distribution object.
+        """
         output_probs = self.objective(function_samples)
         return torch.distributions.Bernoulli(probs=output_probs)
 
     @classmethod
     def from_config(cls, config: Config) -> 'BernoulliObjectiveLikelihood':
+        """Create an instance from a configuration object.
+        
+        Args:
+            config (Config): Configuration object.
+            
+        Returns:
+            BernoulliObjectiveLikelihood: BernoulliObjectiveLikelihood instance.
+        """
         objective_cls = config.getobj(cls.__name__, "objective")
         objective = objective_cls.from_config(config)
         return cls(objective=objective)

--- a/aepsych/likelihoods/ordinal.py
+++ b/aepsych/likelihoods/ordinal.py
@@ -24,6 +24,12 @@ class OrdinalLikelihood(Likelihood):
     """
 
     def __init__(self, n_levels: int, link: Optional[Callable] = None) -> None:
+        """Initialize OrdinalLikelihood.
+        
+        Args:
+            n_levels (int): Number of levels in the ordinal scale.
+            link (Optional[Callable], optional): Link function. Defaults to None.
+        """
         super().__init__()
         self.n_levels = n_levels
         self.register_parameter(
@@ -42,6 +48,14 @@ class OrdinalLikelihood(Likelihood):
         return torch.cat((torch.tensor([0]), torch.cumsum(cutpoint_deltas, 0)))
 
     def forward(self, function_samples: torch.Tensor, *params, **kwargs) -> Categorical:
+        """Forward pass for Ordinal
+        
+        Args:
+            function_samples (torch.Tensor): Function samples.
+            
+        Returns:
+            Categorical: Categorical distribution object.
+        """
 
         # this whole thing can probably be some clever batched thing, meh
         probs = torch.zeros(*function_samples.size(), self.n_levels)
@@ -58,6 +72,13 @@ class OrdinalLikelihood(Likelihood):
 
     @classmethod
     def from_config(cls, config: Config) -> 'OrdinalLikelihood':
+        """Creates an instance fron configuration object
+        
+        Args:
+            config (Config): Configuration object.
+        
+        Returns:
+            OrdinalLikelihood: OrdinalLikelihood instance"""
         classname = cls.__name__
         n_levels = config.getint(classname, "n_levels")
         link = config.getobj(classname, "link", fallback=None)

--- a/aepsych/likelihoods/semi_p.py
+++ b/aepsych/likelihoods/semi_p.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
+from typing import Callable, Optional
 
 import torch
 from aepsych.acquisition.objective import AEPsychObjective, FloorProbitObjective
@@ -23,7 +23,7 @@ class LinearBernoulliLikelihood(_OneDimensionalLikelihood):
         """Initializes the linear bernoulli likelihood.
 
         Args:
-            objective (Callable, optional): Link function to use (sigma in the notation above).
+            objective (Optional[AEPsychObjective], optional): Link function to use (sigma in the notation above).
                 Defaults to probit with no floor.
         """
         super().__init__()
@@ -96,10 +96,26 @@ class LinearBernoulliLikelihood(_OneDimensionalLikelihood):
     def expected_log_prob(self, observations:torch.Tensor, function_dist: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         """This has to be overridden to fix a bug in gpytorch where the kwargs
         aren't being passed along to self.forward.
+
+        Args:
+            observations (torch.Tensor): Observations.
+            function_dist (torch.Tensor): Function distribution.
+
+
+        Returns:
+            torch.Tensor: Expected log probability.
         """
 
         # modified, TODO fixme upstream (cc @bletham)
-        def log_prob_lambda(function_samples):
+        def log_prob_lambda(function_samples: torch.Tensor) -> torch.Tensor:
+            """Lambda function to compute the log probability.
+            
+            Args:
+                function_samples (torch.Tensor): Function samples.
+                
+            Returns:
+                torch.Tensor: Log probability.
+            """
             return self.forward(function_samples, **kwargs).log_prob(observations)
 
         log_prob = self.quadrature(log_prob_lambda, function_dist)
@@ -107,6 +123,14 @@ class LinearBernoulliLikelihood(_OneDimensionalLikelihood):
 
     @classmethod
     def from_config(cls, config: Config) -> 'LinearBernoulliLikelihood':
+        """Create an instance from a configuration object.
+
+        Args:
+            config (Config): Configuration object.
+
+        Returns:
+            LinearBernoulliLikelihood: LinearBernoulliLikelihood instance.
+        """
         classname = cls.__name__
 
         objective = config.getobj(classname, "objective")


### PR DESCRIPTION
One of several PRs addressing issue #366 to improve docstring coverage.

Improves documentation in `aepsych/likelihoods` for better clarity and consistency.
- Adds missing docstrings to functions and methods across likelihood modules.
- Updates existing docstrings with refined type hints and a unified structure.