### PR TITLE
create workflow to automate pypi release

### DIFF
--- a/.github/workflows/build-to-release.yml
+++ b/.github/workflows/build-to-release.yml
@@ -1,0 +1,113 @@
+name: Build new release and publish to PyPI
+
+on: 
+  push:
+    branches: ['release']
+  workflow_dispatch:
+
+
+jobs:
+  build:
+    name: Build distribution from release branch
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: 'release'
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install pypa/build
+      run: >-
+        python3 -m pip install build --user
+
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+
+  publish-to-testpypi:
+    name: Publish dist to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/aepsych
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+        
+    - name: Publish dis to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+
+
+  test-dist:
+    name: Test distribtion from TestPyPI
+    needs: 
+      - publish-to-testpypi
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+        os: [macos-latest, windows-latest, macos-13]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: 'release'
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple "aepsych[dev]"
+
+    - name: Test with unittest
+      run: |
+        python -m unittest
+
+
+  publish-to-pypi:
+    name: >-
+      Publish dist to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - test-dist
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aepsych
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Summary:
adds a workflow that expects a release branch that when either pushed (or the workflow is activate), will:

* build a dist
* upload it to testpypi
* install the package from testpypi and  test
* upload to pypi

Differential Revision: D65291177


