### PR TITLE
Remove normalize_inputs and replace with parameter transform

### DIFF
--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -337,10 +337,6 @@ class AEPsychMixin(GPyTorchModel):
         if targets is not None:
             self.train_targets = targets
 
-    def normalize_inputs(self, x: torch.Tensor) -> torch.Tensor:
-        scale = self.ub - self.lb
-        return (x - self.lb) / scale
-
     def forward(self, x: torch.Tensor) -> gpytorch.distributions.MultivariateNormal:
         """Evaluate GP
 
@@ -351,9 +347,8 @@ class AEPsychMixin(GPyTorchModel):
             gpytorch.distributions.MultivariateNormal: Distribution object
                 holding mean and covariance at x.
         """
-        transformed_x = self.normalize_inputs(x)
-        mean_x = self.mean_module(transformed_x)
-        covar_x = self.covar_module(transformed_x)
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
         pred = gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
         return pred
 

--- a/aepsych/models/monotonic_rejection_gp.py
+++ b/aepsych/models/monotonic_rejection_gp.py
@@ -341,11 +341,7 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
             gpytorch.distributions.MultivariateNormal: Distribution object
                 holding mean and covariance at x.
         """
-
-        # final dim is deriv index, we only normalize the "real" dims
-        transformed_x = x.clone()
-        transformed_x[..., :-1] = self.normalize_inputs(transformed_x[..., :-1])
-        mean_x = self.mean_module(transformed_x)
-        covar_x = self.covar_module(transformed_x)
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
         latent_pred = gpytorch.distributions.MultivariateNormal(mean_x, covar_x)
         return latent_pred

--- a/aepsych/models/multitask_regression.py
+++ b/aepsych/models/multitask_regression.py
@@ -79,9 +79,8 @@ class MultitaskGPRModel(GPRegressionModel):
     def forward(
         self, x: torch.Tensor
     ) -> gpytorch.distributions.MultitaskMultivariateNormal:
-        transformed_x = self.normalize_inputs(x)
-        mean_x = self.mean_module(transformed_x)
-        covar_x = self.covar_module(transformed_x)
+        mean_x = self.mean_module(x)
+        covar_x = self.covar_module(x)
         return gpytorch.distributions.MultitaskMultivariateNormal(mean_x, covar_x)
 
     @classmethod

--- a/aepsych/models/semi_p.py
+++ b/aepsych/models/semi_p.py
@@ -529,18 +529,17 @@ class HadamardSemiPModel(GPClassificationModel):
         Returns:
             MVN object evaluated at samples
         """
-        transformed_x = self.normalize_inputs(x)
         # TODO: make slope prop to intensity width.
-        slope_mean = self.slope_mean_module(transformed_x)
+        slope_mean = self.slope_mean_module(x)
 
         # kc mvn
-        offset_mean = self.offset_mean_module(transformed_x)
+        offset_mean = self.offset_mean_module(x)
 
-        slope_cov = self.slope_covar_module(transformed_x)
-        offset_cov = self.offset_covar_module(transformed_x)
+        slope_cov = self.slope_covar_module(x)
+        offset_cov = self.offset_covar_module(x)
 
         mean_x, cov_x = _hadamard_mvn_approx(
-            x_intensity=transformed_x[..., self.stim_dim],
+            x_intensity=x[..., self.stim_dim],
             slope_mean=slope_mean,
             slope_cov=slope_cov,
             offset_mean=offset_mean,

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -179,6 +179,9 @@ def get_extremum(
         timeout_sec=max_time,
     )
 
+    if hasattr(model, "transforms"):
+        best_point = model.transforms.untransform(best_point)
+
     # PosteriorMean flips the sign on minimize, we flip it back
     if extremum_type == "min":
         best_val = -best_val

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -468,11 +468,15 @@ class Strategy(object):
         stimuli_per_trial = config.getint(name, "stimuli_per_trial", fallback=1)
         outcome_types = config.getlist(name, "outcome_types", element_type=str)
 
-        generator = ParameterTransformedGenerator.from_config(config, name)
+        generator = ParameterTransformedGenerator.from_config(
+            config, name, options={"transforms": transforms}
+        )
 
         model_cls = config.getobj(name, "model", fallback=None)
         if model_cls is not None:
-            model = ParameterTransformedModel.from_config(config, name)
+            model = ParameterTransformedModel.from_config(
+                config, name, options={"transforms": transforms}
+            )
             use_gpu_modeling = config.getboolean(
                 model._base_obj.__class__.__name__, "use_gpu", fallback=False
             )

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -183,6 +183,8 @@ class ParameterTransformedGenerator(ParameterTransformWrapper, ConfigurableMixin
         being set in init (e.g., `Wrapper(Type, lb=lb, ub=ub)`, `lb` and `ub`
         should be in the raw parameter space.
 
+        The object's name will be ParameterTransformed<Generator.__name__>.
+
         Args:
             model (Type | AEPsychGenerator): Generator to wrap, this could either be a
                 completely initialized generator or just the generator class. An
@@ -277,16 +279,21 @@ class ParameterTransformedGenerator(ParameterTransformWrapper, ConfigurableMixin
         """
         if options is None:
             options = {}
+            options["transforms"] = ParameterTransforms.from_config(config)
         else:
+            # Check if there's a transform already if so save it to it persists over copying
+            if "transforms" in options:
+                transforms = options["transforms"]
+            else:
+                transforms = ParameterTransforms.from_config(config)
+
             options = deepcopy(options)
+            options["transforms"] = transforms
 
         if name is None:
             raise ValueError("name of strategy must be set to initialize a generator")
         else:
             gen_cls = config.getobj(name, "generator")
-
-        if "transforms" not in options:
-            options["transforms"] = ParameterTransforms.from_config(config)
 
         # Transform config
         transformed_config = transform_options(config, options["transforms"])
@@ -322,6 +329,8 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
         correctly transformed and in a correctly shaped Tensor. If the bounds are
         being set in init (e.g., `Wrapper(Type, lb=lb, ub=ub)`, `lb` and `ub`
         should be in the raw parameter space.
+
+        The object's name will be ParameterTransformed<Model.__name__>.
 
         Args:
             model (Type | ModelProtocol): Model to wrap, this could either be a
@@ -669,16 +678,21 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
         """
         if options is None:
             options = {}
+            options["transforms"] = ParameterTransforms.from_config(config)
         else:
+            # Check if there's a transform already if so save it to it persists over copying
+            if "transforms" in options:
+                transforms = options["transforms"]
+            else:
+                transforms = ParameterTransforms.from_config(config)
+
             options = deepcopy(options)
+            options["transforms"] = transforms
 
         if name is None:
             raise ValueError("name of strategy must be set to initialize a model")
         else:
             model_cls = config.getobj(name, "model")
-
-        if "transforms" not in options:
-            options["transforms"] = ParameterTransforms.from_config(config)
 
         # Transform config
         transformed_config = transform_options(config, options["transforms"])

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -15,7 +15,6 @@ what parameter types are used and whatever transformations are used.
 Currently, we only support continuous parameters. More parameter types soon to come!
 
 <h3>Continuous<h3>
-
 ```ini
 [parameter]
 par_type = continuous
@@ -58,3 +57,31 @@ For parameters with lower bounds that are positive but still less 1, we will alw
 a constant value of 1 (i.e., `Log10(x + 1)` and `10 ^ (x - 1)`). For parameters with
 lower bounds that are negative, we will use a constant value of the absolute value of
 the lower bound + 1 (i.e., `Log10(x + |lb| + 1)` and `10 ^ (x - |lb| - 1)`).
+
+<h3>Normalize scale</h3>
+By default, all parameters will have their scale min-max normalized to the range of 
+[0, 1]. This prevents any particular parameter with a large scale to completely dominate
+the other parameters. Very rarely, this behavior may not be desired and can be turned 
+off for specific parameters.
+
+```ini
+[parameter]
+par_type = continuous
+lower_bound = 1 
+upper_bound = 100
+normalize_scale = False # turn it on with any of true/yes/on, turn it off with any of false/no/off; case insensitive
+```
+
+By setting the `normalize_scale` option to False, this parameter will not be scaled 
+before being given to the model and therefore maintain its original magnitude. This is
+very rarely necessary and should be used with caution. 
+
+<h2>Order of operations</h2>
+Parameter types and parameter-specific transforms are all handled by the 
+`ParameterTransform` API. Transforms built from config files will have a specific order
+of operation, regardless of how the options were set in the config file. Each parameter
+is transformed entirely separately. 
+
+Currently, the order is as follows:
+* Log scale
+* Normalize scale

--- a/tests/generators/test_manual_generator.py
+++ b/tests/generators/test_manual_generator.py
@@ -51,10 +51,9 @@ class TestManualGenerator(unittest.TestCase):
                 """
         config = Config()
         config.update(config_str=config_str)
-        # gen = ManualGenerator.from_config(config)
         gen = ParameterTransformedGenerator.from_config(config, "init_strat")
-        npt.assert_equal(gen.lb.numpy(), np.array([10, 10]))
-        npt.assert_equal(gen.ub.numpy(), np.array([11, 11]))
+        npt.assert_equal(gen.lb.numpy(), np.array([0, 0]))
+        npt.assert_equal(gen.ub.numpy(), np.array([1, 1]))
         self.assertFalse(gen.finished)
 
         p1 = list(gen.gen()[0])

--- a/tests/models/test_gp_regression.py
+++ b/tests/models/test_gp_regression.py
@@ -88,8 +88,8 @@ class GPRegressionTest(unittest.TestCase):
 
     def test_from_config(self):
         model = self.server.strat.model
-        npt.assert_allclose(model.lb, [-1.0])
-        npt.assert_allclose(model.ub, [3.0])
+        npt.assert_allclose(model.transforms.untransform(model.lb), [-1.0])
+        npt.assert_allclose(model.transforms.untransform(model.ub), [3.0])
         self.assertEqual(model.dim, 1)
         self.assertIsInstance(model.likelihood, GaussianLikelihood)
         self.assertEqual(model.max_fit_time, 1)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -105,6 +105,14 @@ class TransformsConfigTest(unittest.TestCase):
 
     def test_transforms_in_strategy(self):
         for _strat in self.strat.strat_list:
+            # Check if the same transform is passed around everywhere
+            self.assertTrue(id(_strat.transforms) == id(_strat.generator.transforms))
+            if _strat.model is not None:
+                self.assertTrue(
+                    id(_strat.generator.transforms) == id(_strat.model.transforms)
+                )
+
+            # Check all the transform bits are the same
             for strat_transform, gen_transform in zip(
                 _strat.transforms.items(), _strat.generator.transforms.items()
             ):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -111,6 +111,38 @@ class TransformsConfigTest(unittest.TestCase):
                 self.assertTrue(strat_transform[0] == gen_transform[0])
                 self.assertTrue(type(strat_transform[1]) is type(gen_transform[1]))
 
+    def test_options_override(self):
+        config_str = """
+            [common]
+            parnames = [signal1, signal2]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+            target = 0.75
+
+            [signal1]
+            par_type = continuous
+            lower_bound = 0
+            upper_bound = 1
+            log_scale = false
+
+            [signal2]
+            par_type = continuous
+            lower_bound = 1
+            upper_bound = 100
+            log_scale = True
+            """
+        config = Config()
+        config.update(config_str=config_str)
+
+        override = {
+            "indices": [0],
+            "constant": 5,
+        }
+        transform = Log10Plus.from_config(config, "signal2", override)
+
+        self.assertTrue(transform.constant == 5)
+        self.assertTrue(transform.indices[0] == 0)
+
 
 class TransformsLog10Test(unittest.TestCase):
     def test_transform_reshape(self):


### PR DESCRIPTION
Summary:
`normalize_inputs` (the one that min-max scales paraemters) is confusingly named (there's another `normalize_inputs` that concatenates data and ensures they're all the right types) and is a hard-coded transformation that is applied to all parameters. This means that there's no way to turn the behavior off selectively nor is it obvious that it is happening.

This diff removes the normalize_inputs method and replaces it with an parameter transform that will also allow selective application of the transform via an index.

Differential Revision: D65069497
