### PR TITLE
GPU support for generating points

### DIFF
--- a/aepsych/acquisition/bvn.py
+++ b/aepsych/acquisition/bvn.py
@@ -72,6 +72,7 @@ def _bvnu(
     hk = h * k
 
     x, w = _gauss_legendre20(dtype=dh.dtype)
+    x, w = x.to(dh), w.to(dh)
 
     asr = 0.5 * torch.asin(r)
     sn = torch.sin(asr[..., None] * x)

--- a/aepsych/acquisition/lookahead.py
+++ b/aepsych/acquisition/lookahead.py
@@ -34,7 +34,7 @@ def Hb(p: Tensor) -> Tensor:
 
     Returns: Binary entropy for each probability.
     """
-    epsilon = torch.tensor(np.finfo(float).eps)
+    epsilon = torch.tensor(np.finfo(float).eps).to(p)
     p = torch.clamp(p, min=epsilon, max=1 - epsilon)
     return -torch.nan_to_num(p * torch.log2(p) + (1 - p) * torch.log2(1 - p))
 
@@ -78,6 +78,8 @@ def SUR_fn(Px: Tensor, P1: Tensor, P0: Tensor, py1: Tensor) -> Tensor:
 
     Returns: (b) tensor of SUR values.
     """
+    P1 = P1.to(Px)
+    py1 = py1.to(Px)
     sur = ClassErr(Px) - py1 * ClassErr(P1) - (1 - py1) * ClassErr(P0)
     return sur.sum(dim=-1)
 

--- a/aepsych/acquisition/lookahead_utils.py
+++ b/aepsych/acquisition/lookahead_utils.py
@@ -144,7 +144,7 @@ def lookahead_p_at_xstar(
     pstar_marginal_0 = 1 - pstar_marginal_1
     pq_marginal_1 = probit(Mu_q / torch.sqrt(1 + Sigma2_q))
 
-    quad = GaussHermiteQuadrature1D()
+    quad = GaussHermiteQuadrature1D().to(Mu_q)
     fq_mvn = Normal(Mu_q, torch.sqrt(Sigma2_q))
     joint_ystar1_yq1 = quad(lookahead_inner, fq_mvn)
     joint_ystar0_yq1 = pq_marginal_1 - joint_ystar1_yq1

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -17,13 +17,13 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
-    Dict,
     List,
     Mapping,
     Optional,
     Sequence,
     TypeVar,
 )
+
 import botorch
 import gpytorch
 import numpy as np

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -100,7 +100,6 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
     ) -> torch.Tensor:
         # eval should be inherited from superclass
         model.eval()  # type: ignore
-        train_x = model.train_inputs[0]
         acqf = self._instantiate_acquisition_fn(model)
 
         logger.info("Starting gen...")
@@ -108,7 +107,7 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
 
         new_candidate, _ = optimize_acqf(
             acq_function=acqf,
-            bounds=torch.tensor(np.c_[model.lb, model.ub]).T.to(train_x),
+            bounds=torch.stack([model.lb, model.ub]),
             q=num_points,
             num_restarts=self.restarts,
             raw_samples=self.samps,

--- a/aepsych/likelihoods/bernoulli.py
+++ b/aepsych/likelihoods/bernoulli.py
@@ -19,7 +19,7 @@ class BernoulliObjectiveLikelihood(_OneDimensionalLikelihood):
 
     def __init__(self, objective: Callable) -> None:
         """Initialize BernoulliObjectiveLikelihood.
-        
+
         Args:
             objective (Callable): Objective function that maps function samples to probabilities."""
         super().__init__()
@@ -42,10 +42,10 @@ class BernoulliObjectiveLikelihood(_OneDimensionalLikelihood):
     @classmethod
     def from_config(cls, config: Config) -> "BernoulliObjectiveLikelihood":
         """Create an instance from a configuration object.
-        
+
         Args:
             config (Config): Configuration object.
-            
+
         Returns:
             BernoulliObjectiveLikelihood: BernoulliObjectiveLikelihood instance.
         """

--- a/aepsych/likelihoods/semi_p.py
+++ b/aepsych/likelihoods/semi_p.py
@@ -111,10 +111,10 @@ class LinearBernoulliLikelihood(_OneDimensionalLikelihood):
         # modified, TODO fixme upstream (cc @bletham)
         def log_prob_lambda(function_samples: torch.Tensor) -> torch.Tensor:
             """Lambda function to compute the log probability.
-            
+
             Args:
                 function_samples (torch.Tensor): Function samples.
-                
+
             Returns:
                 torch.Tensor: Log probability.
             """

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -10,8 +10,6 @@ from typing import Any, Callable, Iterable, List, Optional, Sized, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
-
-import torch
 from aepsych.strategy import Strategy
 from aepsych.utils import get_lse_contour, get_lse_interval, make_scaled_sobol
 from matplotlib.axes import Axes

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -21,7 +21,7 @@ def make_scaled_sobol(
     lb: torch.Tensor, ub: torch.Tensor, size: int, seed: Optional[int] = None
 ) -> torch.Tensor:
     lb, ub, ndim = _process_bounds(lb, ub, None)
-    grid = SobolEngine(dimension=ndim, scramble=True, seed=seed).draw(size)
+    grid = SobolEngine(dimension=ndim, scramble=True, seed=seed).draw(size).to(lb)
 
     # rescale from [0,1] to [lb, ub]
     grid = lb + (ub - lb) * grid
@@ -126,7 +126,6 @@ def interpolate_monotonic(x, y, z, min_x=-np.inf, max_x=np.inf):
     y1 = y[idx]
 
     x_star = x0 + (x1 - x0) * (z - y0) / (y1 - y0)
-
     return x_star
 
 

--- a/tests_gpu/generators/__init__.py
+++ b/tests_gpu/generators/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests_gpu/generators/test_optimize_acqf_generator.py
+++ b/tests_gpu/generators/test_optimize_acqf_generator.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from aepsych.acquisition import (
+    ApproxGlobalSUR,
+    EAVC,
+    GlobalMI,
+    GlobalSUR,
+    LocalMI,
+    LocalSUR,
+    MCLevelSetEstimation,
+    MCPosteriorVariance,
+)
+from aepsych.acquisition.lookahead import MOCU, SMOCU
+from aepsych.acquisition.mutual_information import BernoulliMCMutualInformation
+from aepsych.generators import OptimizeAcqfGenerator
+from aepsych.models import GPClassificationModel
+from aepsych.strategy import Strategy
+from parameterized import parameterized
+
+acqf_kwargs_target = {"target": 0.75}
+acqf_kwargs_lookahead = {"target": 0.75, "lookahead_type": "posterior"}
+
+acqfs = [
+    (MCPosteriorVariance, {}),
+    (ApproxGlobalSUR, acqf_kwargs_target),
+    (MOCU, acqf_kwargs_target),
+    (SMOCU, acqf_kwargs_target),
+    (EAVC, acqf_kwargs_target),
+    (EAVC, acqf_kwargs_lookahead),
+    (GlobalMI, acqf_kwargs_target),
+    (GlobalMI, acqf_kwargs_lookahead),
+    (GlobalSUR, acqf_kwargs_target),
+    (LocalMI, acqf_kwargs_target),
+    (LocalSUR, acqf_kwargs_target),
+    (MCLevelSetEstimation, acqf_kwargs_target),
+    (BernoulliMCMutualInformation, {}),
+]
+
+
+class TestOptimizeAcqfGenerator(unittest.TestCase):
+    @parameterized.expand(acqfs)
+    def test_gpu_smoketest(self, acqf, acqf_kwargs):
+        lb = torch.tensor([0])
+        ub = torch.tensor([1])
+        model = GPClassificationModel(
+            lb=lb, ub=ub, inducing_size=10, inducing_point_method="pivoted_chol"
+        )
+
+        generator = OptimizeAcqfGenerator(acqf=acqf, acqf_kwargs=acqf_kwargs)
+
+        strat = Strategy(
+            lb=torch.tensor([0]),
+            ub=torch.tensor([1]),
+            model=model,
+            generator=generator,
+            stimuli_per_trial=1,
+            outcome_types=["binary"],
+            min_asks=1,
+            use_gpu_modeling=True,
+            use_gpu_generating=True,
+        )
+
+        strat.add_data(x=torch.tensor([0.90]), y=torch.tensor([1.0]))
+
+        strat.gen(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_gpu/test_strategy.py
+++ b/tests_gpu/test_strategy.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
+from aepsych.generators import OptimizeAcqfGenerator, SobolGenerator
+from aepsych.models.gp_classification import GPClassificationModel
+from aepsych.strategy import Strategy
+
+
+class TestStrategyGPU(unittest.TestCase):
+    def test_gpu_no_model_generator_warn(self):
+        with self.assertWarns(UserWarning):
+            Strategy(
+                lb=[0],
+                ub=[1],
+                stimuli_per_trial=1,
+                outcome_types=["binary"],
+                min_asks=1,
+                generator=SobolGenerator(lb=[0], ub=[1]),
+                use_gpu_generating=True,
+            )
+
+    def test_no_gpu_acqf(self):
+        with self.assertWarns(UserWarning):
+            Strategy(
+                lb=[0],
+                ub=[1],
+                stimuli_per_trial=1,
+                outcome_types=["binary"],
+                min_asks=1,
+                model=GPClassificationModel(lb=[0], ub=[1]),
+                generator=OptimizeAcqfGenerator(acqf=MonotonicMCLSE),
+                use_gpu_generating=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Strategy can now move the model to the gpu to allow generators to enjoy speedups.

This behavior is not owned by the generator, but by the strategy. Future iterations can move this.

Differential Revision: D65361838


