### PR TITLE
Improve Docstrings in `aepsych/generators` and `aepsych/`

### DIFF
--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -33,6 +33,7 @@ from aepsych.version import __version__
 _T = TypeVar("_T")
 _ET = TypeVar("_ET")
 
+
 class Config(configparser.ConfigParser):
     # names in these packages can be referred to by string name
     registered_names: ClassVar[Dict[str, object]] = {}
@@ -132,10 +133,10 @@ class Config(configparser.ConfigParser):
     # Convert config into a dictionary (eliminate duplicates from defaulted 'common' section.)
     def to_dict(self, deduplicate: bool = True) -> Dict[str, Any]:
         """Convert the config into a dictionary.
-        
+
         Args:
             deduplicate (bool): Whether to deduplicate the 'common' section. Defaults to True.
-            
+
         Returns:
             dict: Dictionary representation of the config.
         """
@@ -151,7 +152,7 @@ class Config(configparser.ConfigParser):
     # Turn the metadata section into JSON.
     def jsonifyMetadata(self) -> str:
         """Turn the metadata section into JSON.
-        
+
         Returns:
             str: JSON representation of the metadata section.
         """
@@ -161,7 +162,7 @@ class Config(configparser.ConfigParser):
     # Turn the entire config into JSON format.
     def jsonifyAll(self) -> str:
         """Turn the entire config into JSON format.
-        
+
         Returns:
             str: JSON representation of the entire config.
         """
@@ -239,11 +240,11 @@ class Config(configparser.ConfigParser):
         self, v: str, element_type: Callable[[_ET], _ET] = float
     ) -> List[_T]:
         """Convert a string to a list.
-        
+
         Args:
             v (str): String to convert.
             element_type (Callable[[_ET], _ET]): Type of the elements in the list. Defaults to float.
-            
+
         Returns:
             List[_T]: List of elements of type _T.
         """
@@ -260,10 +261,10 @@ class Config(configparser.ConfigParser):
 
     def _str_to_array(self, v: str) -> np.ndarray:
         """Convert a string to a numpy array.
-        
+
         Args:
             v (str): String to convert.
-            
+
         Returns:
             np.ndarray: Numpy array representation of the string.
         """
@@ -370,7 +371,7 @@ class Config(configparser.ConfigParser):
 
     def __repr__(self) -> str:
         """Return a string representation of the config.
-        
+
         Returns:
             str: String representation of the config.
         """
@@ -410,10 +411,10 @@ class Config(configparser.ConfigParser):
 
     def get_section(self, section: str) -> Dict[str, Any]:
         """Get a section of the config.
-        
+
         Args:
             section (str): Section to get.
-            
+
         Returns:
             Dict[str, Any]: Dictionary representation of the section.
         """
@@ -533,7 +534,7 @@ class Config(configparser.ConfigParser):
     @property
     def version(self) -> str:
         """Returns the version number of the config.
-        
+
         Returns:
             str: Version number of the config.
         """

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -98,9 +98,9 @@ class Config(configparser.ConfigParser):
             section (str): Section to get the option from.
             conv (_T): Converter to use.
             option (str): Option to get.
-            raw (bool, optional): Whether to return the raw value. Defaults to False.
+            raw (bool): Whether to return the raw value. Defaults to False.
             vars (Dict[str, Any], optional): Optional dictionary to use for interpolation. Defaults to None.
-            fallback (_T, optional): Value to return if the option is not found. Defaults to configparser._UNSET.
+            fallback (_T): Value to return if the option is not found. Defaults to configparser._UNSET.
 
         Returns:
             _T: Converted value of the option.
@@ -134,7 +134,7 @@ class Config(configparser.ConfigParser):
         """Convert the config into a dictionary.
         
         Args:
-            deduplicate (bool, optional): Whether to deduplicate the 'common' section. Defaults to True.
+            deduplicate (bool): Whether to deduplicate the 'common' section. Defaults to True.
             
         Returns:
             dict: Dictionary representation of the config.
@@ -169,12 +169,12 @@ class Config(configparser.ConfigParser):
         """Update this object with a new configuration.
 
         Args:
-            config_dict (Mapping[str, str], optional): Mapping to build configuration from.
+            config_dict (Mapping[str, str]): Mapping to build configuration from.
                 Keys are section names, values are dictionaries with keys and values that
                 should be present in the section. Defaults to None.
-            config_fnames (Sequence[str], optional): List of INI filenames to load
+            config_fnames (Sequence[str]): List of INI filenames to load
                 configuration from. Defaults to None.
-            config_str (str, optional): String formatted as an INI file to load configuration
+            config_str (str): String formatted as an INI file to load configuration
                 from. Defaults to None.
         """
         if config_dict is not None:
@@ -278,8 +278,8 @@ class Config(configparser.ConfigParser):
 
         Args:
             v (str): String to convert.
-            fallback_type (_T, optional): Type to fallback to if the object is not found. Defaults to str.
-            warn (bool, optional): Whether to warn if the object is not found. Defaults to True.
+            fallback_type (_T): Type to fallback to if the object is not found. Defaults to str.
+            warn (bool): Whether to warn if the object is not found. Defaults to True.
 
         Returns:
             object: Object representation of the string.

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -77,13 +77,13 @@ class Config(configparser.ConfigParser):
 
     def _get(
         self,
-        section,
-        conv,
-        option,
+        section: str,
+        conv: _T,
+        option: str,
         *,
-        raw=False,
-        vars=None,
-        fallback=configparser._UNSET,
+        raw: bool = False,
+        vars: Optional[Dict[str, Any]] = None,
+        fallback: _T = configparser._UNSET,
         **kwargs,
     ):
         """
@@ -92,6 +92,19 @@ class Config(configparser.ConfigParser):
         up any time we have a module fully configured from the
         common/default section.
         2. Pass extra **kwargs to the converter.
+
+
+        Args:
+            section (str): Section to get the option from.
+            conv (_T): Converter to use.
+            option (str): Option to get.
+            raw (bool, optional): Whether to return the raw value. Defaults to False.
+            vars (Dict[str, Any], optional): Optional dictionary to use for interpolation. Defaults to None.
+            fallback (_T, optional): Value to return if the option is not found. Defaults to configparser._UNSET.
+
+        Returns:
+            _T: Converted value of the option.
+
         """
         try:
             return conv(
@@ -118,6 +131,14 @@ class Config(configparser.ConfigParser):
 
     # Convert config into a dictionary (eliminate duplicates from defaulted 'common' section.)
     def to_dict(self, deduplicate: bool = True) -> Dict[str, Any]:
+        """Convert the config into a dictionary.
+        
+        Args:
+            deduplicate (bool): Whether to deduplicate the 'common' section. Defaults to True.
+            
+        Returns:
+            dict: Dictionary representation of the config.
+        """
         _dict: Dict[str, Any] = {}
         for section in self:
             _dict[section] = {}
@@ -129,11 +150,13 @@ class Config(configparser.ConfigParser):
 
     # Turn the metadata section into JSON.
     def jsonifyMetadata(self) -> str:
+        """Turn the metadata section into JSON."""
         configdict = self.to_dict()
         return json.dumps(configdict["metadata"])
 
     # Turn the entire config into JSON format.
     def jsonifyAll(self) -> str:
+        """Turn the entire config into JSON format."""
         configdict = self.to_dict()
         return json.dumps(configdict)
 
@@ -205,8 +228,17 @@ class Config(configparser.ConfigParser):
             del self["experiment"]
 
     def _str_to_list(
-        self, v: str, element_type: Callable[[_T], _T] = float
+        self, v: str, element_type: _T = float
     ) -> List[_T]:
+        """Convert a string to a list.
+        
+        Args:
+            v (str): String to convert.
+            element_type (_T): Type of the elements in the list. Defaults to float.
+            
+        Returns:
+            List[_T]: List of elements of type _T.
+        """
         v = re.sub(r"\n ", ",", v)
         v = re.sub(r"(?<!,)\s+", ",", v)
         v = re.sub(r",]", "]", v)
@@ -219,13 +251,39 @@ class Config(configparser.ConfigParser):
             return [v.strip()]
 
     def _str_to_array(self, v: str) -> np.ndarray:
+        """Convert a string to a numpy array.
+        
+        Args:
+            v (str): String to convert.
+            
+        Returns:
+            np.ndarray: Numpy array representation of the string.
+        """
         v = ast.literal_eval(v)
         return np.array(v, dtype=float)
 
     def _str_to_tensor(self, v: str) -> torch.Tensor:
+        """Convert a string to a torch tensor.
+
+        Args:
+            v (str): String to convert.
+
+        Returns:
+            torch.Tensor: Tensor representation of the string.
+        """
         return torch.Tensor(self._str_to_array(v)).to(torch.float64)
 
     def _str_to_obj(self, v: str, fallback_type: _T = str, warn: bool = True) -> object:
+        """Convert a string to an object.
+
+        Args:
+            v (str): String to convert.
+            fallback_type (_T): Type to fallback to if the object is not found. Defaults to str.
+            warn (bool): Whether to warn if the object is not found. Defaults to True.
+
+        Returns:
+            object: Object representation of the string.
+        """
         try:
             return self.registered_names[v]
         except KeyError:
@@ -303,6 +361,11 @@ class Config(configparser.ConfigParser):
             )
 
     def __repr__(self) -> str:
+        """Return a string representation of the config.
+        
+        Returns:
+            str: String representation of the config.
+        """
         return f"Config at {hex(id(self))}: \n {str(self)}"
 
     @classmethod
@@ -337,7 +400,15 @@ class Config(configparser.ConfigParser):
             )
         cls.registered_names.update({obj.__name__: obj})
 
-    def get_section(self, section):
+    def get_section(self, section: str) -> Dict[str, Any]:
+        """Get a section of the config.
+        
+        Args:
+            section (str): Section to get.
+            
+        Returns:
+            Dict[str, Any]: Dictionary representation of the section.
+        """
         sec = {}
         for setting in self[section]:
             if section != "common" and setting in self["common"]:
@@ -346,6 +417,7 @@ class Config(configparser.ConfigParser):
         return sec
 
     def __str__(self):
+        """Return a string representation of the config."""
         _str = ""
         for section in self:
             sec = self.get_section(section)
@@ -355,6 +427,7 @@ class Config(configparser.ConfigParser):
         return _str
 
     def convert_to_latest(self):
+        """Converts the config to the latest version."""
         self.convert(self.version, __version__)
 
     def convert(self, from_version: str, to_version: str) -> None:
@@ -451,7 +524,11 @@ class Config(configparser.ConfigParser):
 
     @property
     def version(self) -> str:
-        """Returns the version number of the config."""
+        """Returns the version number of the config.
+        
+        Returns:
+            str: Version number of the config.
+        """
         # TODO: implement an explicit versioning system
 
         # Try to infer the version

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -31,7 +31,7 @@ import torch
 from aepsych.version import __version__
 
 _T = TypeVar("_T")
-
+_ET = TypeVar("_ET")
 
 class Config(configparser.ConfigParser):
     # names in these packages can be referred to by string name
@@ -150,26 +150,34 @@ class Config(configparser.ConfigParser):
 
     # Turn the metadata section into JSON.
     def jsonifyMetadata(self) -> str:
-        """Turn the metadata section into JSON."""
+        """Turn the metadata section into JSON.
+        
+        Returns:
+            str: JSON representation of the metadata section.
+        """
         configdict = self.to_dict()
         return json.dumps(configdict["metadata"])
 
     # Turn the entire config into JSON format.
     def jsonifyAll(self) -> str:
-        """Turn the entire config into JSON format."""
+        """Turn the entire config into JSON format.
+        
+        Returns:
+            str: JSON representation of the entire config.
+        """
         configdict = self.to_dict()
         return json.dumps(configdict)
 
     def update(
         self,
-        config_dict: Mapping[str, str] = None,
+        config_dict: Optional[Mapping[str, str]] = None,
         config_fnames: Sequence[str] = None,
         config_str: str = None,
     ) -> None:
         """Update this object with a new configuration.
 
         Args:
-            config_dict (Mapping[str, str]): Mapping to build configuration from.
+            config_dict (Mapping[str, str], optional): Mapping to build configuration from.
                 Keys are section names, values are dictionaries with keys and values that
                 should be present in the section. Defaults to None.
             config_fnames (Sequence[str]): List of INI filenames to load
@@ -228,13 +236,13 @@ class Config(configparser.ConfigParser):
             del self["experiment"]
 
     def _str_to_list(
-        self, v: str, element_type: _T = float
+        self, v: str, element_type: Callable[[_ET], _ET] = float
     ) -> List[_T]:
         """Convert a string to a list.
         
         Args:
             v (str): String to convert.
-            element_type (_T): Type of the elements in the list. Defaults to float.
+            element_type (Callable[[_ET], _ET]): Type of the elements in the list. Defaults to float.
             
         Returns:
             List[_T]: List of elements of type _T.
@@ -427,7 +435,7 @@ class Config(configparser.ConfigParser):
         return _str
 
     def convert_to_latest(self):
-        """Converts the config to the latest version."""
+        """Converts the config to the latest version in place."""
         self.convert(self.version, __version__)
 
     def convert(self, from_version: str, to_version: str) -> None:

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -134,7 +134,7 @@ class Config(configparser.ConfigParser):
         """Convert the config into a dictionary.
         
         Args:
-            deduplicate (bool): Whether to deduplicate the 'common' section. Defaults to True.
+            deduplicate (bool, optional): Whether to deduplicate the 'common' section. Defaults to True.
             
         Returns:
             dict: Dictionary representation of the config.
@@ -278,8 +278,8 @@ class Config(configparser.ConfigParser):
 
         Args:
             v (str): String to convert.
-            fallback_type (_T): Type to fallback to if the object is not found. Defaults to str.
-            warn (bool): Whether to warn if the object is not found. Defaults to True.
+            fallback_type (_T, optional): Type to fallback to if the object is not found. Defaults to str.
+            warn (bool, optional): Whether to warn if the object is not found. Defaults to True.
 
         Returns:
             object: Object representation of the string.

--- a/aepsych/generators/acqf_thompson_sampler_generator.py
+++ b/aepsych/generators/acqf_thompson_sampler_generator.py
@@ -51,8 +51,8 @@ class AcqfThompsonSamplerGenerator(AEPsychGenerator):
             acqf (AcquisitionFunction): Acquisition function to use.
             acqf_kwargs (Dict[str, object], optional): Extra arguments to
                 pass to acquisition function. Defaults to no arguments.
-            samps (int): Number of samples for quasi-random initialization of the acquisition function optimizer.
-            stimuli_per_trial (int): Number of stimuli per trial. Defaults to 1.
+            samps (int, optional): Number of samples for quasi-random initialization of the acquisition function optimizer.
+            stimuli_per_trial (int, optional): Number of stimuli per trial. Defaults to 1.
         """
 
         if acqf_kwargs is None:

--- a/aepsych/generators/acqf_thompson_sampler_generator.py
+++ b/aepsych/generators/acqf_thompson_sampler_generator.py
@@ -51,8 +51,8 @@ class AcqfThompsonSamplerGenerator(AEPsychGenerator):
             acqf (AcquisitionFunction): Acquisition function to use.
             acqf_kwargs (Dict[str, object], optional): Extra arguments to
                 pass to acquisition function. Defaults to no arguments.
-            samps (int, optional): Number of samples for quasi-random initialization of the acquisition function optimizer.
-            stimuli_per_trial (int, optional): Number of stimuli per trial. Defaults to 1.
+            samps (int): Number of samples for quasi-random initialization of the acquisition function optimizer.
+            stimuli_per_trial (int): Number of stimuli per trial. Defaults to 1.
         """
 
         if acqf_kwargs is None:

--- a/aepsych/generators/acqf_thompson_sampler_generator.py
+++ b/aepsych/generators/acqf_thompson_sampler_generator.py
@@ -51,7 +51,7 @@ class AcqfThompsonSamplerGenerator(AEPsychGenerator):
             acqf (AcquisitionFunction): Acquisition function to use.
             acqf_kwargs (Dict[str, object], optional): Extra arguments to
                 pass to acquisition function. Defaults to no arguments.
-            samps (int): Number of samples for quasi-random initialization of the acquisition function optimizer.
+            samps (int): Number of samples for quasi-random initialization of the acquisition function optimizer. Defaults to 1000.
             stimuli_per_trial (int): Number of stimuli per trial. Defaults to 1.
         """
 

--- a/aepsych/generators/acqf_thompson_sampler_generator.py
+++ b/aepsych/generators/acqf_thompson_sampler_generator.py
@@ -64,10 +64,10 @@ class AcqfThompsonSamplerGenerator(AEPsychGenerator):
 
     def _instantiate_acquisition_fn(self, model: ModelProtocol) -> AcquisitionFunction:
         """Instantiate the acquisition function with the model and any extra arguments.
-        
+
         Args:
             model (ModelProtocol): The model to use for the acquisition function.
-            
+
         Returns:
             AcquisitionFunction: The instantiated acquisition function.
         """
@@ -152,10 +152,10 @@ class AcqfThompsonSamplerGenerator(AEPsychGenerator):
     @classmethod
     def from_config(cls, config: Config) -> AcqfThompsonSamplerGenerator:
         """Initialize AcqfThompsonSamplerGenerator from configuration.
-        
+
         Args:
             config (Config): Configuration object containing initialization parameters.
-            
+
         Returns:
             AcqfThompsonSamplerGenerator: The initialized generator.
         """

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -64,16 +64,15 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
         cls, acqf: AcquisitionFunction, config: Config
     ) -> Dict[str, Any]:
         """Get the extra arguments for the acquisition function from the config.
-        
+
         Args:
             acqf (AcquisitionFunction): The acquisition function to get arguments for.
             config (Config): The configuration object.
-            
+
         Returns:
             Dict[str, Any]: The extra arguments for the acquisition function.
         """
 
-        
         if acqf is not None:
             acqf_name = acqf.__name__
 

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -63,6 +63,17 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
     def _get_acqf_options(
         cls, acqf: AcquisitionFunction, config: Config
     ) -> Dict[str, Any]:
+        """Get the extra arguments for the acquisition function from the config.
+        
+        Args:
+            acqf (AcquisitionFunction): The acquisition function to get arguments for.
+            config (Config): The configuration object.
+            
+        Returns:
+            Dict[str, Any]: The extra arguments for the acquisition function.
+        """
+
+        
         if acqf is not None:
             acqf_name = acqf.__name__
 

--- a/aepsych/generators/epsilon_greedy_generator.py
+++ b/aepsych/generators/epsilon_greedy_generator.py
@@ -17,7 +17,7 @@ from .optimize_acqf_generator import OptimizeAcqfGenerator
 class EpsilonGreedyGenerator(AEPsychGenerator):
     def __init__(self, subgenerator: AEPsychGenerator, epsilon: float = 0.1) -> None:
         """Initialize EpsilonGreedyGenerator.
-        
+
         Args:
             subgenerator (AEPsychGenerator): The generator to use when not exploiting.
             epsilon (float): The probability of exploration. Defaults to 0.1.
@@ -26,12 +26,12 @@ class EpsilonGreedyGenerator(AEPsychGenerator):
         self.epsilon = epsilon
 
     @classmethod
-    def from_config(cls, config: Config) -> 'EpsilonGreedyGenerator':
+    def from_config(cls, config: Config) -> "EpsilonGreedyGenerator":
         """Create an EpsilonGreedyGenerator from a Config object.
-        
+
         Args:
             config (Config): Configuration object containing initialization parameters.
-            
+
         Returns:
             EpsilonGreedyGenerator: The generator.
         """
@@ -45,7 +45,7 @@ class EpsilonGreedyGenerator(AEPsychGenerator):
 
     def gen(self, num_points: int, model: ModelProtocol) -> torch.Tensor:
         """Query next point(s) to run by sampling from the subgenerator with probability 1-epsilon, and randomly otherwise.
-        
+
         Args:
             num_points (int): Number of points to query.
             model (ModelProtocol): Model to use for generating points.

--- a/aepsych/generators/epsilon_greedy_generator.py
+++ b/aepsych/generators/epsilon_greedy_generator.py
@@ -16,11 +16,25 @@ from .optimize_acqf_generator import OptimizeAcqfGenerator
 
 class EpsilonGreedyGenerator(AEPsychGenerator):
     def __init__(self, subgenerator: AEPsychGenerator, epsilon: float = 0.1) -> None:
+        """Initialize EpsilonGreedyGenerator.
+        
+        Args:
+            subgenerator (AEPsychGenerator): The generator to use when not exploiting.
+            epsilon (float): The probability of exploration. Defaults to 0.1.
+        """
         self.subgenerator = subgenerator
         self.epsilon = epsilon
 
     @classmethod
-    def from_config(cls, config: Config) -> "EpsilonGreedyGenerator":
+    def from_config(cls, config: Config) -> 'EpsilonGreedyGenerator':
+        """Create an EpsilonGreedyGenerator from a Config object.
+        
+        Args:
+            config (Config): Configuration object containing initialization parameters.
+            
+        Returns:
+            EpsilonGreedyGenerator: The generator.
+        """
         classname = cls.__name__
         subgen_cls = config.getobj(
             classname, "subgenerator", fallback=OptimizeAcqfGenerator
@@ -30,6 +44,12 @@ class EpsilonGreedyGenerator(AEPsychGenerator):
         return cls(subgenerator=subgen, epsilon=epsilon)
 
     def gen(self, num_points: int, model: ModelProtocol) -> torch.Tensor:
+        """Query next point(s) to run by sampling from the subgenerator with probability 1-epsilon, and randomly otherwise.
+        
+        Args:
+            num_points (int): Number of points to query.
+            model (ModelProtocol): Model to use for generating points.
+        """
         if num_points > 1:
             raise NotImplementedError("Epsilon-greedy batched gen is not implemented!")
         if np.random.uniform() < self.epsilon:

--- a/aepsych/generators/manual_generator.py
+++ b/aepsych/generators/manual_generator.py
@@ -57,7 +57,7 @@ class ManualGenerator(AEPsychGenerator):
     ) -> torch.Tensor:
         """Query next point(s) to run by quasi-randomly sampling the parameter space.
         Args:
-            num_points (int): Number of points to query. Defaults to 1.
+            num_points (int, optional): Number of points to query. Defaults to 1.
             model (AEPsychMixin, optional): Model to use for generating points. Not used in this generator. Defaults to None.
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].

--- a/aepsych/generators/manual_generator.py
+++ b/aepsych/generators/manual_generator.py
@@ -32,11 +32,12 @@ class ManualGenerator(AEPsychGenerator):
     ) -> None:
         """Iniatialize ManualGenerator.
         Args:
-            lb torch.Tensor: Lower bounds of each parameter.
-            ub torch.Tensor: Upper bounds of each parameter.
-            points torch.Tensor: The points that will be generated.
+            lb (torch.Tensor): Lower bounds of each parameter.
+            ub (torch.Tensor): Upper bounds of each parameter.
+            points (torch.Tensor): The points that will be generated.
             dim (int, optional): Dimensionality of the parameter space. If None, it is inferred from lb and ub.
             shuffle (bool): Whether or not to shuffle the order of the points. True by default.
+            seed (int, optional): Random seed. Defaults to None.
         """
         self.seed = seed
         self.lb, self.ub, self.dim = _process_bounds(lb, ub, dim)
@@ -56,7 +57,8 @@ class ManualGenerator(AEPsychGenerator):
     ) -> torch.Tensor:
         """Query next point(s) to run by quasi-randomly sampling the parameter space.
         Args:
-            num_points (int): Number of points to query.
+            num_points (int): Number of points to query. Defaults to 1.
+            model (AEPsychMixin, optional): Model to use for generating points. Not used in this generator. Defaults to None.
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
         """
@@ -77,6 +79,22 @@ class ManualGenerator(AEPsychGenerator):
 
     @classmethod
     def get_config_options(cls, config: Config, name: Optional[str] = None) -> Dict:
+        """
+        Extracts and processes configuration options for initializing the ManualGenerator.
+
+        Args:
+            config (Config): Configuration object containing initialization parameters.
+            name (str, optional): Name of the configuration section for this generator. Defaults to the class name.
+
+        Returns:
+            Dict: A dictionary of options, including:
+                 "lb" (torch.Tensor): Lower bounds of each parameter.
+                 "ub" (torch.Tensor): Upper bounds of each parameter.
+                 "dim" (int, optional): Dimensionality of the parameter space.
+                 "points" (torch.Tensor): Predefined points to generate.
+                 "shuffle" (bool): Whether to shuffle the order of points.
+                 "seed" (int, optional): Random seed for shuffling.
+        """
         if name is None:
             name = cls.__name__
 
@@ -123,13 +141,10 @@ class SampleAroundPointsGenerator(ManualGenerator):
     ) -> None:
         """Iniatialize SampleAroundPointsGenerator.
         Args:
-            lb (Union[np.ndarray, torch.Tensor]): Lower bounds of each parameter.
-            ub (Union[np.ndarray, torch.Tensor]): Upper bounds of each parameter.
-            window (Union[np.ndarray, torch.Tensor]): How far away to sample from the
-                reference point along each dimension. If the parameters are transformed,
-                the proportion of the range (based on ub/lb given) covered by the window
-                will be preserved (and not the absolute distance from the reference points).
-            points (Union[np.ndarray, torch.Tensor]): The points that will be generated.
+            lb (torch.Tensor): Lower bounds of each parameter.
+            ub (torch.Tensor): Upper bounds of each parameter.
+            window (torch.Tensor): How far away to sample from the reference point along each dimension.
+            points (torch.Tensor): The points that will be generated.
             samples_per_point (int): How many samples around each point to take.
             dim (int, optional): Dimensionality of the parameter space. If None, it is inferred from lb and ub.
             shuffle (bool): Whether or not to shuffle the order of the points. True by default.
@@ -162,6 +177,24 @@ class SampleAroundPointsGenerator(ManualGenerator):
 
     @classmethod
     def get_config_options(cls, config: Config, name: Optional[str] = None) -> Dict:
+        """
+        Extracts and processes configuration options for initializing the SampleAroundPointsGenerator.
+
+        Args:
+            config (Config): Configuration object containing initialization parameters.
+            name (str, optional): Name of the configuration section for this generator. Defaults to the class name.
+
+        Returns:
+            Dict: A dictionary of options, including:
+                - "lb" (torch.Tensor): Lower bounds of each parameter.
+                - "ub" (torch.Tensor): Upper bounds of each parameter.
+                - "dim" (int, optional): Dimensionality of the parameter space.
+                - "points" (torch.Tensor): Predefined reference points.
+                - "shuffle" (bool): Whether to shuffle the order of points.
+                - "seed" (int, optional): Random seed for shuffling.
+                - "window" (torch.Tensor): Sampling range around each reference point along each dimension.
+                - "samples_per_point" (int): Number of samples to generate around each reference point.
+        """
         if name is None:
             name = cls.__name__
 

--- a/aepsych/generators/manual_generator.py
+++ b/aepsych/generators/manual_generator.py
@@ -57,7 +57,7 @@ class ManualGenerator(AEPsychGenerator):
     ) -> torch.Tensor:
         """Query next point(s) to run by quasi-randomly sampling the parameter space.
         Args:
-            num_points (int, optional): Number of points to query. Defaults to 1.
+            num_points (int): Number of points to query. Defaults to 1.
             model (AEPsychMixin, optional): Model to use for generating points. Not used in this generator. Defaults to None.
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].

--- a/aepsych/generators/monotonic_rejection_generator.py
+++ b/aepsych/generators/monotonic_rejection_generator.py
@@ -178,7 +178,7 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         return Xopt
 
     @classmethod
-    def from_config(cls, config: Config) -> 'MonotonicRejectionGenerator':
+    def from_config(cls, config: Config) -> "MonotonicRejectionGenerator":
         """
         Creates an instance of MonotonicRejectionGenerator from a configuration object.
 

--- a/aepsych/generators/monotonic_rejection_generator.py
+++ b/aepsych/generators/monotonic_rejection_generator.py
@@ -28,7 +28,7 @@ def default_loss_constraint_fun(
 
     Args:
         loss (torch.Tensor): Value of loss at candidate points.
-        candidates (torch.Tensor): Location of candidate points.
+        candidates (torch.Tensor): Location of candidate points. Unused.
 
     Returns:
         torch.Tensor: New loss (unchanged)
@@ -51,11 +51,11 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         Args:
             acqf (AcquisitionFunction): Acquisition function to use.
             acqf_kwargs (Dict[str, object], optional): Extra arguments to
-                pass to acquisition function. Defaults to no arguments.
-            model_gen_options: Dictionary with options for generating candidate, such as
-                SGD parameters. See code for all options and their defaults.
-            explore_features: List of features that will be selected randomly and then
-                fixed for acquisition fn optimization.
+                pass to acquisition function. Defaults to None.
+            model_gen_options (Dict[str, Any], optional): Dictionary with options for generating candidate, such as
+                SGD parameters. See code for all options and their defaults. Defaults to None.
+            explore_features (Sequence[int], optional): List of features that will be selected randomly and then
+                fixed for acquisition fn optimization. Defaults to None.
         """
         if acqf_kwargs is None:
             acqf_kwargs = {}
@@ -67,6 +67,15 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
     def _instantiate_acquisition_fn(
         self, model: MonotonicRejectionGP
     ) -> AcquisitionFunction:
+        """
+        Instantiates the acquisition function with the specified model and additional arguments.
+
+        Args:
+            model (MonotonicRejectionGP): The model to use with the acquisition function.
+
+        Returns:
+            AcquisitionFunction: Configured acquisition function.
+        """
         return self.acqf(
             model=model,
             deriv_constraint_points=model._get_deriv_constraint_points(),
@@ -80,7 +89,7 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
     ) -> torch.Tensor:
         """Query next point(s) to run by optimizing the acquisition function.
         Args:
-            num_points (int, optional): Number of points to query.
+            num_points (int): Number of points to query. Currently only supports 1.
             model (AEPsychMixin): Fitted model of the data.
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
@@ -169,7 +178,17 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         return Xopt
 
     @classmethod
-    def from_config(cls, config: Config) -> "MonotonicRejectionGenerator":
+    def from_config(cls, config: Config) -> 'MonotonicRejectionGenerator':
+        """
+        Creates an instance of MonotonicRejectionGenerator from a configuration object.
+
+        Args:
+            config (Config): Configuration object containing initialization parameters.
+
+        Returns:
+            MonotonicRejectionGenerator: A configured instance of the generator class with specified acquisition function,
+            gradient descent options, exploration features, and acquisition function arguments.
+        """
         classname = cls.__name__
         acqf = config.getobj("common", "acqf", fallback=None)
         extra_acqf_args = cls._get_acqf_options(acqf, config)

--- a/aepsych/generators/monotonic_rejection_generator.py
+++ b/aepsych/generators/monotonic_rejection_generator.py
@@ -49,7 +49,7 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
     ) -> None:
         """Initialize MonotonicRejectionGenerator.
         Args:
-            acqf (AcquisitionFunction): Acquisition function to use.
+            acqf (MonotonicMCAcquisition): Acquisition function to use.
             acqf_kwargs (Dict[str, object], optional): Extra arguments to
                 pass to acquisition function. Defaults to None.
             model_gen_options (Dict[str, Any], optional): Dictionary with options for generating candidate, such as

--- a/aepsych/generators/monotonic_thompson_sampler_generator.py
+++ b/aepsych/generators/monotonic_thompson_sampler_generator.py
@@ -7,9 +7,9 @@
 
 from typing import List, Optional, Type
 
-import numpy as np
 import torch
 from aepsych.acquisition.objective import ProbitObjective
+from aepsych.models.base import AEPsychMixin
 from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator
 from aepsych.models.monotonic_rejection_gp import MonotonicRejectionGP
@@ -39,9 +39,10 @@ class MonotonicThompsonSamplerGenerator(AEPsychGenerator[MonotonicRejectionGP]):
             num_rejection_samples (int): Number of rejection samples to draw.
             num_ts_points (int): Number of points at which to sample.
             target_value (float): target value that is being looked for
-            objective (Optional[MCAcquisitionObjective], optional): Objective transform of the GP output
+            objective (MCAcquisitionObjective): Objective transform of the GP output
                 before evaluating the acquisition. Defaults to identity transform.
-            explore_features (Sequence[int], optional)
+            explore_features (List[Type[int]], optional): List of features that will be selected randomly and then
+                fixed for acquisition fn optimization. Defaults to None.
         """
         self.n_samples = n_samples
         self.n_rejection_samples = n_rejection_samples
@@ -53,11 +54,11 @@ class MonotonicThompsonSamplerGenerator(AEPsychGenerator[MonotonicRejectionGP]):
     def gen(
         self,
         num_points: int,  # Current implementation only generates 1 point at a time
-        model: MonotonicRejectionGP,
+        model: AEPsychMixin,
     ) -> torch.Tensor:
         """Query next point(s) to run by optimizing the acquisition function.
         Args:
-            num_points (int, optional): Number of points to query.
+            num_points (int): Number of points to query. current implementation only generates 1 point at a time.
             model (AEPsychMixin): Fitted model of the data.
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
@@ -89,7 +90,17 @@ class MonotonicThompsonSamplerGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         return torch.Tensor(X[best_indx])
 
     @classmethod
-    def from_config(cls, config: Config) -> "MonotonicThompsonSamplerGenerator":
+    def from_config(cls, config: Config) -> 'MonotonicThompsonSamplerGenerator':
+        """
+        Creates an instance of MonotonicThompsonSamplerGenerator from a configuration object.
+
+        Args:
+            config (Config): Configuration object containing initialization parameters.
+
+        Returns:
+            MonotonicThompsonSamplerGenerator: A configured instance of the generator class with specified number of samples,
+            rejection samples, Thompson sampling points, target value, objective transformation, and optional exploration features.
+        """
         classname = cls.__name__
         n_samples = config.getint(classname, "num_samples", fallback=1)
         n_rejection_samples = config.getint(

--- a/aepsych/generators/monotonic_thompson_sampler_generator.py
+++ b/aepsych/generators/monotonic_thompson_sampler_generator.py
@@ -54,12 +54,12 @@ class MonotonicThompsonSamplerGenerator(AEPsychGenerator[MonotonicRejectionGP]):
     def gen(
         self,
         num_points: int,  # Current implementation only generates 1 point at a time
-        model: AEPsychMixin,
+        model: MonotonicRejectionGP,
     ) -> torch.Tensor:
         """Query next point(s) to run by optimizing the acquisition function.
         Args:
             num_points (int): Number of points to query. current implementation only generates 1 point at a time.
-            model (AEPsychMixin): Fitted model of the data.
+            model (MonotonicRejectionGP): Fitted model of the data.
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
         """

--- a/aepsych/generators/monotonic_thompson_sampler_generator.py
+++ b/aepsych/generators/monotonic_thompson_sampler_generator.py
@@ -9,9 +9,9 @@ from typing import List, Optional, Type
 
 import torch
 from aepsych.acquisition.objective import ProbitObjective
-from aepsych.models.base import AEPsychMixin
 from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator
+from aepsych.models.base import AEPsychMixin
 from aepsych.models.monotonic_rejection_gp import MonotonicRejectionGP
 from botorch.acquisition.objective import MCAcquisitionObjective
 from botorch.utils.sampling import draw_sobol_samples
@@ -90,7 +90,7 @@ class MonotonicThompsonSamplerGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         return torch.Tensor(X[best_indx])
 
     @classmethod
-    def from_config(cls, config: Config) -> 'MonotonicThompsonSamplerGenerator':
+    def from_config(cls, config: Config) -> "MonotonicThompsonSamplerGenerator":
         """
         Creates an instance of MonotonicThompsonSamplerGenerator from a configuration object.
 

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -50,7 +50,7 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
         Args:
             acqf (AcquisitionFunction): Acquisition function to use.
             acqf_kwargs (Dict[str, object], optional): Extra arguments to
-                pass to acquisition function. Defaults to no arguments. 
+                pass to acquisition function. Defaults to no arguments.
             restarts (int): Number of restarts for acquisition function optimization. Defaults to 10.
             samps (int): Number of samples for quasi-random initialization of the acquisition function optimizer. Defaults to 1000.
             max_gen_time (float, optional): Maximum time (in seconds) to optimize the acquisition function. Defaults to None.
@@ -141,13 +141,13 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
         return new_candidate
 
     @classmethod
-    def from_config(cls, config: Config) -> 'OptimizeAcqfGenerator':
+    def from_config(cls, config: Config) -> "OptimizeAcqfGenerator":
         """
         Creates an instance of OptimizeAcqfGenerator from a configuration object.
-        
+
         Args:
             config (Config): Configuration object containing initialization parameters.
-            
+
         Returns:
             OptimizeAcqfGenerator: A configured instance of OptimizeAcqfGenerator with specified acquisition function,
             restart and sample parameters, maximum generation time, and stimuli per trial.

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -51,10 +51,10 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
             acqf (AcquisitionFunction): Acquisition function to use.
             acqf_kwargs (Dict[str, object], optional): Extra arguments to
                 pass to acquisition function. Defaults to no arguments. 
-            restarts (int, optional): Number of restarts for acquisition function optimization. Defaults to 10.
-            samps (int, optional): Number of samples for quasi-random initialization of the acquisition function optimizer. Defaults to 1000.
+            restarts (int): Number of restarts for acquisition function optimization. Defaults to 10.
+            samps (int): Number of samples for quasi-random initialization of the acquisition function optimizer. Defaults to 1000.
             max_gen_time (float, optional): Maximum time (in seconds) to optimize the acquisition function. Defaults to None.
-            stimuli_per_trial (int, optional): Number of stimuli per trial. Defaults to 1.
+            stimuli_per_trial (int): Number of stimuli per trial. Defaults to 1.
         """
 
         if acqf_kwargs is None:

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -50,10 +50,11 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
         Args:
             acqf (AcquisitionFunction): Acquisition function to use.
             acqf_kwargs (Dict[str, object], optional): Extra arguments to
-                pass to acquisition function. Defaults to no arguments.
-            restarts (int): Number of restarts for acquisition function optimization.
-            samps (int): Number of samples for quasi-random initialization of the acquisition function optimizer.
-            max_gen_time (optional, float): Maximum time (in seconds) to optimize the acquisition function.
+                pass to acquisition function. Defaults to no arguments. 
+            restarts (int): Number of restarts for acquisition function optimization. Defaults to 10.
+            samps (int): Number of samples for quasi-random initialization of the acquisition function optimizer. Defaults to 1000.
+            max_gen_time (float, optional): Maximum time (in seconds) to optimize the acquisition function. Defaults to None.
+            stimuli_per_trial (int): Number of stimuli per trial. Defaults to 1.
         """
 
         if acqf_kwargs is None:
@@ -66,6 +67,16 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
         self.stimuli_per_trial = stimuli_per_trial
 
     def _instantiate_acquisition_fn(self, model: ModelProtocol) -> AcquisitionFunction:
+        """
+        Instantiates the acquisition function with the specified model and additional arguments.
+
+        Args:
+            model (ModelProtocol): The model to use with the acquisition function.
+
+        Returns:
+            AcquisitionFunction: Configured acquisition function.
+        """
+
         if self.acqf == AnalyticExpectedUtilityOfBestOption:
             return self.acqf(pref_model=model)
 
@@ -77,7 +88,7 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
     def gen(self, num_points: int, model: ModelProtocol, **gen_options) -> torch.Tensor:
         """Query next point(s) to run by optimizing the acquisition function.
         Args:
-            num_points (int, optional): Number of points to query.
+            num_points (int): Number of points to query.
             model (ModelProtocol): Fitted model of the data.
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
@@ -96,8 +107,19 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
             return self._gen(num_points=num_points, model=model, **gen_options)
 
     def _gen(
-        self, num_points: int, model: ModelProtocol, **gen_options
+        self, num_points: int, model: ModelProtocol, **gen_options: Dict[str, Any]
     ) -> torch.Tensor:
+        """
+        Generates the next query points by optimizing the acquisition function.
+
+        Args:
+            num_points (int): Number of points to query.
+            model (ModelProtocol): Fitted model of the data.
+            gen_options (Dict[str, Any]): Additional options for generating points, such as custom configurations.
+
+        Returns:
+            torch.Tensor: Next set of points to evaluate, with shape [num_points x dim].
+        """
         # eval should be inherited from superclass
         model.eval()  # type: ignore
         acqf = self._instantiate_acquisition_fn(model)
@@ -119,7 +141,17 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
         return new_candidate
 
     @classmethod
-    def from_config(cls, config: Config) -> "OptimizeAcqfGenerator":
+    def from_config(cls, config: Config) -> 'OptimizeAcqfGenerator':
+        """
+        Creates an instance of OptimizeAcqfGenerator from a configuration object.
+        
+        Args:
+            config (Config): Configuration object containing initialization parameters.
+            
+        Returns:
+            OptimizeAcqfGenerator: A configured instance of OptimizeAcqfGenerator with specified acquisition function,
+            restart and sample parameters, maximum generation time, and stimuli per trial.
+        """
         classname = cls.__name__
         acqf = config.getobj(classname, "acqf", fallback=None)
         extra_acqf_args = cls._get_acqf_options(acqf, config)

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -51,10 +51,10 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
             acqf (AcquisitionFunction): Acquisition function to use.
             acqf_kwargs (Dict[str, object], optional): Extra arguments to
                 pass to acquisition function. Defaults to no arguments. 
-            restarts (int): Number of restarts for acquisition function optimization. Defaults to 10.
-            samps (int): Number of samples for quasi-random initialization of the acquisition function optimizer. Defaults to 1000.
+            restarts (int, optional): Number of restarts for acquisition function optimization. Defaults to 10.
+            samps (int, optional): Number of samples for quasi-random initialization of the acquisition function optimizer. Defaults to 1000.
             max_gen_time (float, optional): Maximum time (in seconds) to optimize the acquisition function. Defaults to None.
-            stimuli_per_trial (int): Number of stimuli per trial. Defaults to 1.
+            stimuli_per_trial (int, optional): Number of stimuli per trial. Defaults to 1.
         """
 
         if acqf_kwargs is None:

--- a/aepsych/generators/pairwise_optimize_acqf_generator.py
+++ b/aepsych/generators/pairwise_optimize_acqf_generator.py
@@ -17,7 +17,17 @@ class PairwiseOptimizeAcqfGenerator(OptimizeAcqfGenerator):
     stimuli_per_trial = 2
 
     @classmethod
-    def from_config(cls, config: Config) -> "OptimizeAcqfGenerator":
+    def from_config(cls, config: Config) -> 'OptimizeAcqfGenerator':
+        """
+        Create an instance of PairwiseOptimizeAcqfGenerator from a configration object.
+        
+        Args:
+            config (Config): Configuration object containing initialization parameters.
+            
+        Returns:
+            OptimizeAcqfGenerator: A configured instance of OptimizeAcqfGenerator with specified acquisition function,
+            restart and sample parameters, maximum generation time, and stimuli per trial(two in this case).
+        """
         warnings.warn(
             "PairwiseOptimizeAcqfGenerator is deprecated. Use OptimizeAcqfGenerator instead.",
             DeprecationWarning,

--- a/aepsych/generators/pairwise_optimize_acqf_generator.py
+++ b/aepsych/generators/pairwise_optimize_acqf_generator.py
@@ -17,13 +17,13 @@ class PairwiseOptimizeAcqfGenerator(OptimizeAcqfGenerator):
     stimuli_per_trial = 2
 
     @classmethod
-    def from_config(cls, config: Config) -> 'OptimizeAcqfGenerator':
+    def from_config(cls, config: Config) -> "OptimizeAcqfGenerator":
         """
         Create an instance of PairwiseOptimizeAcqfGenerator from a configration object.
-        
+
         Args:
             config (Config): Configuration object containing initialization parameters.
-            
+
         Returns:
             OptimizeAcqfGenerator: A configured instance of OptimizeAcqfGenerator with specified acquisition function,
             restart and sample parameters, maximum generation time, and stimuli per trial(two in this case).

--- a/aepsych/generators/pairwise_sobol_generator.py
+++ b/aepsych/generators/pairwise_sobol_generator.py
@@ -18,13 +18,13 @@ class PairwiseSobolGenerator(SobolGenerator):
     stimuli_per_trial = 2
 
     @classmethod
-    def from_config(cls, config: Config) -> 'SobolGenerator':
+    def from_config(cls, config: Config) -> "SobolGenerator":
         """
         Create an instance of PairwiseSobolGenerator from a configration object.
-        
+
         Args:
             config (Config): Configuration object containing initialization parameters.
-            
+
         Returns:
             SobolGenerator: A configured instance of the generator with specified bounds, dimensionality, random seed, and stimuli per trial(two in this case).
         """

--- a/aepsych/generators/pairwise_sobol_generator.py
+++ b/aepsych/generators/pairwise_sobol_generator.py
@@ -18,7 +18,16 @@ class PairwiseSobolGenerator(SobolGenerator):
     stimuli_per_trial = 2
 
     @classmethod
-    def from_config(cls, config: Config):
+    def from_config(cls, config: Config) -> 'SobolGenerator':
+        """
+        Create an instance of PairwiseSobolGenerator from a configration object.
+        
+        Args:
+            config (Config): Configuration object containing initialization parameters.
+            
+        Returns:
+            SobolGenerator: A configured instance of the generator with specified bounds, dimensionality, random seed, and stimuli per trial(two in this case).
+        """
         warnings.warn(
             "PairwiseSobolGenerator is deprecated. Use SobolGenerator instead.",
             DeprecationWarning,

--- a/aepsych/generators/random_generator.py
+++ b/aepsych/generators/random_generator.py
@@ -5,9 +5,8 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Optional, Union
+from typing import Optional
 
-import numpy as np
 import torch
 from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator
@@ -28,8 +27,8 @@ class RandomGenerator(AEPsychGenerator):
     ) -> None:
         """Iniatialize RandomGenerator.
         Args:
-            lb torch.Tensor: Lower bounds of each parameter.
-            ub torch.Tensor: Upper bounds of each parameter.
+            lb (torch.Tensor): Lower bounds of each parameter.
+            ub (torch.Tensor): Upper bounds of each parameter.
             dim (int, optional): Dimensionality of the parameter space. If None, it is inferred from lb and ub.
         """
 
@@ -43,7 +42,8 @@ class RandomGenerator(AEPsychGenerator):
     ) -> torch.Tensor:
         """Query next point(s) to run by randomly sampling the parameter space.
         Args:
-            num_points (int, optional): Number of points to query. Currently, only 1 point can be queried at a time.
+            num_points (int): Number of points to query. Currently, only 1 point can be queried at a time.
+            model (AEPsychMixin, optional): Model to use for generating points. Not used in this generator.
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
         """
@@ -53,7 +53,16 @@ class RandomGenerator(AEPsychGenerator):
         return X
 
     @classmethod
-    def from_config(cls, config: Config) -> "RandomGenerator":
+    def from_config(cls, config: Config) -> 'RandomGenerator':
+        """
+        Create an instance of RandomGenerator from a configuration object.
+        
+        Args:
+            config (Config): Configuration object containing initialization parameters.
+            
+        Returns:
+            RandomGenerator: A configured instance of the generator with specified bounds and dimensionality.
+        """
         classname = cls.__name__
         lb = config.gettensor(classname, "lb")
         ub = config.gettensor(classname, "ub")

--- a/aepsych/generators/random_generator.py
+++ b/aepsych/generators/random_generator.py
@@ -53,13 +53,13 @@ class RandomGenerator(AEPsychGenerator):
         return X
 
     @classmethod
-    def from_config(cls, config: Config) -> 'RandomGenerator':
+    def from_config(cls, config: Config) -> "RandomGenerator":
         """
         Create an instance of RandomGenerator from a configuration object.
-        
+
         Args:
             config (Config): Configuration object containing initialization parameters.
-            
+
         Returns:
             RandomGenerator: A configured instance of the generator with specified bounds and dimensionality.
         """

--- a/aepsych/generators/semi_p.py
+++ b/aepsych/generators/semi_p.py
@@ -35,6 +35,18 @@ class IntensityAwareSemiPGenerator(OptimizeAcqfGenerator):
         model: SemiParametricGPModel,  # type: ignore[override]
         context_objective: Type = SemiPThresholdObjective,
     ) -> torch.Tensor:
+        """Query next point(s) to run by optimizing the acquisition function for both context and intensity.
+
+        Args:
+            num_points (int): Number of points to query.
+            model (SemiParametricGPModel): Fitted semi-parametric model of the data.
+            context_objective (Type): The objective function used for context. Defaults to SemiPThresholdObjective.
+
+        Returns:
+            torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
+        """
+
+
         fixed_features = {model.stim_dim: 0}
         next_x = super().gen(
             num_points=num_points, model=model, fixed_features=fixed_features

--- a/aepsych/generators/semi_p.py
+++ b/aepsych/generators/semi_p.py
@@ -46,7 +46,6 @@ class IntensityAwareSemiPGenerator(OptimizeAcqfGenerator):
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
         """
 
-
         fixed_features = {model.stim_dim: 0}
         next_x = super().gen(
             num_points=num_points, model=model, fixed_features=fixed_features

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -67,7 +67,7 @@ class SobolGenerator(AEPsychGenerator):
         return grid.reshape(num_points, self.stimuli_per_trial, -1).swapaxes(-1, -2)
 
     @classmethod
-    def from_config(cls, config: Config) -> 'SobolGenerator':
+    def from_config(cls, config: Config) -> "SobolGenerator":
         """
         Creates an instance of SobolGenerator from a configuration object.
 

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-from typing import Dict, Optional, Union
+from typing import Optional
 
 import numpy as np
 import torch
@@ -65,7 +65,17 @@ class SobolGenerator(AEPsychGenerator):
         return grid.reshape(num_points, self.stimuli_per_trial, -1).swapaxes(-1, -2)
 
     @classmethod
-    def from_config(cls, config: Config) -> "SobolGenerator":
+    def from_config(cls, config: Config) -> 'SobolGenerator':
+        """
+        Creates an instance of SobolGenerator from a configuration object.
+
+        Args:
+            config (Config): Configuration object containing initialization parameters.
+
+        Returns:
+            SobolGenerator: A configured instance of the generator with specified bounds, dimensionality, random seed, and stimuli per trial.
+        """
+
         classname = cls.__name__
 
         lb = config.gettensor(classname, "lb")

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -32,8 +32,8 @@ class SobolGenerator(AEPsychGenerator):
     ) -> None:
         """Iniatialize SobolGenerator.
         Args:
-            lb torch.Tensor: Lower bounds of each parameter.
-            ub torch.Tensor: Upper bounds of each parameter.
+            lb (torch.Tensor): Lower bounds of each parameter.
+            ub (torch.Tensor): Upper bounds of each parameter.
             dim (int, optional): Dimensionality of the parameter space. If None, it is inferred from lb and ub.
             seed (int, optional): Random seed.
             stimuli_per_trial (int): Number of stimuli per trial. Defaults to 1.
@@ -54,7 +54,7 @@ class SobolGenerator(AEPsychGenerator):
     ) -> torch.Tensor:
         """Query next point(s) to run by quasi-randomly sampling the parameter space.
         Args:
-            num_points (int): Number of points to query.
+            num_points (int): Number of points to query. Defaults to 1.
             moodel (AEPsychMixin, optional): Model to use for generating points. Not used in this generator. Defaults to None.
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim] or [num_points x dim x stimuli_per_trial] if stimuli_per_trial != 1.

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -36,6 +36,7 @@ class SobolGenerator(AEPsychGenerator):
             ub torch.Tensor: Upper bounds of each parameter.
             dim (int, optional): Dimensionality of the parameter space. If None, it is inferred from lb and ub.
             seed (int, optional): Random seed.
+            stimuli_per_trial (int, optional): Number of stimuli per trial. Defaults to 1.
         """
         self.lb, self.ub, self.dim = _process_bounds(lb, ub, dim)
         self.lb = self.lb.repeat(stimuli_per_trial)

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -36,7 +36,7 @@ class SobolGenerator(AEPsychGenerator):
             ub torch.Tensor: Upper bounds of each parameter.
             dim (int, optional): Dimensionality of the parameter space. If None, it is inferred from lb and ub.
             seed (int, optional): Random seed.
-            stimuli_per_trial (int, optional): Number of stimuli per trial. Defaults to 1.
+            stimuli_per_trial (int): Number of stimuli per trial. Defaults to 1.
         """
         self.lb, self.ub, self.dim = _process_bounds(lb, ub, dim)
         self.lb = self.lb.repeat(stimuli_per_trial)
@@ -54,7 +54,8 @@ class SobolGenerator(AEPsychGenerator):
     ) -> torch.Tensor:
         """Query next point(s) to run by quasi-randomly sampling the parameter space.
         Args:
-            num_points (int, optional): Number of points to query.
+            num_points (int): Number of points to query.
+            moodel (AEPsychMixin, optional): Model to use for generating points. Not used in this generator. Defaults to None.
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim] or [num_points x dim x stimuli_per_trial] if stimuli_per_trial != 1.
         """

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -400,14 +400,14 @@ def plot_strat_3d(
     """Creates a plot of a 2d slice of a 3D strategy, showing the estimated model or probability response and contours
     Args:
         strat (Strategy): Strategy object to be plotted. Must have a dimensionality of 3.
-        parnames (List[str], optional): list of the parameter names
+        parnames (List[str], optional): list of the parameter names. If None, defaults to ["x1", "x2", "x3"].
         outcome_label (str): The label of the outcome variable
         slice_dim (int): dimension to slice on. Default: 0.
         slice_vals (Union[List[float], int]): values to take slices; OR number of values to take even slices from. Default: 5.
         contour_levels (Union[Iterable[float], bool], optional): List contour values to plot. Default: None. If true, all integer levels.
         probability_space (bool): Whether to plot probability. Default: False
         gridsize (int): The number of points to sample each dimension at. Default: 30.
-        extent_multiplier (List[float], optional): multipliers for each of the dimensions when plotting. Default:None
+        extent_multiplier (List[float], optional): multipliers for each of the dimensions when plotting. If None, defaults to [1, 1, 1].
         save_path (str, optional): File name to save the plot to. Default: None.
         show (bool): Whether the plot should be shown in an interactive window. Default: True.
     """

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -8,12 +8,13 @@
 import warnings
 from typing import Any, Callable, Iterable, List, Optional, Sized, Union
 
-from matplotlib.image import AxesImage
 import matplotlib.pyplot as plt
 import numpy as np
 from aepsych.strategy import Strategy
 from aepsych.utils import get_lse_contour, get_lse_interval, make_scaled_sobol
 from matplotlib.axes import Axes
+
+from matplotlib.image import AxesImage
 from scipy.stats import norm
 
 
@@ -151,7 +152,7 @@ def _plot_strat_1d(
     gridsize: int,
 ) -> plt.Axes:
     """Helper function for creating 1-d plots. See plot_strat for an explanation of the arguments.
-    
+
     Args:
         strat (Strategy): Strategy object to be plotted. Must have a dimensionality of 1.
         ax (plt.Axes): Matplotlib axis to plot on
@@ -271,7 +272,7 @@ def _plot_strat_2d(
     include_colorbar: bool,
 ):
     """Helper function for creating 2-d plots. See plot_strat for an explanation of the arguments.
-    
+
     Args:
         strat (Strategy): Strategy object to be plotted. Must have a dimensionality of 2.
         ax (plt.Axes): Matplotlib axis to plot on

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -44,23 +44,23 @@ def plot_strat(
         ax (plt.Axes, optional): Matplotlib axis to plot on (if None, creates a new axis). Default: None.
         true_testfun (Callable, optional): Ground truth response function. Should take a n_samples x n_parameters tensor
                     as input and produce the response probability at each sample as output. Default: None.
-        cred_level (float): Percentage of posterior mass around the mean to be shaded. Default: 0.95.
+        cred_level (float, optional): Percentage of posterior mass around the mean to be shaded. Default: 0.95.
         target_level (float, optional): Response probability to estimate the threshold of. Default: 0.75.
         xlabel (str, optional): Label of the x-axis. Default: "Context (abstract)".
         ylabel (str, optional): Label of the y-axis (if None, defaults to "Response Probability" for 1-d plots or
                       "Intensity (Abstract)" for 2-d plots). Default: None.
-        yes_label (str): Label of trials with response of 1. Default: "Yes trial".
-        no_label (str): Label of trials with response of 0. Default: "No trial".
-        flipx (bool): Whether the values of the x-axis should be flipped such that the min becomes the max and vice
+        yes_label (str, optional): Label of trials with response of 1. Default: "Yes trial".
+        no_label (str, optional): Label of trials with response of 0. Default: "No trial".
+        flipx (bool, optional): Whether the values of the x-axis should be flipped such that the min becomes the max and vice
                       versa.
                (Only valid for 2-d plots.) Default: False.
-        logx (bool): Whether the x-axis should be log-transformed. (Only valid for 2-d plots.) Default: False.
-        gridsize (int): The number of points to sample each dimension at. Default: 30.
-        title (str): Title of the plot. Default: ''.
+        logx (bool, optional): Whether the x-axis should be log-transformed. (Only valid for 2-d plots.) Default: False.
+        gridsize (int, optional): The number of points to sample each dimension at. Default: 30.
+        title (str, optional): Title of the plot. Default: ''.
         save_path (str, optional): File name to save the plot to. Default: None.
-        show (bool): Whether the plot should be shown in an interactive window. Default: True.
-        include_legend (bool): Whether to include the legend in the figure. Default: True.
-        include_colorbar (bool): Whether to include the colorbar indicating the probability of "Yes" trials.
+        show (bool, optional): Whether the plot should be shown in an interactive window. Default: True.
+        include_legend (bool, optional): Whether to include the legend in the figure. Default: True.
+        include_colorbar (bool, optional): Whether to include the colorbar indicating the probability of "Yes" trials.
                                  Default: True.
     """
 
@@ -401,15 +401,15 @@ def plot_strat_3d(
     Args:
         strat (Strategy): Strategy object to be plotted. Must have a dimensionality of 3.
         parnames (List[str], optional): list of the parameter names
-        outcome_label (str): The label of the outcome variable
-        slice_dim (int): dimension to slice on. Default: 0.
-        slice_vals (Union[List[float], int]): values to take slices; OR number of values to take even slices from. Default: 5.
+        outcome_label (str, optional): The label of the outcome variable
+        slice_dim (int, optional): dimension to slice on. Default: 0.
+        slice_vals (Union[List[float], int], optional): values to take slices; OR number of values to take even slices from. Default: 5.
         contour_levels (Union[Iterable[float], bool], optional): List contour values to plot. Default: None. If true, all integer levels.
-        probability_space (bool): Whether to plot probability. Default: False
-        gridsize (int): The number of points to sample each dimension at. Default: 30.
+        probability_space (bool, optional): Whether to plot probability. Default: False
+        gridsize (int, optional): The number of points to sample each dimension at. Default: 30.
         extent_multiplier (List[float], optional): multipliers for each of the dimensions when plotting. Default:None
         save_path (str, optional): File name to save the plot to. Default: None.
-        show (bool): Whether the plot should be shown in an interactive window. Default: True.
+        show (bool, optional): Whether the plot should be shown in an interactive window. Default: True.
     """
     assert strat.model is not None, "Cannot plot without a model!"
 
@@ -503,9 +503,9 @@ def plot_slice(
         slice_val (int): value to take the slice along that dimension.
         vmin (float): global model minimum to use for plotting.
         vmax (float): global model maximum to use for plotting.
-        gridsize (int): The number of points to sample each dimension at. Default: 30.
-        contour_levels (Sized): Contours to plot. Default: None
-        lse (bool): Whether to plot probability. Default: False
+        gridsize (int, optional): The number of points to sample each dimension at. Default: 30.
+        contour_levels (Sized, optional): Contours to plot. Default: None
+        lse (bool, optional): Whether to plot probability. Default: False
         extent_multiplier (List, optional): multipliers for each of the dimensions when plotting. Default:None
 
     Returns:

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -44,23 +44,23 @@ def plot_strat(
         ax (plt.Axes, optional): Matplotlib axis to plot on (if None, creates a new axis). Default: None.
         true_testfun (Callable, optional): Ground truth response function. Should take a n_samples x n_parameters tensor
                     as input and produce the response probability at each sample as output. Default: None.
-        cred_level (float, optional): Percentage of posterior mass around the mean to be shaded. Default: 0.95.
+        cred_level (float): Percentage of posterior mass around the mean to be shaded. Default: 0.95.
         target_level (float, optional): Response probability to estimate the threshold of. Default: 0.75.
         xlabel (str, optional): Label of the x-axis. Default: "Context (abstract)".
         ylabel (str, optional): Label of the y-axis (if None, defaults to "Response Probability" for 1-d plots or
                       "Intensity (Abstract)" for 2-d plots). Default: None.
-        yes_label (str, optional): Label of trials with response of 1. Default: "Yes trial".
-        no_label (str, optional): Label of trials with response of 0. Default: "No trial".
-        flipx (bool, optional): Whether the values of the x-axis should be flipped such that the min becomes the max and vice
+        yes_label (str): Label of trials with response of 1. Default: "Yes trial".
+        no_label (str): Label of trials with response of 0. Default: "No trial".
+        flipx (bool): Whether the values of the x-axis should be flipped such that the min becomes the max and vice
                       versa.
                (Only valid for 2-d plots.) Default: False.
-        logx (bool, optional): Whether the x-axis should be log-transformed. (Only valid for 2-d plots.) Default: False.
-        gridsize (int, optional): The number of points to sample each dimension at. Default: 30.
-        title (str, optional): Title of the plot. Default: ''.
+        logx (bool): Whether the x-axis should be log-transformed. (Only valid for 2-d plots.) Default: False.
+        gridsize (int): The number of points to sample each dimension at. Default: 30.
+        title (str): Title of the plot. Default: ''.
         save_path (str, optional): File name to save the plot to. Default: None.
-        show (bool, optional): Whether the plot should be shown in an interactive window. Default: True.
-        include_legend (bool, optional): Whether to include the legend in the figure. Default: True.
-        include_colorbar (bool, optional): Whether to include the colorbar indicating the probability of "Yes" trials.
+        show (bool): Whether the plot should be shown in an interactive window. Default: True.
+        include_legend (bool): Whether to include the legend in the figure. Default: True.
+        include_colorbar (bool): Whether to include the colorbar indicating the probability of "Yes" trials.
                                  Default: True.
     """
 
@@ -401,15 +401,15 @@ def plot_strat_3d(
     Args:
         strat (Strategy): Strategy object to be plotted. Must have a dimensionality of 3.
         parnames (List[str], optional): list of the parameter names
-        outcome_label (str, optional): The label of the outcome variable
-        slice_dim (int, optional): dimension to slice on. Default: 0.
-        slice_vals (Union[List[float], int], optional): values to take slices; OR number of values to take even slices from. Default: 5.
+        outcome_label (str): The label of the outcome variable
+        slice_dim (int): dimension to slice on. Default: 0.
+        slice_vals (Union[List[float], int]): values to take slices; OR number of values to take even slices from. Default: 5.
         contour_levels (Union[Iterable[float], bool], optional): List contour values to plot. Default: None. If true, all integer levels.
-        probability_space (bool, optional): Whether to plot probability. Default: False
-        gridsize (int, optional): The number of points to sample each dimension at. Default: 30.
+        probability_space (bool): Whether to plot probability. Default: False
+        gridsize (int): The number of points to sample each dimension at. Default: 30.
         extent_multiplier (List[float], optional): multipliers for each of the dimensions when plotting. Default:None
         save_path (str, optional): File name to save the plot to. Default: None.
-        show (bool, optional): Whether the plot should be shown in an interactive window. Default: True.
+        show (bool): Whether the plot should be shown in an interactive window. Default: True.
     """
     assert strat.model is not None, "Cannot plot without a model!"
 
@@ -503,9 +503,9 @@ def plot_slice(
         slice_val (int): value to take the slice along that dimension.
         vmin (float): global model minimum to use for plotting.
         vmax (float): global model maximum to use for plotting.
-        gridsize (int, optional): The number of points to sample each dimension at. Default: 30.
+        gridsize (int): The number of points to sample each dimension at. Default: 30.
         contour_levels (Sized, optional): Contours to plot. Default: None
-        lse (bool, optional): Whether to plot probability. Default: False
+        lse (bool): Whether to plot probability. Default: False
         extent_multiplier (List, optional): multipliers for each of the dimensions when plotting. Default:None
 
     Returns:

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -8,6 +8,7 @@
 import warnings
 from typing import Any, Callable, Iterable, List, Optional, Sized, Union
 
+from matplotlib.image import AxesImage
 import matplotlib.pyplot as plt
 import numpy as np
 from aepsych.strategy import Strategy
@@ -44,9 +45,9 @@ def plot_strat(
         true_testfun (Callable, optional): Ground truth response function. Should take a n_samples x n_parameters tensor
                     as input and produce the response probability at each sample as output. Default: None.
         cred_level (float): Percentage of posterior mass around the mean to be shaded. Default: 0.95.
-        target_level (float): Response probability to estimate the threshold of. Default: 0.75.
-        xlabel (str): Label of the x-axis. Default: "Context (abstract)".
-        ylabel (str): Label of the y-axis (if None, defaults to "Response Probability" for 1-d plots or
+        target_level (float, optional): Response probability to estimate the threshold of. Default: 0.75.
+        xlabel (str, optional): Label of the x-axis. Default: "Context (abstract)".
+        ylabel (str, optional): Label of the y-axis (if None, defaults to "Response Probability" for 1-d plots or
                       "Intensity (Abstract)" for 2-d plots). Default: None.
         yes_label (str): Label of trials with response of 1. Default: "Yes trial".
         no_label (str): Label of trials with response of 0. Default: "No trial".
@@ -148,8 +149,26 @@ def _plot_strat_1d(
     yes_label: str,
     no_label: str,
     gridsize: int,
-):
-    """Helper function for creating 1-d plots. See plot_strat for an explanation of the arguments."""
+) -> plt.Axes:
+    """Helper function for creating 1-d plots. See plot_strat for an explanation of the arguments.
+    
+    Args:
+        strat (Strategy): Strategy object to be plotted. Must have a dimensionality of 1.
+        ax (plt.Axes): Matplotlib axis to plot on
+        true_testfun (Callable, optional): Ground truth response function. Should take a n_samples x n_parameters tensor
+                    as input and produce the response probability at each sample as output. Default: None.
+        cred_level (float): Percentage of posterior mass around the mean to be shaded. Default: 0.95.
+        target_level (float, optional): Response probability to estimate the threshold of. Default: 0.75.
+        xlabel (str): Label of the x-axis. Default: "Context (abstract)".
+        ylabel (str): Label of the y-axis (if None, defaults to "Response Probability" for 1-d plots or
+                      "Intensity (Abstract)" for 2-d plots). Default: None.
+        yes_label (str): Label of trials with response of 1. Default: "Yes trial".
+        no_label (str): Label of trials with response of 0. Default: "No trial".
+        gridsize (int): The number of points to sample each dimension at. Default: 30.
+
+    Returns:
+        plt.Axes: The axis object with the plot.
+    """
 
     x, y = strat.x, strat.y
     assert x is not None and y is not None, "No data to plot!"
@@ -251,7 +270,31 @@ def _plot_strat_2d(
     gridsize: int,
     include_colorbar: bool,
 ):
-    """Helper function for creating 2-d plots. See plot_strat for an explanation of the arguments."""
+    """Helper function for creating 2-d plots. See plot_strat for an explanation of the arguments.
+    
+    Args:
+        strat (Strategy): Strategy object to be plotted. Must have a dimensionality of 2.
+        ax (plt.Axes): Matplotlib axis to plot on
+        true_testfun (Callable, optional): Ground truth response function. Should take a n_samples x n_parameters tensor
+                    as input and produce the response probability at each sample as output. Default: None.
+        cred_level (float): Percentage of posterior mass around the mean to be shaded. Default: 0.95.
+        target_level (float, optional): Response probability to estimate the threshold of. Default: 0.75.
+        xlabel (str): Label of the x-axis. Default: "Context (abstract)".
+        ylabel (str): Label of the y-axis (if None, defaults to "Response Probability" for 1-d plots or
+                      "Intensity (Abstract)" for 2-d plots). Default: None.
+        yes_label (str): Label of trials with response of 1. Default: "Yes trial".
+        no_label (str): Label of trials with response of 0. Default: "No trial".
+        flipx (bool): Whether the values of the x-axis should be flipped such that the min becomes the max and vice
+                      versa.
+               (Only valid for 2-d plots.) Default: False.
+        logx (bool): Whether the x-axis should be log-transformed. (Only valid for 2-d plots.) Default: False.
+        gridsize (int): The number of points to sample each dimension at. Default: 30.
+        include_colorbar (bool): Whether to include the colorbar indicating the probability of "Yes" trials.
+                                 Default: True.
+
+    Returns:
+        plt.Axes: The axis object with the plot.
+    """
 
     x, y = strat.x, strat.y
     assert x is not None and y is not None, "No data to plot!"
@@ -360,14 +403,14 @@ def plot_strat_3d(
     """Creates a plot of a 2d slice of a 3D strategy, showing the estimated model or probability response and contours
     Args:
         strat (Strategy): Strategy object to be plotted. Must have a dimensionality of 3.
-        parnames (str list): list of the parameter names
+        parnames (List[str], optional): list of the parameter names
         outcome_label (str): The label of the outcome variable
-        slice_dim (int): dimension to slice on
-        dim_vals (list of floats or int): values to take slices; OR number of values to take even slices from
-        contour_levels (iterable of floats or bool, optional): List contour values to plot. Default: None. If true, all integer levels.
+        slice_dim (int): dimension to slice on. Default: 0.
+        slice_vals (Union[List[float], int]): values to take slices; OR number of values to take even slices from. Default: 5.
+        contour_levels (Union[Iterable[float], bool], optional): List contour values to plot. Default: None. If true, all integer levels.
         probability_space (bool): Whether to plot probability. Default: False
         gridsize (int): The number of points to sample each dimension at. Default: 30.
-        extent_multiplier (list, optional): multipliers for each of the dimensions when plotting. Default:None
+        extent_multiplier (List[float], optional): multipliers for each of the dimensions when plotting. Default:None
         save_path (str, optional): File name to save the plot to. Default: None.
         show (bool): Whether the plot should be shown in an interactive window. Default: True.
     """
@@ -453,20 +496,23 @@ def plot_slice(
     contour_levels: Optional[Sized] = None,
     lse: bool = False,
     extent_multiplier: Optional[List] = None,
-):
+) -> AxesImage:
     """Creates a plot of a 2d slice of a 3D strategy, showing the estimated model or probability response and contours
     Args:
-        strat (Strategy): Strategy object to be plotted. Must have a dimensionality of 3.
         ax (plt.Axes): Matplotlib axis to plot on
-        parnames (str list): list of the parameter names
-        slice_dim (int): dimension to slice on
-        slice_vals (float): value to take the slice along that dimension
-        vmin (float): global model minimum to use for plotting
-        vmax (float): global model maximum to use for plotting
+        start (Strategy): Strategy object to be plotted. Must have a dimensionality of 3.
+        parnames (List[str]): list of the parameter names.
+        slice_dim (int): dimension to slice on.
+        slice_val (int): value to take the slice along that dimension.
+        vmin (float): global model minimum to use for plotting.
+        vmax (float): global model maximum to use for plotting.
         gridsize (int): The number of points to sample each dimension at. Default: 30.
-        contour_levels (int list): Contours to plot. Default: None
+        contour_levels (Sized): Contours to plot. Default: None
         lse (bool): Whether to plot probability. Default: False
-        extent_multiplier (list, optional): multipliers for each of the dimensions when plotting. Default:None
+        extent_multiplier (List, optional): multipliers for each of the dimensions when plotting. Default:None
+
+    Returns:
+        AxesImage: The axis object with the plot.
     """
     extent = np.c_[strat.lb, strat.ub].reshape(-1)
     if strat.model is not None:

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -291,9 +291,6 @@ def _plot_strat_2d(
         gridsize (int): The number of points to sample each dimension at. Default: 30.
         include_colorbar (bool): Whether to include the colorbar indicating the probability of "Yes" trials.
                                  Default: True.
-
-    Returns:
-        plt.Axes: The axis object with the plot.
     """
 
     x, y = strat.x, strat.y

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -47,7 +47,7 @@ from botorch.models.transforms.input import ChainedInputTransform
 logger = getLogger()
 
 
-def ensure_model_is_fresh(f:Callable) -> Callable:
+def ensure_model_is_fresh(f: Callable) -> Callable:
     """Decorator to ensure that the model is up-to-date before running a method.
 
     Args:
@@ -56,6 +56,7 @@ def ensure_model_is_fresh(f:Callable) -> Callable:
     Returns:
         Callable: The wrapped function.
     """
+
     def wrapper(self, *args, **kwargs):
         if self.can_fit and not self._model_is_fresh:
             starttime = time.time()
@@ -332,18 +333,18 @@ class Strategy(object):
 
     @ensure_model_is_fresh
     def get_max(
-        self, 
-        constraints: Optional[Mapping[int, List[float]]]  = None, 
-        probability_space: bool = False, 
-        max_time: Optional[float] = None
+        self,
+        constraints: Optional[Mapping[int, List[float]]] = None,
+        probability_space: bool = False,
+        max_time: Optional[float] = None,
     ) -> Tuple[float, torch.Tensor]:
         """Get the maximum value of the acquisition function.
-        
+
         Args:
             constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
             probability_space (bool): Whether to return the max in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
-            
+
         Returns:
             Tuple[float, torch.Tensor]: The maximum value of the acquisition function and the corresponding input.
         """
@@ -358,18 +359,18 @@ class Strategy(object):
 
     @ensure_model_is_fresh
     def get_min(
-        self, 
-        constraints: Optional[Mapping[int, List[float]]]  = None, 
-        probability_space: bool = False, 
-        max_time: Optional[float] = None
+        self,
+        constraints: Optional[Mapping[int, List[float]]] = None,
+        probability_space: bool = False,
+        max_time: Optional[float] = None,
     ) -> Tuple[float, torch.Tensor]:
         """Get the minimum value of the acquisition function.
-        
+
         Args:
             constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
             probability_space (bool): Whether to return the min in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
-            
+
         Returns:
             Tuple[float, torch.Tensor]: The minimum value of the acquisition function and the corresponding input.
         """
@@ -384,14 +385,14 @@ class Strategy(object):
 
     @ensure_model_is_fresh
     def inv_query(
-        self, 
-        y: int, 
-        constraints: Optional[Mapping[int, List[float]]]  = None, 
-        probability_space: bool = False, 
-        max_time: Optional[float] = None
+        self,
+        y: int,
+        constraints: Optional[Mapping[int, List[float]]] = None,
+        probability_space: bool = False,
+        max_time: Optional[float] = None,
     ) -> Tuple[float, torch.Tensor]:
         """Get the input that corresponds to a given output value.
-        
+
         Args:
             y (int): The output value.
             constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
@@ -399,7 +400,7 @@ class Strategy(object):
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
 
         Returns:
-            Tuple[float, torch.Tensor]: The input that corresponds to the given output value and the corresponding output.    
+            Tuple[float, torch.Tensor]: The input that corresponds to the given output value and the corresponding output.
         """
         constraints = constraints or {}
         assert (
@@ -413,11 +414,11 @@ class Strategy(object):
     @ensure_model_is_fresh
     def predict(self, x: torch.Tensor, probability_space: bool = False) -> torch.Tensor:
         """Predict the output value(s) for the given input(s).
-        
+
         Args:
             x (torch.Tensor): The input value(s).
             probability_space (bool): Whether to return the output in probability space. Defaults to False.
-            
+
         Returns:
             torch.Tensor: The predicted output value(s).
         """
@@ -430,7 +431,7 @@ class Strategy(object):
         self, *args, **kwargs
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
         """Get the just-noticeable difference (JND) for the given input(s).
-        
+
         Returns:
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]: The JND value(s).
         """
@@ -449,7 +450,7 @@ class Strategy(object):
         Args:
             x (torch.Tensor): The input value(s).
             num_samples (int, optional): The number of samples to generate. Defaults to None.
-        
+
         Returns:
             torch.Tensor: The sampled output value(s).
         """
@@ -464,7 +465,7 @@ class Strategy(object):
     @property
     def finished(self) -> bool:
         """Check if the strategy is finished.
-        
+
         Returns:
             bool: True if the strategy is finished, False otherwise.
         """
@@ -514,7 +515,7 @@ class Strategy(object):
     @property
     def can_fit(self) -> bool:
         """Check if the strategy can be fitted.
-        
+
         Returns:
             bool: True if the strategy can be fitted, False otherwise.
         """
@@ -523,7 +524,7 @@ class Strategy(object):
     @property
     def n_trials(self) -> int:
         """Get the number of trials.
-        
+
         Returns:
             int: The number of trials.
         """
@@ -604,11 +605,11 @@ class Strategy(object):
     @classmethod
     def from_config(cls, config: Config, name: str) -> Strategy:
         """Create a strategy object from a configuration object.
-        
+
         Args:
             config (Config): The configuration object.
             name (str): The name of the strategy.
-            
+
         Returns:
             Strategy: The strategy object.
         """
@@ -710,7 +711,7 @@ class SequentialStrategy(object):
 
     def __init__(self, strat_list: List[Strategy]) -> None:
         """Initialize the SequentialStrategy object.
-        
+
         Args:
             strat_list (List[Strategy]): The list of strategies.
         """
@@ -723,7 +724,7 @@ class SequentialStrategy(object):
     @property
     def _strat(self) -> Strategy:
         """Get the current strategy.
-        
+
         Returns:
             Strategy: The current strategy.
         """
@@ -731,10 +732,10 @@ class SequentialStrategy(object):
 
     def __getattr__(self, name: str) -> Any:
         """Get the attribute of the current strategy.
-        
+
         Args:
             name (str): The name of the attribute.
-            
+
         Returns:
             Any: The attribute of the current strategy.
         """
@@ -762,10 +763,10 @@ class SequentialStrategy(object):
 
     def gen(self, num_points: int = 1, **kwargs) -> torch.Tensor:
         """Generate the next set of points to evaluate.
-        
+
         Args:
             num_points (int): The number of points to generate. Defaults to 1.
-            
+
         Returns:
             torch.Tensor: The next set of points to evaluate.
         """
@@ -781,7 +782,7 @@ class SequentialStrategy(object):
     @property
     def finished(self) -> bool:
         """Check if the strategy is finished.
-        
+
         Returns:
             bool: True if the strategy is finished, False otherwise.
         """
@@ -791,7 +792,7 @@ class SequentialStrategy(object):
         self, x: Union[np.ndarray, torch.Tensor], y: Union[np.ndarray, torch.Tensor]
     ) -> None:
         """Add new data points to the strategy.
-        
+
         Args:
             x (Union[np.ndarray, torch.Tensor]): The input data points.
             y (Union[np.ndarray, torch.Tensor]): The output data points.
@@ -801,10 +802,10 @@ class SequentialStrategy(object):
     @classmethod
     def from_config(cls, config: Config) -> SequentialStrategy:
         """Create a SequentialStrategy object from a configuration object.
-        
+
         Args:
             config (Config): The configuration object.
-            
+
         Returns:
             SequentialStrategy: The SequentialStrategy object.
         """

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -118,8 +118,8 @@ class Strategy(object):
             outcome_types (Sequence[Type[str]]): The types of outcomes that the strategy will generate.
             dim (int, optional): The number of dimensions in the parameter space. If None, it is inferred from the size
                 of lb and ub.
-            min_total_tells (int): The minimum number of total observations needed to complete this strategy.
-            min_asks (int): The minimum number of points that should be generated from this strategy.
+            min_total_tells (int, optional): The minimum number of total observations needed to complete this strategy.
+            min_asks (int, optional): The minimum number of points that should be generated from this strategy.
             model (ModelProtocol, optional): The AEPsych model of the data.
             use_gpu_modeling (bool): Whether to move the model to GPU fitting/predictions, defaults to False.
             use_gpu_generating (bool): Whether to use the GPU for generating points, defaults to False.
@@ -133,8 +133,8 @@ class Strategy(object):
                 as data collected from later trials. When None, the model is fitted on all data.
             min_post_range (float, optional): Experimental. The required difference between the posterior's minimum and maximum value in
                 probablity space before the strategy will finish. Ignored if None (default).
-            name (str): The name of the strategy. Defaults to the empty string.
-            run_indefinitely (bool): If true, the strategy will run indefinitely until finish() is explicitly called. Other stopping criteria will
+            name (str, optional): The name of the strategy. Defaults to the empty string.
+            run_indefinitely (bool, optional): If true, the strategy will run indefinitely until finish() is explicitly called. Other stopping criteria will
                 be ignored. Defaults to False.
             transforms (ReversibleInputTransform, optional): Transforms
                 to apply parameters. This is immediately applied to lb/ub, thus lb/ub
@@ -311,7 +311,7 @@ class Strategy(object):
         """Query next point(s) to run by optimizing the acquisition function.
 
         Args:
-            num_points (int): Number of points to query. Defaults to 1.
+            num_points (int, optional): Number of points to query. Defaults to 1.
             Other arguments are forwared to underlying model.
 
         Returns:
@@ -341,7 +341,7 @@ class Strategy(object):
         
         Args:
             constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
-            probability_space (bool): Whether to return the max in probability space. Defaults to False.
+            probability_space (bool, optional): Whether to return the max in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
             
         Returns:
@@ -367,7 +367,7 @@ class Strategy(object):
         
         Args:
             constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
-            probability_space (bool): Whether to return the min in probability space. Defaults to False.
+            probability_space (bool, optional): Whether to return the min in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
             
         Returns:
@@ -395,7 +395,7 @@ class Strategy(object):
         Args:
             y (int): The output value.
             constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
-            probability_space (bool): Whether to return the input in probability space. Defaults to False.
+            probability_space (bool, optional): Whether to return the input in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
 
         Returns:
@@ -416,7 +416,7 @@ class Strategy(object):
         
         Args:
             x (torch.Tensor): The input value(s).
-            probability_space (bool): Whether to return the output in probability space. Defaults to False.
+            probability_space (bool, optional): Whether to return the output in probability space. Defaults to False.
             
         Returns:
             torch.Tensor: The predicted output value(s).
@@ -764,7 +764,7 @@ class SequentialStrategy(object):
         """Generate the next set of points to evaluate.
         
         Args:
-            num_points (int): The number of points to generate. Defaults to 1.
+            num_points (int, optional): The number of points to generate. Defaults to 1.
             
         Returns:
             torch.Tensor: The next set of points to evaluate.

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -118,8 +118,8 @@ class Strategy(object):
             outcome_types (Sequence[Type[str]]): The types of outcomes that the strategy will generate.
             dim (int, optional): The number of dimensions in the parameter space. If None, it is inferred from the size
                 of lb and ub.
-            min_total_tells (int, optional): The minimum number of total observations needed to complete this strategy.
-            min_asks (int, optional): The minimum number of points that should be generated from this strategy.
+            min_total_tells (int): The minimum number of total observations needed to complete this strategy.
+            min_asks (int): The minimum number of points that should be generated from this strategy.
             model (ModelProtocol, optional): The AEPsych model of the data.
             use_gpu_modeling (bool): Whether to move the model to GPU fitting/predictions, defaults to False.
             use_gpu_generating (bool): Whether to use the GPU for generating points, defaults to False.
@@ -133,8 +133,8 @@ class Strategy(object):
                 as data collected from later trials. When None, the model is fitted on all data.
             min_post_range (float, optional): Experimental. The required difference between the posterior's minimum and maximum value in
                 probablity space before the strategy will finish. Ignored if None (default).
-            name (str, optional): The name of the strategy. Defaults to the empty string.
-            run_indefinitely (bool, optional): If true, the strategy will run indefinitely until finish() is explicitly called. Other stopping criteria will
+            name (str): The name of the strategy. Defaults to the empty string.
+            run_indefinitely (bool): If true, the strategy will run indefinitely until finish() is explicitly called. Other stopping criteria will
                 be ignored. Defaults to False.
             transforms (ReversibleInputTransform, optional): Transforms
                 to apply parameters. This is immediately applied to lb/ub, thus lb/ub
@@ -311,7 +311,7 @@ class Strategy(object):
         """Query next point(s) to run by optimizing the acquisition function.
 
         Args:
-            num_points (int, optional): Number of points to query. Defaults to 1.
+            num_points (int): Number of points to query. Defaults to 1.
             Other arguments are forwared to underlying model.
 
         Returns:
@@ -341,7 +341,7 @@ class Strategy(object):
         
         Args:
             constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
-            probability_space (bool, optional): Whether to return the max in probability space. Defaults to False.
+            probability_space (bool): Whether to return the max in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
             
         Returns:
@@ -367,7 +367,7 @@ class Strategy(object):
         
         Args:
             constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
-            probability_space (bool, optional): Whether to return the min in probability space. Defaults to False.
+            probability_space (bool): Whether to return the min in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
             
         Returns:
@@ -395,7 +395,7 @@ class Strategy(object):
         Args:
             y (int): The output value.
             constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
-            probability_space (bool, optional): Whether to return the input in probability space. Defaults to False.
+            probability_space (bool): Whether to return the input in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
 
         Returns:
@@ -416,7 +416,7 @@ class Strategy(object):
         
         Args:
             x (torch.Tensor): The input value(s).
-            probability_space (bool, optional): Whether to return the output in probability space. Defaults to False.
+            probability_space (bool): Whether to return the output in probability space. Defaults to False.
             
         Returns:
             torch.Tensor: The predicted output value(s).
@@ -764,7 +764,7 @@ class SequentialStrategy(object):
         """Generate the next set of points to evaluate.
         
         Args:
-            num_points (int, optional): The number of points to generate. Defaults to 1.
+            num_points (int): The number of points to generate. Defaults to 1.
             
         Returns:
             torch.Tensor: The next set of points to evaluate.

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -64,7 +64,7 @@ def dim_grid(
     Args:
         lower (int): lower bound.
         upper (int): upper bound.
-        gridsize (int, optional): size for grid. Defaults to 30.
+        gridsize (int): size for grid. Defaults to 30.
         slice_dims (Mapping[int, float], optional): values to use for slicing axes, as an {index:value} dict. Defaults to None.
 
     Returns:
@@ -180,11 +180,11 @@ def get_lse_interval(
         mono_grid (Union[torch.Tensor, np.ndarray]): Monotonic grid.
         target_level (float): Target level.
         cred_level (float, optional): Credibility level. Defaults to None.
-        mono_dim (int, optional): Monotonic dimension. Defaults to -1.
-        n_samps (int, optional): Number of samples. Defaults to 500.
-        lb (float, optional): Lower bound. Defaults to -float("inf").
-        ub (float, optional): Upper bound. Defaults to float("inf").
-        gridsize (int, optional): Grid size. Defaults to 30.
+        mono_dim (int): Monotonic dimension. Defaults to -1.
+        n_samps (int): Number of samples. Defaults to 500.
+        lb (float): Lower bound. Defaults to -float("inf").
+        ub (float): Upper bound. Defaults to float("inf").
+        gridsize (int): Grid size. Defaults to 30.
 
     Returns:
         Union[Tuple[torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor]: Level set estimate interval.
@@ -240,9 +240,9 @@ def get_lse_contour(post_mean: torch.Tensor, mono_grid: Union[torch.Tensor, np.n
         post_mean (torch.Tensor): Posterior mean.
         mono_grid (Union[torch.Tensor, np.ndarray]): Monotonic grid.
         level (float): Level.
-        mono_dim (int, optional): Monotonic dimension. Defaults to -1.
-        lb (float, optional): Lower bound. Defaults to -np.inf.
-        ub (float, optional): Upper bound. Defaults to np.inf.
+        mono_dim (int): Monotonic dimension. Defaults to -1.
+        lb (float): Lower bound. Defaults to -np.inf.
+        ub (float): Upper bound. Defaults to np.inf.
         
     Returns:
         torch.Tensor: Level set estimate contour.
@@ -262,10 +262,10 @@ def get_jnd_1d(post_mean: torch.Tensor, mono_grid: torch.Tensor, df: int = 1, mo
     Args:
         post_mean (torch.Tensor): Posterior mean.
         mono_grid (torch.Tensor): Monotonic grid.
-        df (int, optional): Degrees of freedom. Defaults to 1.
-        mono_dim (int, optional): Monotonic dimension. Defaults to -1.
-        lb (Union[torch.Tensor, float], optional): Lower bound. Defaults to -float("inf").
-        ub (Union[torch.Tensor, float], optional): Upper bound. Defaults to float("inf").
+        df (int): Degrees of freedom. Defaults to 1.
+        mono_dim (int): Monotonic dimension. Defaults to -1.
+        lb (Union[torch.Tensor, float]): Lower bound. Defaults to -float("inf").
+        ub (Union[torch.Tensor, float]): Upper bound. Defaults to float("inf").
 
     Returns:
         torch.Tensor: Just noticeable difference.
@@ -297,10 +297,10 @@ def get_jnd_multid(
     Args:
         post_mean (torch.Tensor): Posterior mean.
         mono_grid (torch.Tensor): Monotonic grid.
-        df (int, optional): Degrees of freedom. Defaults to 1.
-        mono_dim (int, optional): Monotonic dimension. Defaults to -1.
-        lb (Union[torch.Tensor, float], optional): Lower bound. Defaults to -float("inf").
-        ub (Union[torch.Tensor, float], optional): Upper bound. Defaults to float("inf").
+        df (int): Degrees of freedom. Defaults to 1.
+        mono_dim (int): Monotonic dimension. Defaults to -1.
+        lb (Union[torch.Tensor, float]): Lower bound. Defaults to -float("inf").
+        ub (Union[torch.Tensor, float]): Upper bound. Defaults to float("inf").
 
     Returns:
         torch.Tensor: Just noticeable difference.

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -42,7 +42,7 @@ def make_scaled_sobol(
 
 def promote_0d(x: Union[torch.Tensor, np.ndarray, List]) -> torch.Tensor:
     """Promote a 0d tensor to a 1d tensor
-    
+
     Args:
         x (Union[torch.Tensor, np.ndarray]): Input tensor
 
@@ -95,12 +95,12 @@ def _process_bounds(
     dim: Optional[int],
 ) -> Tuple[torch.Tensor, torch.Tensor, int]:
     """Helper function for ensuring bounds are correct shape and type.
-    
+
     Args:
         lb (Union[np.ndarray, torch.Tensor, List]): Lower bounds.
         ub (Union[np.ndarray, torch.Tensor, List]): Upper bounds.
         dim (int, optional): Dimension of the bounds.
-        
+
     Returns:
         Tuple[torch.Tensor, torch.Tensor, int]: Tuple of lower bounds, upper bounds, and dimension.
     """
@@ -134,16 +134,22 @@ def _process_bounds(
     return lb, ub, dim
 
 
-def interpolate_monotonic(x: Union[torch.Tensor, np.ndarray], y: Union[torch.Tensor, np.ndarray], z: Union[torch.Tensor, np.ndarray, float], min_x: Union[torch.Tensor, np.ndarray, float] = -np.inf, max_x: Union[torch.Tensor, np.ndarray, float] = np.inf) -> Any:
+def interpolate_monotonic(
+    x: Union[torch.Tensor, np.ndarray],
+    y: Union[torch.Tensor, np.ndarray],
+    z: Union[torch.Tensor, np.ndarray, float],
+    min_x: Union[torch.Tensor, np.ndarray, float] = -np.inf,
+    max_x: Union[torch.Tensor, np.ndarray, float] = np.inf,
+) -> Any:
     """Interpolate a monotonic function
-    
+
     Args:
         x (Union[torch.Tensor, np.ndarray]): x values.
         y (Union[torch.Tensor, np.ndarray]): y values.
         z (Union[torch.Tensor, np.ndarray, float]): z values.
         min_x (Union[torch.Tensor, np.ndarray, float]): Minimum x value. Defaults to -np.inf.
         max_x (Union[torch.Tensor, np.ndarray, float]): Maximum x value. Defaults to np.inf.
-        
+
     Returns:
         Any: Interpolated value.
     """
@@ -237,9 +243,16 @@ def get_lse_interval(
         return median, lower, upper
 
 
-def get_lse_contour(post_mean: torch.Tensor, mono_grid: Union[torch.Tensor, np.ndarray], level: float, mono_dim: int = -1, lb: Union[torch.Tensor, float] = -np.inf, ub: Union[torch.Tensor, float] = np.inf) -> torch.Tensor:
+def get_lse_contour(
+    post_mean: torch.Tensor,
+    mono_grid: Union[torch.Tensor, np.ndarray],
+    level: float,
+    mono_dim: int = -1,
+    lb: Union[torch.Tensor, float] = -np.inf,
+    ub: Union[torch.Tensor, float] = np.inf,
+) -> torch.Tensor:
     """Get the level set estimate contour
-    
+
     Args:
         post_mean (torch.Tensor): Posterior mean.
         mono_grid (Union[torch.Tensor, np.ndarray]): Monotonic grid.
@@ -247,7 +260,7 @@ def get_lse_contour(post_mean: torch.Tensor, mono_grid: Union[torch.Tensor, np.n
         mono_dim (int): Monotonic dimension. Defaults to -1.
         lb (float): Lower bound. Defaults to -np.inf.
         ub (float): Upper bound. Defaults to np.inf.
-        
+
     Returns:
         torch.Tensor: Level set estimate contour.
     """
@@ -260,7 +273,14 @@ def get_lse_contour(post_mean: torch.Tensor, mono_grid: Union[torch.Tensor, np.n
     )
 
 
-def get_jnd_1d(post_mean: torch.Tensor, mono_grid: torch.Tensor, df: int = 1, mono_dim: int = -1, lb: Union[torch.Tensor, float] = -float("inf"), ub: Union[torch.Tensor, float] = float("inf")) -> torch.Tensor:
+def get_jnd_1d(
+    post_mean: torch.Tensor,
+    mono_grid: torch.Tensor,
+    df: int = 1,
+    mono_dim: int = -1,
+    lb: Union[torch.Tensor, float] = -float("inf"),
+    ub: Union[torch.Tensor, float] = float("inf"),
+) -> torch.Tensor:
     """Get the just noticeable difference for a 1D function
 
     Args:
@@ -297,7 +317,7 @@ def get_jnd_multid(
     ub: Union[torch.Tensor, float] = float("inf"),
 ) -> torch.Tensor:
     """Get the just noticeable difference for a multidimensional function
-    
+
     Args:
         post_mean (torch.Tensor): Posterior mean.
         mono_grid (torch.Tensor): Monotonic grid.

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -64,7 +64,7 @@ def dim_grid(
     Args:
         lower (int): lower bound.
         upper (int): upper bound.
-        gridsize (int): size for grid. Defaults to 30.
+        gridsize (int, optional): size for grid. Defaults to 30.
         slice_dims (Mapping[int, float], optional): values to use for slicing axes, as an {index:value} dict. Defaults to None.
 
     Returns:
@@ -180,11 +180,11 @@ def get_lse_interval(
         mono_grid (Union[torch.Tensor, np.ndarray]): Monotonic grid.
         target_level (float): Target level.
         cred_level (float, optional): Credibility level. Defaults to None.
-        mono_dim (int): Monotonic dimension. Defaults to -1.
-        n_samps (int): Number of samples. Defaults to 500.
-        lb (float): Lower bound. Defaults to -float("inf").
-        ub (float): Upper bound. Defaults to float("inf").
-        gridsize (int): Grid size. Defaults to 30.
+        mono_dim (int, optional): Monotonic dimension. Defaults to -1.
+        n_samps (int, optional): Number of samples. Defaults to 500.
+        lb (float, optional): Lower bound. Defaults to -float("inf").
+        ub (float, optional): Upper bound. Defaults to float("inf").
+        gridsize (int, optional): Grid size. Defaults to 30.
 
     Returns:
         Union[Tuple[torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor]: Level set estimate interval.
@@ -240,9 +240,9 @@ def get_lse_contour(post_mean: torch.Tensor, mono_grid: Union[torch.Tensor, np.n
         post_mean (torch.Tensor): Posterior mean.
         mono_grid (Union[torch.Tensor, np.ndarray]): Monotonic grid.
         level (float): Level.
-        mono_dim (int): Monotonic dimension. Defaults to -1.
-        lb (float): Lower bound. Defaults to -np.inf.
-        ub (float): Upper bound. Defaults to np.inf.
+        mono_dim (int, optional): Monotonic dimension. Defaults to -1.
+        lb (float, optional): Lower bound. Defaults to -np.inf.
+        ub (float, optional): Upper bound. Defaults to np.inf.
         
     Returns:
         torch.Tensor: Level set estimate contour.
@@ -262,10 +262,10 @@ def get_jnd_1d(post_mean: torch.Tensor, mono_grid: torch.Tensor, df: int = 1, mo
     Args:
         post_mean (torch.Tensor): Posterior mean.
         mono_grid (torch.Tensor): Monotonic grid.
-        df (int): Degrees of freedom. Defaults to 1.
-        mono_dim (int): Monotonic dimension. Defaults to -1.
-        lb (Union[torch.Tensor, float]): Lower bound. Defaults to -float("inf").
-        ub (Union[torch.Tensor, float]): Upper bound. Defaults to float("inf").
+        df (int, optional): Degrees of freedom. Defaults to 1.
+        mono_dim (int, optional): Monotonic dimension. Defaults to -1.
+        lb (Union[torch.Tensor, float], optional): Lower bound. Defaults to -float("inf").
+        ub (Union[torch.Tensor, float], optional): Upper bound. Defaults to float("inf").
 
     Returns:
         torch.Tensor: Just noticeable difference.
@@ -297,10 +297,10 @@ def get_jnd_multid(
     Args:
         post_mean (torch.Tensor): Posterior mean.
         mono_grid (torch.Tensor): Monotonic grid.
-        df (int): Degrees of freedom. Defaults to 1.
-        mono_dim (int): Monotonic dimension. Defaults to -1.
-        lb (Union[torch.Tensor, float]): Lower bound. Defaults to -float("inf").
-        ub (Union[torch.Tensor, float]): Upper bound. Defaults to float("inf").
+        df (int, optional): Degrees of freedom. Defaults to 1.
+        mono_dim (int, optional): Monotonic dimension. Defaults to -1.
+        lb (Union[torch.Tensor, float], optional): Lower bound. Defaults to -float("inf").
+        ub (Union[torch.Tensor, float], optional): Upper bound. Defaults to float("inf").
 
     Returns:
         torch.Tensor: Just noticeable difference.

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -7,7 +7,7 @@
 
 from collections.abc import Iterable
 from configparser import NoOptionError
-from typing import Any, Dict, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 import numpy as np
 import torch

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -40,17 +40,18 @@ def make_scaled_sobol(
     return grid
 
 
-def promote_0d(x: Union[torch.Tensor, np.ndarray]) -> Union[Iterable[np.ndarray], torch.Tensor]:
+def promote_0d(x: Union[torch.Tensor, np.ndarray, List]) -> torch.Tensor:
     """Promote a 0d tensor to a 1d tensor
     
     Args:
         x (Union[torch.Tensor, np.ndarray]): Input tensor
 
     Returns:
-        List[Union[torch.Tensor, np.ndarray]]: Promoted tensor.
+        torch.Tensor: Promoted tensor.
     """
     if not isinstance(x, Iterable):
-        return [x]
+        x = [x]
+    x = torch.tensor(x)
     return x
 
 
@@ -89,15 +90,15 @@ def dim_grid(
 
 
 def _process_bounds(
-    lb: Union[Iterable[np.ndarray], torch.Tensor],
-    ub: Union[Iterable[np.ndarray], torch.Tensor],
+    lb: Union[np.ndarray, torch.Tensor, List],
+    ub: Union[np.ndarray, torch.Tensor, List],
     dim: Optional[int],
 ) -> Tuple[torch.Tensor, torch.Tensor, int]:
     """Helper function for ensuring bounds are correct shape and type.
     
     Args:
-        lb (Union[torch.Tensor, np.ndarray, List[Union[torch.Tensor, np.ndarray]]]): Lower bounds.
-        ub (Union[torch.Tensor, np.ndarray, List[Union[torch.Tensor, np.ndarray]]]): Upper bounds.
+        lb (Union[np.ndarray, torch.Tensor, List]): Lower bounds.
+        ub (Union[np.ndarray, torch.Tensor, List]): Upper bounds.
         dim (int, optional): Dimension of the bounds.
         
     Returns:

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -20,6 +20,17 @@ from torch.quasirandom import SobolEngine
 def make_scaled_sobol(
     lb: torch.Tensor, ub: torch.Tensor, size: int, seed: Optional[int] = None
 ) -> torch.Tensor:
+    """Create a scaled Sobol grid
+
+    Args:
+        lb (torch.Tensor): Lower bounds
+        ub (torch.Tensor): Upper bounds
+        size (int): Number of points to generate
+        seed (int, optional): Random seed. Defaults to None.
+
+    Returns:
+        torch.Tensor: Scaled Sobol grid
+    """
     lb, ub, ndim = _process_bounds(lb, ub, None)
     grid = SobolEngine(dimension=ndim, scramble=True, seed=seed).draw(size).to(lb)
 
@@ -30,6 +41,11 @@ def make_scaled_sobol(
 
 
 def promote_0d(x: Union[torch.Tensor, np.ndarray]):
+    """Promote a 0d tensor to a 1d tensor
+    
+    Args:
+        x (Union[torch.Tensor, np.ndarray]): Input tensor
+    """
     if not isinstance(x, Iterable):
         return [x]
     return x
@@ -44,16 +60,15 @@ def dim_grid(
     """Create a grid
     Create a grid based on lower, upper, and dim.
     Parameters
-    ----------
-    - lower ('int') - lower bound
-    - upper ('int') - upper bound
-    - dim ('int) - dimension
-    - gridsize ('int') - size for grid
-    - slice_dims (Optional, dict) - values to use for slicing axes, as an {index:value} dict
-    Returns
-    ----------
-    grid : torch.FloatTensor
-        Tensor
+
+    Args:
+        lower (int): lower bound.
+        upper (int): upper bound.
+        gridsize (int): size for grid. Defaults to 30.
+        slice_dims (Mapping[int, float], optional): values to use for slicing axes, as an {index:value} dict. Defaults to None.
+
+    Returns:
+        torch.Tensor: Tensor of grid points.
     """
     slice_dims = slice_dims or {}
 
@@ -75,7 +90,16 @@ def _process_bounds(
     ub: Union[torch.Tensor, np.ndarray],
     dim: Optional[int],
 ) -> Tuple[torch.Tensor, torch.Tensor, int]:
-    """Helper function for ensuring bounds are correct shape and type."""
+    """Helper function for ensuring bounds are correct shape and type.
+    
+    Args:
+        lb (Union[torch.Tensor, np.ndarray]): Lower bounds.
+        ub (Union[torch.Tensor, np.ndarray]): Upper bounds.
+        dim (int, optional): Dimension of the bounds.
+        
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor, int]: Tuple of lower bounds, upper bounds, and dimension.
+    """
     lb = promote_0d(lb)
     ub = promote_0d(ub)
 
@@ -106,7 +130,19 @@ def _process_bounds(
     return lb, ub, dim
 
 
-def interpolate_monotonic(x, y, z, min_x=-np.inf, max_x=np.inf):
+def interpolate_monotonic(x: Union[torch.Tensor, np.ndarray], y: Union[torch.Tensor, np.ndarray], z: Union[torch.Tensor, np.ndarray, float], min_x: Union[torch.Tensor, np.ndarray, float] = -np.inf, max_x: Union[torch.Tensor, np.ndarray, float] = np.inf) -> Any:
+    """Interpolate a monotonic function
+    
+    Args:
+        x (Union[torch.Tensor, np.ndarray]): x values.
+        y (Union[torch.Tensor, np.ndarray]): y values.
+        z (Union[torch.Tensor, np.ndarray, float]): z values.
+        min_x (Union[torch.Tensor, np.ndarray, float]): Minimum x value. Defaults to -np.inf.
+        max_x (Union[torch.Tensor, np.ndarray, float]): Maximum x value. Defaults to np.inf.
+        
+    Returns:
+        Any: Interpolated value.
+    """
     # Ben Letham's 1d interpolation code, assuming monotonicity.
     # basic idea is find the nearest two points to the LSE and
     # linearly interpolate between them (I think this is bisection
@@ -137,6 +173,22 @@ def get_lse_interval(
     gridsize: int = 30,
     **kwargs,
 ) -> Union[Tuple[torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor]:
+    """Get the level set estimate interval
+
+    Args:
+        model (GPyTorchModel): Model to use for sampling.
+        mono_grid (Union[torch.Tensor, np.ndarray]): Monotonic grid.
+        target_level (float): Target level.
+        cred_level (float, optional): Credibility level. Defaults to None.
+        mono_dim (int): Monotonic dimension. Defaults to -1.
+        n_samps (int): Number of samples. Defaults to 500.
+        lb (float): Lower bound. Defaults to -float("inf").
+        ub (float): Upper bound. Defaults to float("inf").
+        gridsize (int): Grid size. Defaults to 30.
+
+    Returns:
+        Union[Tuple[torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor]: Level set estimate interval.
+    """
     # Create a meshgrid using torch.linspace
     xgrid = torch.stack(
         torch.meshgrid(
@@ -181,7 +233,20 @@ def get_lse_interval(
         return median, lower, upper
 
 
-def get_lse_contour(post_mean, mono_grid, level, mono_dim=-1, lb=-np.inf, ub=np.inf):
+def get_lse_contour(post_mean: torch.Tensor, mono_grid: Union[torch.Tensor, np.ndarray], level: float, mono_dim: int = -1, lb: Union[torch.Tensor, float] = -np.inf, ub: Union[torch.Tensor, float] = np.inf) -> torch.Tensor:
+    """Get the level set estimate contour
+    
+    Args:
+        post_mean (torch.Tensor): Posterior mean.
+        mono_grid (Union[torch.Tensor, np.ndarray]): Monotonic grid.
+        level (float): Level.
+        mono_dim (int): Monotonic dimension. Defaults to -1.
+        lb (float): Lower bound. Defaults to -np.inf.
+        ub (float): Upper bound. Defaults to np.inf.
+        
+    Returns:
+        torch.Tensor: Level set estimate contour.
+    """
     return torch.tensor(
         np.apply_along_axis(
             lambda p: interpolate_monotonic(mono_grid, p, level, lb, ub),
@@ -191,7 +256,20 @@ def get_lse_contour(post_mean, mono_grid, level, mono_dim=-1, lb=-np.inf, ub=np.
     )
 
 
-def get_jnd_1d(post_mean, mono_grid, df=1, mono_dim=-1, lb=-np.inf, ub=np.inf):
+def get_jnd_1d(post_mean: torch.Tensor, mono_grid: torch.Tensor, df: int = 1, mono_dim: int = -1, lb: Union[torch.Tensor, float] = -float("inf"), ub: Union[torch.Tensor, float] = float("inf")) -> torch.Tensor:
+    """Get the just noticeable difference for a 1D function
+
+    Args:
+        post_mean (torch.Tensor): Posterior mean.
+        mono_grid (torch.Tensor): Monotonic grid.
+        df (int): Degrees of freedom. Defaults to 1.
+        mono_dim (int): Monotonic dimension. Defaults to -1.
+        lb (Union[torch.Tensor, float]): Lower bound. Defaults to -float("inf").
+        ub (Union[torch.Tensor, float]): Upper bound. Defaults to float("inf").
+
+    Returns:
+        torch.Tensor: Just noticeable difference.
+    """
     interpolate_to = post_mean + df
     return torch.tensor(
         (
@@ -214,6 +292,20 @@ def get_jnd_multid(
     lb: Union[torch.Tensor, float] = -float("inf"),
     ub: Union[torch.Tensor, float] = float("inf"),
 ) -> torch.Tensor:
+    """Get the just noticeable difference for a multidimensional function
+    
+    Args:
+        post_mean (torch.Tensor): Posterior mean.
+        mono_grid (torch.Tensor): Monotonic grid.
+        df (int): Degrees of freedom. Defaults to 1.
+        mono_dim (int): Monotonic dimension. Defaults to -1.
+        lb (Union[torch.Tensor, float]): Lower bound. Defaults to -float("inf").
+        ub (Union[torch.Tensor, float]): Upper bound. Defaults to float("inf").
+
+    Returns:
+        torch.Tensor: Just noticeable difference.
+    """
+
     # Move mono_dim to the last dimension if it isn't already
     if mono_dim != -1:
         post_mean = post_mean.transpose(mono_dim, -1)

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -40,11 +40,14 @@ def make_scaled_sobol(
     return grid
 
 
-def promote_0d(x: Union[torch.Tensor, np.ndarray]):
+def promote_0d(x: Union[torch.Tensor, np.ndarray]) -> Union[Iterable[np.ndarray], torch.Tensor]:
     """Promote a 0d tensor to a 1d tensor
     
     Args:
         x (Union[torch.Tensor, np.ndarray]): Input tensor
+
+    Returns:
+        List[Union[torch.Tensor, np.ndarray]]: Promoted tensor.
     """
     if not isinstance(x, Iterable):
         return [x]
@@ -86,15 +89,15 @@ def dim_grid(
 
 
 def _process_bounds(
-    lb: Union[torch.Tensor, np.ndarray],
-    ub: Union[torch.Tensor, np.ndarray],
+    lb: Union[Iterable[np.ndarray], torch.Tensor],
+    ub: Union[Iterable[np.ndarray], torch.Tensor],
     dim: Optional[int],
 ) -> Tuple[torch.Tensor, torch.Tensor, int]:
     """Helper function for ensuring bounds are correct shape and type.
     
     Args:
-        lb (Union[torch.Tensor, np.ndarray]): Lower bounds.
-        ub (Union[torch.Tensor, np.ndarray]): Upper bounds.
+        lb (Union[torch.Tensor, np.ndarray, List[Union[torch.Tensor, np.ndarray]]]): Lower bounds.
+        ub (Union[torch.Tensor, np.ndarray, List[Union[torch.Tensor, np.ndarray]]]): Upper bounds.
         dim (int, optional): Dimension of the bounds.
         
     Returns:

--- a/aepsych/utils_logging.py
+++ b/aepsych/utils_logging.py
@@ -17,7 +17,7 @@ def getLogger(level=logging.INFO, log_path: str = "logs") -> logging.Logger:
     
     Args:
         level: logging level. Default is logging.INFO.
-        log_path (str, optional): path to save the log file. Default is "logs".
+        log_path (str): path to save the log file. Default is "logs".
 
     Returns:
         logger: a logger object.

--- a/aepsych/utils_logging.py
+++ b/aepsych/utils_logging.py
@@ -12,12 +12,12 @@ import os
 logger = logging.getLogger()
 
 
-def getLogger(level=logging.INFO, log_path="logs") -> logging.Logger:
+def getLogger(level=logging.INFO, log_path: str = "logs") -> logging.Logger:
     """Get a logger with the specified level and log path.
     
     Args:
         level: logging level. Default is logging.INFO.
-        log_path: path to save the log file. Default is "logs".
+        log_path (str, optional): path to save the log file. Default is "logs".
 
     Returns:
         logger: a logger object.

--- a/aepsych/utils_logging.py
+++ b/aepsych/utils_logging.py
@@ -13,6 +13,15 @@ logger = logging.getLogger()
 
 
 def getLogger(level=logging.INFO, log_path="logs") -> logging.Logger:
+    """Get a logger with the specified level and log path.
+    
+    Args:
+        level: logging level. Default is logging.INFO.
+        log_path: path to save the log file. Default is "logs".
+
+    Returns:
+        logger: a logger object.
+    """
     my_format = "%(asctime)-15s [%(levelname)-7s] %(message)s"
     os.makedirs(log_path, exist_ok=True)
 

--- a/aepsych/utils_logging.py
+++ b/aepsych/utils_logging.py
@@ -14,7 +14,7 @@ logger = logging.getLogger()
 
 def getLogger(level=logging.INFO, log_path: str = "logs") -> logging.Logger:
     """Get a logger with the specified level and log path.
-    
+
     Args:
         level: logging level. Default is logging.INFO.
         log_path (str): path to save the log file. Default is "logs".


### PR DESCRIPTION
This PR is the first of several to standardize docstrings across the AEPsych codebase, focusing on:

- **Added Docstrings**: Included docstrings in all root files of `aepsych` and in files within `aepsych/generators`.
- **Consistent Format**: Updated existing docstrings for uniform structure and style.
- **With Reverted Changes in `plotting` and `utils`**: Added type hints and docstrings to maintain consistency, even with reverted changes.
- Applied the suggested changes for DocStrings by other similar PRs.

