### PR TITLE
separate out all gpu tests to its own directory

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -51,4 +51,5 @@ jobs:
         pip install ".[dev]"
     - name: Test with unittest
       run: |
+        cd tests
         python -m unittest

--- a/tests/models/test_gp_classification.py
+++ b/tests/models/test_gp_classification.py
@@ -148,44 +148,6 @@ class GPClassificationSmoketest(unittest.TestCase):
         pred = (pm > 0).numpy()
         npt.assert_allclose(pred, y.numpy())
 
-    @unittest.skipUnless(torch.cuda.is_available(), "no gpu available")
-    def test_1d_classification_gpu(self):
-        """
-        Just see if we memorize the training set but on gpu
-        """
-        X, y = self.X, self.y
-
-        model = GPClassificationModel(
-            torch.Tensor([-3]),
-            torch.Tensor([3]),
-            inducing_size=10,
-        ).to("cuda")
-
-        model.fit(X[:50], y[:50])
-
-        # pspace
-        pm, _ = model.predict_probability(X[:50])
-        pred = (pm > 0.5).cpu().numpy()
-        npt.assert_allclose(pred, y[:50].cpu().numpy())
-
-        # fspace
-        pm, _ = model.predict(X[:50], probability_space=False)
-        pred = (pm > 0).cpu().numpy()
-        npt.assert_allclose(pred, y[:50].cpu().numpy())
-
-        # smoke test update
-        model.update(X, y)
-
-        # pspace
-        pm, _ = model.predict_probability(X)
-        pred = (pm > 0.5).cpu().numpy()
-        npt.assert_allclose(pred, y.cpu().numpy())
-
-        # fspace
-        pm, _ = model.predict(X, probability_space=False)
-        pred = (pm > 0).cpu().numpy()
-        npt.assert_allclose(pred, y.cpu().numpy())
-
     def test_1d_classification_pytorchopt(self):
         """
         Just see if we memorize the training set

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1163,38 +1163,6 @@ class ConfigTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             config.update(config_str=config_str)
 
-    @unittest.skipUnless(torch.cuda.is_available(), "no gpu available")
-    def test_model_gpu(self):
-        config_str = """
-            [common]
-            parnames = [par1]
-            strategy_names = [gpu_strategy]
-            outcome_types = [binary]
-            stimuli_per_trial = 1
-
-            [par1]
-            par_type = continuous
-            lower_bound = 0
-            upper_bound = 1
-            
-            [gpu_strategy]
-            model = GPClassificationModel
-            
-            [GPClassificationModel]
-            use_gpu = True
-        """
-        config = Config()
-        config.update(config_str=config_str)
-
-        strat = SequentialStrategy.from_config(config)
-
-        self.assertTrue(strat.model.device.type == "cuda")
-
-        strat.add_data(torch.tensor([0.5]), torch.tensor([1]))
-        strat.fit()
-
-        self.assertTrue(strat.model.device.type == "cuda")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests_gpu/__init__.py
+++ b/tests_gpu/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests_gpu/models/__init__.py
+++ b/tests_gpu/models/__init__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests_gpu/models/test_gp_classification.py
+++ b/tests_gpu/models/test_gp_classification.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import unittest
+
+import torch
+
+# run on single threads to keep us from deadlocking weirdly in CI
+if "CI" in os.environ or "SANDCASTLE" in os.environ:
+    torch.set_num_threads(1)
+
+import numpy as np
+import numpy.testing as npt
+from aepsych.models import GPClassificationModel
+from scipy.stats import norm
+from sklearn.datasets import make_classification
+
+
+def f_1d(x, mu=0):
+    """
+    latent is just a gaussian bump at mu
+    """
+    return np.exp(-((x - mu) ** 2))
+
+
+def f_2d(x):
+    """
+    a gaussian bump at 0 , 0
+    """
+    return np.exp(-np.linalg.norm(x, axis=-1))
+
+
+def new_novel_det_params(freq, scale_factor=1.0):
+    """Get the loc and scale params for 2D synthetic novel_det(frequency) function
+        Keyword arguments:
+    freq -- 1D array of frequencies whose thresholds to return
+    scale factor -- scale for the novel_det function, where higher is steeper/lower SD
+    target -- target threshold
+    """
+    locs = 0.66 * np.power(0.8 * freq * (0.2 * freq - 1), 2) + 0.05
+    scale = 2 * locs / (3 * scale_factor)
+    loc = -1 + 2 * locs
+    return loc, scale
+
+
+def target_new_novel_det(freq, scale_factor=1.0, target=0.75):
+    """Get the target (i.e. threshold) for 2D synthetic novel_det(frequency) function
+        Keyword arguments:
+    freq -- 1D array of frequencies whose thresholds to return
+    scale factor -- scale for the novel_det function, where higher is steeper/lower SD
+    target -- target threshold
+    """
+    locs, scale = new_novel_det_params(freq, scale_factor)
+    return norm.ppf(target, loc=locs, scale=scale)
+
+
+def new_novel_det(x, scale_factor=1.0):
+    """Get the cdf for 2D synthetic novel_det(frequency) function
+        Keyword arguments:
+    x -- array of shape (n,2) of locations to sample;
+         x[...,0] is frequency from -1 to 1; x[...,1] is intensity from -1 to 1
+    scale factor -- scale for the novel_det function, where higher is steeper/lower SD
+    """
+    freq = x[..., 0]
+    locs, scale = new_novel_det_params(freq, scale_factor)
+    return (x[..., 1] - locs) / scale
+
+
+def cdf_new_novel_det(x, scale_factor=1.0):
+    """Get the cdf for 2D synthetic novel_det(frequency) function
+        Keyword arguments:
+    x -- array of shape (n,2) of locations to sample;
+         x[...,0] is frequency from -1 to 1; x[...,1] is intensity from -1 to 1
+    scale factor -- scale for the novel_det function, where higher is steeper/lower SD
+    """
+    return norm.cdf(new_novel_det(x, scale_factor))
+
+
+class GPClassificationSmoketest(unittest.TestCase):
+    """
+    Super basic smoke test to make sure we know if we broke the underlying model
+    for single-probit  ("1AFC") model
+    """
+
+    def setUp(self):
+        np.random.seed(1)
+        torch.manual_seed(1)
+        X, y = make_classification(
+            n_samples=100,
+            n_features=1,
+            n_redundant=0,
+            n_informative=1,
+            random_state=1,
+            n_clusters_per_class=1,
+        )
+        self.X, self.y = torch.Tensor(X), torch.Tensor(y)
+
+    def test_1d_classification_gpu(self):
+        """
+        Just see if we memorize the training set but on gpu
+        """
+        X, y = self.X, self.y
+
+        model = GPClassificationModel(
+            torch.Tensor([-3]),
+            torch.Tensor([3]),
+            inducing_size=10,
+        ).to("cuda")
+
+        model.fit(X[:50], y[:50])
+
+        # pspace
+        pm, _ = model.predict_probability(X[:50])
+        pred = (pm > 0.5).cpu().numpy()
+        npt.assert_allclose(pred, y[:50].cpu().numpy())
+
+        # fspace
+        pm, _ = model.predict(X[:50], probability_space=False)
+        pred = (pm > 0).cpu().numpy()
+        npt.assert_allclose(pred, y[:50].cpu().numpy())
+
+        # smoke test update
+        model.update(X, y)
+
+        # pspace
+        pm, _ = model.predict_probability(X)
+        pred = (pm > 0.5).cpu().numpy()
+        npt.assert_allclose(pred, y.cpu().numpy())
+
+        # fspace
+        pm, _ = model.predict(X, probability_space=False)
+        pred = (pm > 0).cpu().numpy()
+        npt.assert_allclose(pred, y.cpu().numpy())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_gpu/models/test_gp_regression.py
+++ b/tests_gpu/models/test_gp_regression.py
@@ -10,14 +10,12 @@ import unittest
 import uuid
 
 import numpy as np
-import numpy.testing as npt
 import torch
 from aepsych.server import AEPsychServer
 
 from aepsych.server.message_handlers.handle_ask import ask
 from aepsych.server.message_handlers.handle_setup import configure
 from aepsych.server.message_handlers.handle_tell import tell
-from gpytorch.likelihoods import GaussianLikelihood
 
 # run on single threads to keep us from deadlocking weirdly in CI
 if "CI" in os.environ or "SANDCASTLE" in os.environ:
@@ -72,28 +70,15 @@ class GPRegressionTest(unittest.TestCase):
     def tearDown(self):
         self.server.db.delete_db()
 
-    def test_extremum(self):
-        tol = 0.2  # don't need to be super precise because it's small data
-        fmax, argmax = self.server.strat.get_max()
+    def test_gpu_fit(self):
+        self.server._strats[0].strat_list[1].model_device = torch.device("cuda")
 
-        npt.assert_allclose(fmax, 0, atol=tol)
-        npt.assert_allclose(argmax, 0, atol=tol)
+        data = torch.tensor([0])
+        response = self.f(data)
+        self.server.strat.add_data(data, response)
+        self.server.strat.fit()
 
-        fmin, argmin = self.server.strat.get_min()
-        npt.assert_allclose(fmin, -256 / 27, atol=tol)
-        npt.assert_allclose(argmin, 8 / 3, atol=tol)
-
-        val, arg = self.server.strat.inv_query(0)
-        npt.assert_allclose(val, 0, atol=tol)
-        npt.assert_allclose(arg, 0, atol=tol)
-
-    def test_from_config(self):
-        model = self.server.strat.model
-        npt.assert_allclose(model.lb, [-1.0])
-        npt.assert_allclose(model.ub, [3.0])
-        self.assertEqual(model.dim, 1)
-        self.assertIsInstance(model.likelihood, GaussianLikelihood)
-        self.assertEqual(model.max_fit_time, 1)
+        self.assertTrue(self.server.strat.model.device.type == "cuda")
 
 
 if __name__ == "__main__":

--- a/tests_gpu/test_config.py
+++ b/tests_gpu/test_config.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from aepsych.config import Config
+
+from aepsych.strategy import SequentialStrategy
+from aepsych.version import __version__
+
+
+class ConfigTestCase(unittest.TestCase):
+    def test_model_gpu(self):
+        config_str = """
+            [common]
+            parnames = [par1]
+            strategy_names = [gpu_strategy]
+            outcome_types = [binary]
+            stimuli_per_trial = 1
+
+            [par1]
+            par_type = continuous
+            lower_bound = 0
+            upper_bound = 1
+            
+            [gpu_strategy]
+            model = GPClassificationModel
+            
+            [GPClassificationModel]
+            use_gpu = True
+        """
+        config = Config()
+        config.update(config_str=config_str)
+
+        strat = SequentialStrategy.from_config(config)
+
+        self.assertTrue(strat.model.device.type == "cuda")
+
+        strat.add_data(torch.tensor([0.5]), torch.tensor([1]))
+        strat.fit()
+
+        self.assertTrue(strat.model.device.type == "cuda")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary: GPU tests can only run in a very specific buck TARGET block. Moving out all those tests to their own directory can allow us to only test those and avoid a lot of noise from tests just skipping. This also removes the tests from Github Workflows, again avoiding noise.

Differential Revision: D65492677


