### PR TITLE
setup ConfigurableMixin for wider use

### DIFF
--- a/aepsych/config.pyi
+++ b/aepsych/config.pyi
@@ -68,6 +68,16 @@ class Config(configparser.ConfigParser):
 
 class ConfigurableMixin(abc.ABC):
     @classmethod
-    def get_config_options(cls, config: Config, name: str) -> Dict[str, Any]: ...
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]: ...
     @classmethod
-    def from_config(cls, config: Config, name: Optional[str] = None): ...
+    def from_config(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ): ...

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -55,23 +55,17 @@ class SobolGenerator(AEPsychGenerator):
         Args:
             num_points (int, optional): Number of points to query.
         Returns:
-            torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
+            torch.Tensor: Next set of point(s) to evaluate, [num_points x dim] or [num_points x dim x stimuli_per_trial] if stimuli_per_trial != 1.
         """
         grid = self.engine.draw(num_points)
         grid = self.lb + (self.ub - self.lb) * grid
         if self.stimuli_per_trial == 1:
             return grid
 
-        return torch.tensor(
-            np.moveaxis(
-                grid.reshape(num_points, self.stimuli_per_trial, -1).numpy(),
-                -1,
-                -self.stimuli_per_trial,
-            )
-        )
+        return grid.reshape(num_points, self.stimuli_per_trial, -1).swapaxes(-1, -2)
 
     @classmethod
-    def from_config(cls, config: Config) -> 'SobolGenerator':
+    def from_config(cls, config: Config) -> "SobolGenerator":
         classname = cls.__name__
 
         lb = config.gettensor(classname, "lb")


### PR DESCRIPTION
Summary: Setup the ConfigurableMixin for wider use, the following diffs will immediately use it for parameter transforms but the general API is intended to be eventually used for all classes with a "from_config".

Differential Revision: D65496216


