### PR TITLE
Support optimizer options to be modified in models, starting from config

### DIFF
--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -364,6 +364,9 @@ class AEPsychMixin(GPyTorchModel):
         optimizer_kwargs = {} if optimizer_kwargs is None else optimizer_kwargs.copy()
         max_fit_time = kwargs.pop("max_fit_time", self.max_fit_time)
         if max_fit_time is not None:
+            if "options" not in optimizer_kwargs:
+                optimizer_kwargs["options"] = {}
+
             # figure out how long evaluating a single samp
             starttime = time.time()
             _ = mll(self(train_x), train_y)
@@ -371,7 +374,8 @@ class AEPsychMixin(GPyTorchModel):
                 time.time() - starttime + 1e-6
             )  # add an epsilon to avoid divide by zero
             n_eval = int(max_fit_time / single_eval_time)
-            optimizer_kwargs["options"] = {"maxfun": n_eval}
+
+            optimizer_kwargs["options"]["maxfun"] = n_eval
             logger.info(f"fit maxfun is {n_eval}")
 
         starttime = time.time()

--- a/aepsych/models/monotonic_projection_gp.py
+++ b/aepsych/models/monotonic_projection_gp.py
@@ -7,7 +7,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import gpytorch
 import numpy as np
@@ -15,6 +15,7 @@ import torch
 from aepsych.config import Config
 from aepsych.factory.default import default_mean_covar_factory
 from aepsych.models.gp_classification import GPClassificationModel
+from aepsych.utils import get_optimizer_options
 from botorch.posteriors.gpytorch import GPyTorchPosterior
 from gpytorch.likelihoods import Likelihood
 from statsmodels.stats.moment_helpers import corr2cov, cov2corr
@@ -104,6 +105,7 @@ class MonotonicProjectionGP(GPClassificationModel):
         inducing_size: Optional[int] = None,
         max_fit_time: Optional[float] = None,
         inducing_point_method: str = "auto",
+        optimizer_options: Optional[Dict[str, Any]] = None,
     ) -> None:
         assert len(monotonic_dims) > 0
         self.monotonic_dims = [int(d) for d in monotonic_dims]
@@ -119,6 +121,7 @@ class MonotonicProjectionGP(GPClassificationModel):
             inducing_size=inducing_size,
             max_fit_time=max_fit_time,
             inducing_point_method=inducing_point_method,
+            optimizer_options=optimizer_options,
         )
 
     def posterior(
@@ -222,6 +225,8 @@ class MonotonicProjectionGP(GPClassificationModel):
         )
         min_f_val = config.getfloat(classname, "min_f_val", fallback=None)
 
+        optimizer_options = get_optimizer_options(config, classname)
+
         return cls(
             lb=lb,
             ub=ub,
@@ -235,4 +240,5 @@ class MonotonicProjectionGP(GPClassificationModel):
             monotonic_dims=monotonic_dims,
             monotonic_grid_size=monotonic_grid_size,
             min_f_val=min_f_val,
+            optimizer_options=optimizer_options,
         )

--- a/aepsych/models/semi_p.py
+++ b/aepsych/models/semi_p.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import gpytorch
 import numpy as np
@@ -18,7 +18,7 @@ from aepsych.acquisition.objective.semi_p import SemiPThresholdObjective
 from aepsych.config import Config
 from aepsych.likelihoods import BernoulliObjectiveLikelihood, LinearBernoulliLikelihood
 from aepsych.models import GPClassificationModel
-from aepsych.utils import _process_bounds, promote_0d
+from aepsych.utils import _process_bounds, get_optimizer_options, promote_0d
 from aepsych.utils_logging import getLogger
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.optim.fit import fit_gpytorch_mll_scipy
@@ -189,6 +189,7 @@ class SemiParametricGPModel(GPClassificationModel):
         inducing_size: Optional[int] = None,
         max_fit_time: Optional[float] = None,
         inducing_point_method: str = "auto",
+        optimizer_options: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Initialize SemiParametricGP.
@@ -212,6 +213,8 @@ class SemiParametricGPModel(GPClassificationModel):
                 If "pivoted_chol", selects points based on the pivoted Cholesky heuristic.
                 If "kmeans++", selects points by performing kmeans++ clustering on the training data.
                 If "auto", tries to determine the best method automatically.
+            optimizer_options (Dict[str, Any], optional): Optimizer options to pass to the SciPy optimizer during
+                fitting. Assumes we are using L-BFGS-B.
         """
 
         lb, ub, dim = _process_bounds(lb, ub, dim)
@@ -252,6 +255,7 @@ class SemiParametricGPModel(GPClassificationModel):
             inducing_size=inducing_size,
             max_fit_time=max_fit_time,
             inducing_point_method=inducing_point_method,
+            optimizer_options=optimizer_options,
         )
 
     @classmethod
@@ -294,6 +298,8 @@ class SemiParametricGPModel(GPClassificationModel):
 
         slope_mean = config.getfloat(classname, "slope_mean", fallback=2)
 
+        optimizer_options = get_optimizer_options(config, classname)
+
         return cls(
             lb=lb,
             ub=ub,
@@ -304,6 +310,7 @@ class SemiParametricGPModel(GPClassificationModel):
             inducing_size=inducing_size,
             max_fit_time=max_fit_time,
             inducing_point_method=inducing_point_method,
+            optimizer_options=optimizer_options,
         )
 
     def fit(
@@ -440,6 +447,7 @@ class HadamardSemiPModel(GPClassificationModel):
         inducing_size: Optional[int] = None,
         max_fit_time: Optional[float] = None,
         inducing_point_method: str = "auto",
+        optimizer_options: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Initialize HadamardSemiPModel.
@@ -462,6 +470,8 @@ class HadamardSemiPModel(GPClassificationModel):
                 If "pivoted_chol", selects points based on the pivoted Cholesky heuristic.
                 If "kmeans++", selects points by performing kmeans++ clustering on the training data.
                 If "auto", tries to determine the best method automatically.
+            optimizer_options (Dict[str, Any], optional): Optimizer options to pass to the SciPy optimizer during
+                fitting. Assumes we are using L-BFGS-B.
         """
         super().__init__(
             lb=lb,
@@ -470,6 +480,7 @@ class HadamardSemiPModel(GPClassificationModel):
             inducing_size=inducing_size,
             max_fit_time=max_fit_time,
             inducing_point_method=inducing_point_method,
+            optimizer_options=optimizer_options,
         )
 
         self.stim_dim = stim_dim
@@ -595,6 +606,8 @@ class HadamardSemiPModel(GPClassificationModel):
 
         stim_dim = config.getint(classname, "stim_dim", fallback=0)
 
+        optimizer_options = get_optimizer_options(config, classname)
+
         return cls(
             lb=lb,
             ub=ub,
@@ -609,6 +622,7 @@ class HadamardSemiPModel(GPClassificationModel):
             inducing_size=inducing_size,
             max_fit_time=max_fit_time,
             inducing_point_method=inducing_point_method,
+            optimizer_options=optimizer_options,
         )
 
     def predict(

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -346,3 +346,31 @@ def get_dim(config: Config) -> int:
             )  # Choice parameters with n_choices < 3 add n_choices - 1 dims
 
     return dim
+
+
+def get_optimizer_options(config: Config, name: str) -> Dict[str, Any]:
+    """Return the optimizer options for the model to pass to the SciPy L-BFGS-B
+    optimizer. Only the somewhat useful ones for AEPsych are searched for: maxcor,
+    ftol, gtol, maxfun, maxiter, maxls. See docs for details:
+    https://docs.scipy.org/doc/scipy/reference/optimize.minimize-lbfgsb.html#optimize-minimize-lbfgsb
+
+    Args:
+        config (Config): Config to search for options.
+        name (str): Model name to look for options for.
+
+    Return:
+        Dict[str, Any]: Dictionary of options to pass to SciPy's minimize, assuming the
+            method is L-BFGS-B.
+    """
+    options: Dict[str, Optional[Union[float, int]]] = {}
+
+    options["maxcor"] = config.getint(name, "maxcor", fallback=None)
+    options["ftol"] = config.getfloat(name, "ftol", fallback=None)
+    options["gtol"] = config.getfloat(name, "gtol", fallback=None)
+    options["maxfun"] = config.getint(name, "maxfun", fallback=None)
+    options["maxiter"] = config.getint(name, "maxiter", fallback=None)
+    options["maxls"] = config.getint(name, "maxls", fallback=None)
+
+    # Filter all the nones out, which could just come back as an empty dict
+    options = {key: value for key, value in options.items() if value is not None}
+    return options


### PR DESCRIPTION
Summary:
Optimizer options can be used to control the SciPy minimize function during model fit. We now allow these options to be set during model initialization (including from config).

Every model includes these options.

Solves issue #439  

Differential Revision: D65641684


