### PR TITLE
make test_time_limit even more loose

### DIFF
--- a/tests/generators/test_optimize_acqf_generator.py
+++ b/tests/generators/test_optimize_acqf_generator.py
@@ -62,7 +62,9 @@ class TestOptimizeAcqfGenerator(unittest.TestCase):
         short = end - start
 
         # very loose test because fit time is only approximately computed
-        self.assertTrue(long > short)
+        # on very fast machines, short sometimes actually wins, but hopefully not by
+        # much
+        self.assertTrue(long - short > -0.05, f"Long time: {long}, short time: {short}")
 
     def test_instantiate_eubo(self):
         config = """


### PR DESCRIPTION
Summary:
Sometimes test_time_limit will fail on very fast devices (https://github.com/facebookresearch/aepsych/actions/runs/11827946255/attempts/1).

We make this test even more loose and add extra logging to help debug in future.

Differential Revision: D65923982


