### PR TITLE
add support for fixed parameters

### DIFF
--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -260,6 +260,22 @@ class Config(configparser.ConfigParser):
                 raise ValueError(
                     f"Parameter {param_name} is missing the upper_bound setting."
                 )
+        elif param_block["par_type"] == "integer":
+            # Check if bounds exist and actaully integers
+            if "lower_bound" not in param_block:
+                raise ValueError(
+                    f"Parameter {param_name} is missing the lower_bound setting."
+                )
+            if "upper_bound" not in param_block:
+                raise ValueError(
+                    f"Parameter {param_name} is missing the upper_bound setting."
+                )
+
+            if not (
+                self.getint(param_name, "lower_bound") % 1 == 0
+                and self.getint(param_name, "upper_bound") % 1 == 0
+            ):
+                raise ValueError(f"Parameter {param_name} has non-integer bounds.")
         else:
             raise ValueError(
                 f"Parameter {param_name} has an unsupported parameter type {param_block['par_type']}."

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -182,8 +182,8 @@ class Config(configparser.ConfigParser):
                     # Validate the parameter-specific block
                     self._check_param_settings(par_name)
 
-                    lb[i] = self[par_name]["lower_bound"]
-                    ub[i] = self[par_name]["upper_bound"]
+                    lb[i] = self[par_name].get("lower_bound", fallback="0")
+                    ub[i] = self[par_name].get("upper_bound", fallback="1")
 
                 self["common"]["lb"] = f"[{', '.join(lb)}]"
                 self["common"]["ub"] = f"[{', '.join(ub)}]"
@@ -276,6 +276,11 @@ class Config(configparser.ConfigParser):
                 and self.getint(param_name, "upper_bound") % 1 == 0
             ):
                 raise ValueError(f"Parameter {param_name} has non-integer bounds.")
+        elif param_block["par_type"] == "binary":
+            if "lower_bound" in param_block or "upper_bound" in param_block:
+                raise ValueError(
+                    f"Parameter {param_name} is binary and shouldn't have bounds."
+                )
         else:
             raise ValueError(
                 f"Parameter {param_name} has an unsupported parameter type {param_block['par_type']}."

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -260,6 +260,7 @@ class Config(configparser.ConfigParser):
                 raise ValueError(
                     f"Parameter {param_name} is missing the upper_bound setting."
                 )
+
         elif param_block["par_type"] == "integer":
             # Check if bounds exist and actaully integers
             if "lower_bound" not in param_block:
@@ -271,18 +272,27 @@ class Config(configparser.ConfigParser):
                     f"Parameter {param_name} is missing the upper_bound setting."
                 )
 
-            if not (
-                self.getint(param_name, "lower_bound") % 1 == 0
-                and self.getint(param_name, "upper_bound") % 1 == 0
-            ):
-                raise ValueError(f"Parameter {param_name} has non-integer bounds.")
+            try:
+                if not (
+                    self.getint(param_name, "lower_bound") % 1 == 0
+                    and self.getint(param_name, "upper_bound") % 1 == 0
+                ):
+                    raise ParameterConfigError(
+                        f"Parameter {param_name} has non-integer bounds."
+                    )
+            except ValueError:
+                raise ParameterConfigError(
+                    f"Parameter {param_name} has non-discrete bounds."
+                )
+
         elif param_block["par_type"] == "binary":
             if "lower_bound" in param_block or "upper_bound" in param_block:
-                raise ValueError(
+                raise ParameterConfigError(
                     f"Parameter {param_name} is binary and shouldn't have bounds."
                 )
+
         else:
-            raise ValueError(
+            raise ParameterConfigError(
                 f"Parameter {param_name} has an unsupported parameter type {param_block['par_type']}."
             )
 
@@ -513,3 +523,7 @@ Config.register_module(gpytorch.kernels)
 Config.register_module(botorch.acquisition)
 Config.register_module(botorch.acquisition.multi_objective)
 Config.registered_names["None"] = None
+
+
+class ParameterConfigError(Exception):
+    pass

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -291,6 +291,12 @@ class Config(configparser.ConfigParser):
                     f"Parameter {param_name} is binary and shouldn't have bounds."
                 )
 
+        elif param_block["par_type"] == "fixed":
+            if "value" not in param_block:
+                raise ParameterConfigError(
+                    f"Parameter {param_name} is fixed and needs to have value set."
+                )
+
         else:
             raise ParameterConfigError(
                 f"Parameter {param_name} has an unsupported parameter type {param_block['par_type']}."

--- a/aepsych/generators/manual_generator.py
+++ b/aepsych/generators/manual_generator.py
@@ -6,9 +6,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import warnings
-from typing import Dict, Optional, Union
+from typing import Dict, Optional
 
-import numpy as np
 import torch
 from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator
@@ -26,7 +25,7 @@ class ManualGenerator(AEPsychGenerator):
         self,
         lb: torch.Tensor,
         ub: torch.Tensor,
-        points: Union[np.ndarray, torch.Tensor],
+        points: torch.Tensor,
         dim: Optional[int] = None,
         shuffle: bool = True,
         seed: Optional[int] = None,
@@ -35,16 +34,18 @@ class ManualGenerator(AEPsychGenerator):
         Args:
             lb torch.Tensor: Lower bounds of each parameter.
             ub torch.Tensor: Upper bounds of each parameter.
-            points (Union[np.ndarray, torch.Tensor]): The points that will be generated.
+            points torch.Tensor: The points that will be generated.
             dim (int, optional): Dimensionality of the parameter space. If None, it is inferred from lb and ub.
             shuffle (bool): Whether or not to shuffle the order of the points. True by default.
         """
         self.seed = seed
         self.lb, self.ub, self.dim = _process_bounds(lb, ub, dim)
+        self.points = points
         if shuffle:
-            np.random.seed(self.seed)
-            np.random.shuffle(points)
-        self.points = torch.tensor(points)
+            if seed is not None:
+                torch.manual_seed(seed)
+            self.points = points[torch.randperm(len(points))]
+
         self.max_asks = len(self.points)
         self._idx = 0
 
@@ -82,9 +83,13 @@ class ManualGenerator(AEPsychGenerator):
         lb = config.gettensor(name, "lb")
         ub = config.gettensor(name, "ub")
         dim = config.getint(name, "dim", fallback=None)
-        points = config.getarray(name, "points")
+        points = config.gettensor(name, "points")
         shuffle = config.getboolean(name, "shuffle", fallback=True)
         seed = config.getint(name, "seed", fallback=None)
+
+        if len(points.shape) == 3:
+            # Configs have a reasonable natural input method that produces incorrect tensors
+            points = points.swapaxes(-1, -2)
 
         options = {
             "lb": lb,
@@ -107,10 +112,10 @@ class SampleAroundPointsGenerator(ManualGenerator):
 
     def __init__(
         self,
-        lb: Union[np.ndarray, torch.Tensor],
-        ub: Union[np.ndarray, torch.Tensor],
-        window: Union[np.ndarray, torch.Tensor],
-        points: Union[np.ndarray, torch.Tensor],
+        lb: torch.Tensor,
+        ub: torch.Tensor,
+        window: torch.Tensor,
+        points: torch.Tensor,
         samples_per_point: int,
         dim: Optional[int] = None,
         shuffle: bool = True,
@@ -120,7 +125,10 @@ class SampleAroundPointsGenerator(ManualGenerator):
         Args:
             lb (Union[np.ndarray, torch.Tensor]): Lower bounds of each parameter.
             ub (Union[np.ndarray, torch.Tensor]): Upper bounds of each parameter.
-            window (Union[np.ndarray, torch.Tensor]): How far away to sample from the reference point along each dimension.
+            window (Union[np.ndarray, torch.Tensor]): How far away to sample from the
+                reference point along each dimension. If the parameters are transformed,
+                the proportion of the range (based on ub/lb given) covered by the window
+                will be preserved (and not the absolute distance from the reference points).
             points (Union[np.ndarray, torch.Tensor]): The points that will be generated.
             samples_per_point (int): How many samples around each point to take.
             dim (int, optional): Dimensionality of the parameter space. If None, it is inferred from lb and ub.
@@ -128,16 +136,27 @@ class SampleAroundPointsGenerator(ManualGenerator):
             seed (int, optional): Random seed.
         """
         lb, ub, dim = _process_bounds(lb, ub, dim)
-        points = torch.Tensor(points)
         self.engine = SobolEngine(dimension=dim, scramble=True, seed=seed)
-        generated = []
+        gen_points = []
+        if len(points.shape) > 2:
+            # We need to determine how many stimuli there are per trial to maintain the proper tensor shape
+            n_draws = points.shape[-1]
+        else:
+            n_draws = 1
         for point in points:
+            if len(points.shape) > 2:
+                point = point.T
             p_lb = torch.max(point - window, lb)
             p_ub = torch.min(point + window, ub)
-            grid = self.engine.draw(samples_per_point)
-            grid = p_lb + (p_ub - p_lb) * grid
-            generated.append(grid)
-        generated = torch.Tensor(np.vstack(generated))  # type: ignore
+            for _ in range(samples_per_point):
+                grid = self.engine.draw(n_draws)
+                grid = p_lb + (p_ub - p_lb) * grid
+                gen_points.append(grid)
+        if len(points.shape) > 2:
+            generated = torch.stack(gen_points)
+            generated = generated.swapaxes(-2, -1)
+        else:
+            generated = torch.vstack(gen_points)
 
         super().__init__(lb, ub, generated, dim, shuffle, seed)  # type: ignore
 

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -238,7 +238,7 @@ class Strategy(object):
         if self.stimuli_per_trial == 1:
             self.event_shape: Tuple[int, ...] = (self.dim,)
 
-        if self.stimuli_per_trial == 2:
+        if self.stimuli_per_trial > 1:
             self.event_shape = (self.dim, self.stimuli_per_trial)
 
         self.model = model

--- a/aepsych/transforms/ops/__init__.py
+++ b/aepsych/transforms/ops/__init__.py
@@ -5,8 +5,9 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .fixed import Fixed
 from .log10_plus import Log10Plus
 from .normalize_scale import NormalizeScale
 from .round import Round
 
-__all__ = ["Log10Plus", "NormalizeScale", "Round"]
+__all__ = ["Log10Plus", "NormalizeScale", "Round", "Fixed"]

--- a/aepsych/transforms/ops/__init__.py
+++ b/aepsych/transforms/ops/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .log10_plus import Log10Plus
+from .normalize_scale import NormalizeScale
+from .round import Round
+
+__all__ = ["Log10Plus", "NormalizeScale", "Round"]

--- a/aepsych/transforms/ops/base.py
+++ b/aepsych/transforms/ops/base.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+from abc import ABC
+from copy import deepcopy
+from typing import Any, Dict, Literal, Optional
+
+import torch
+from aepsych.config import Config, ConfigurableMixin
+from botorch.models.transforms.input import ReversibleInputTransform
+
+
+class Transform(ReversibleInputTransform, ConfigurableMixin, ABC):
+    """Base class for individual transforms. These transforms are intended to be stacked
+    together using the ParameterTransforms class.
+    """
+
+    def transform_bounds(
+        self, X: torch.Tensor, bound: Optional[Literal["lb", "ub"]] = None, **kwargs
+    ) -> torch.Tensor:
+        r"""Return the bounds X transformed.
+
+        Args:
+            X (torch.Tensor): Either a `[1, dim]` or `[2, dim]` tensor of parameter
+                bounds.
+            bound (Literal["lb", "ub"], optional): Which bound this is to transform, if
+                None, it's the `[2, dim]` form with both bounds stacked.
+            **kwargs: Keyword arguments for specific transforms, they should have
+                default values.
+
+        Returns:
+            torch.Tensor: A transformed set of parameter bounds.
+        """
+        return self.transform(X)
+
+    @classmethod
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return a dictionary of the relevant options to initialize a Log10Plus
+        transform for the named parameter within the config.
+
+        Args:
+            config (Config): Config to look for options in.
+            name (str, optionla): Parameter to find options for.
+            options (Dict[str, Any], optional): Options to override from the config.
+
+        Returns:
+            Dict[str, Any]: A dictionary of options to initialize this class with,
+                including the transformed bounds.
+        """
+        if name is None:
+            raise ValueError(f"{name} must be set to initialize a transform.")
+
+        if options is None:
+            options = {}
+        else:
+            options = deepcopy(options)
+
+        # Figure out the index of this parameter
+        parnames = config.getlist("common", "parnames", element_type=str)
+        idx = parnames.index(name)
+
+        if "indices" not in options:
+            options["indices"] = [idx]
+
+        return options

--- a/aepsych/transforms/ops/fixed.py
+++ b/aepsych/transforms/ops/fixed.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+from aepsych.config import Config
+from aepsych.transforms.ops.base import Transform
+
+
+class Fixed(Transform, torch.nn.Module):
+    def __init__(
+        self,
+        indices: List[int],
+        values: List[Union[float, int]],
+        transform_on_train: bool = True,
+        transform_on_eval: bool = True,
+        transform_on_fantasize: bool = True,
+        reverse: bool = False,
+        **kwargs,
+    ) -> None:
+        """Initialize a fixed transform. It will add and remove fixed values from
+        tensors.
+
+        Args:
+            indices (List[int]): The indices of the parameters to be fixed.
+            values (List[Union[float, int]]): The values of the fixed parameters.
+            transform_on_train (bool): A boolean indicating whether to apply the
+                transforms in train() mode. Default: True.
+            transform_on_eval (bool): A boolean indicating whether to apply the
+                transform in eval() mode. Default: True.
+            transform_on_fantasize (bool): A boolean indicating whether to apply the
+                transform when called from within a `fantasize` call. Default: True.
+            reverse (bool): A boolean indicating whether the forward pass should
+                untransform the inputs. Default: False.
+            **kwargs: Accepted to conform to API.
+        """
+        # Turn indices and values into tensors and sort
+        indices_ = torch.tensor(indices, dtype=torch.long)
+        values_ = torch.tensor(values, dtype=torch.float64)
+
+        # Sort indices and values
+        sort_idx = torch.argsort(indices_)
+        indices_ = indices_[sort_idx]
+        values_ = values_[sort_idx]
+
+        super().__init__()
+        self.register_buffer("indices", indices_)
+        self.register_buffer("values", values_)
+        self.transform_on_train = transform_on_train
+        self.transform_on_eval = transform_on_eval
+        self.transform_on_fantasize = transform_on_fantasize
+        self.reverse = reverse
+
+    def _transform(self, X: torch.Tensor) -> torch.Tensor:
+        r"""Transform the input Tensor by popping out the fixed parameters at the
+        specified indices.
+
+        Args:
+            X (torch.Tensor): A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            torch.Tensor: The input tensor with fixed parameters removed.
+        """
+        X = X.clone()
+
+        mask = ~torch.isin(torch.arange(X.shape[1]), self.indices)
+
+        X = X[:, mask]
+
+        return X
+
+    def _untransform(self, X: torch.Tensor) -> torch.Tensor:
+        r"""Transform the input tensor by adding back in the fixed parameters at the
+        specified indices.
+
+        Args:
+            X (torch.Tensor): A `batch_shape x n x d`-dim tensor of transformed inputs.
+
+        Returns:
+            torch.Tensor: The same tensor as the input with the fixed parameters added
+                back in.
+        """
+        X = X.clone()
+
+        for i, idx in enumerate(self.indices):
+            pre_fixed = X[:, :idx]
+            post_fixed = X[:, idx:]
+            fixed = torch.tile(self.values[i], (X.shape[0], 1))
+            X = torch.cat((pre_fixed, fixed, post_fixed), dim=1)
+
+        return X
+
+    @classmethod
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return a dictionary of the relevant options to initialize a Fixed parameter
+        transform for the named parameter within the config.
+
+        Args:
+            config (Config): Config to look for options in.
+            name (str, optional): Parameter to find options for.
+            options (Dict[str, Any], optional): Options to override from the config.
+
+        Returns:
+            Dict[str, Any]: A dictionary of options to initialize this class with,
+                including the transformed bounds.
+        """
+        options = super().get_config_options(config=config, name=name, options=options)
+
+        if name is None:
+            raise ValueError(f"{name} must be set to initialize a transform.")
+
+        if "values" not in options:
+            options["values"] = [config.getfloat(name, "value")]
+
+        return options

--- a/aepsych/transforms/ops/log10_plus.py
+++ b/aepsych/transforms/ops/log10_plus.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+from aepsych.config import Config
+from aepsych.transforms.ops.base import Transform
+from aepsych.utils import get_bounds
+from botorch.models.transforms.input import Log10, subset_transform
+
+
+class Log10Plus(Log10, Transform):
+    """Base-10 log transform that we add a constant to the values"""
+
+    def __init__(
+        self,
+        indices: List[int],
+        constant: float = 0.0,
+        transform_on_train: bool = True,
+        transform_on_eval: bool = True,
+        transform_on_fantasize: bool = True,
+        reverse: bool = False,
+        **kwargs,
+    ) -> None:
+        """Initalize transform
+
+        Args:
+            indices (List[int]): The indices of the parameters to log transform.
+            constant (float): The constant to add to inputs before log transforming.
+                Defaults to 0.0.
+            transform_on_train (bool): A boolean indicating whether to apply the
+                transforms in train() mode. Default: True.
+            transform_on_eval (bool): A boolean indicating whether to apply the
+                transform in eval() mode. Default: True.
+            transform_on_fantasize (bool): A boolean indicating whether to apply the
+                transform when called from within a `fantasize` call. Default: True.
+            reverse (bool): A boolean indicating whether the forward pass should
+                untransform the inputs. Default: False.
+            **kwargs: Accepted to conform to API.
+        """
+        super().__init__(
+            indices=indices,
+            transform_on_train=transform_on_train,
+            transform_on_eval=transform_on_eval,
+            transform_on_fantasize=transform_on_fantasize,
+            reverse=reverse,
+        )
+        self.register_buffer("constant", torch.tensor(constant, dtype=torch.long))
+
+    @subset_transform
+    def _transform(self, X: torch.Tensor) -> torch.Tensor:
+        r"""Add the constant then log transform the inputs.
+
+        Args:
+            X (torch.Tensor): A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            torch.Tensor: A `batch_shape x n x d`-dim tensor of transformed inputs.
+        """
+        X = X + (torch.ones_like(X) * self.constant)
+        return X.log10()
+
+    @subset_transform
+    def _untransform(self, X: torch.Tensor) -> torch.Tensor:
+        r"""Reverse the log transformation then subtract the constant.
+
+        Args:
+            X (torch.Tensor): A `batch_shape x n x d`-dim tensor of transformed inputs.
+
+        Returns:
+            torch.Tensor: A `batch_shape x n x d`-dim tensor of untransformed inputs.
+        """
+        X = 10.0**X
+        return X - (torch.ones_like(X) * self.constant)
+
+    @classmethod
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return a dictionary of the relevant options to initialize a Log10Plus
+        transform for the named parameter within the config.
+
+        Args:
+            config (Config): Config to look for options in.
+            name (str, optional): Parameter to find options for.
+            options (Dict[str, Any], optional): Options to override from the config.
+
+        Returns:
+            Dict[str, Any]: A dictionary of options to initialize this class with,
+                including the transformed bounds.
+        """
+        options = super().get_config_options(config=config, name=name, options=options)
+
+        # Make sure we have bounds ready
+        if "bounds" not in options:
+            options["bounds"] = get_bounds(config)
+
+        if "constant" not in options:
+            lb = options["bounds"][0, options["indices"]]
+            if lb < 0.0:
+                constant = np.abs(lb) + 1.0
+            elif lb < 1.0:
+                constant = 1.0
+            else:
+                constant = 0.0
+
+            options["constant"] = constant
+
+        return options

--- a/aepsych/transforms/ops/normalize_scale.py
+++ b/aepsych/transforms/ops/normalize_scale.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+from aepsych.config import Config
+from aepsych.transforms.ops.base import Transform
+from aepsych.utils import get_bounds
+from botorch.models.transforms.input import Normalize
+
+
+class NormalizeScale(Normalize, Transform):
+    def __init__(
+        self,
+        d: int,
+        indices: Optional[Union[List[int], torch.Tensor]] = None,
+        bounds: Optional[torch.Tensor] = None,
+        batch_shape: torch.Size = torch.Size(),
+        transform_on_train: bool = True,
+        transform_on_eval: bool = True,
+        transform_on_fantasize: bool = True,
+        reverse: bool = False,
+        min_range: float = 1e-8,
+        learn_bounds: Optional[bool] = None,
+        almost_zero: float = 1e-12,
+        **kwargs,
+    ) -> None:
+        r"""Normalizes the scale of the parameters.
+
+        Args:
+            d (int): Total number of parameters (dimensions).
+            indices (Union[List[int], torch.Tensor], optional
+                inputs to normalize. If omitted, take all dimensions of the inputs into
+                account.
+            bounds (torch.Tensor, optional): If provided, use these bounds to normalize
+                the parameters. If omitted, learn the bounds in train mode.
+            batch_shape (torch.Size): The batch shape of the inputs (assuming input
+                tensors of shape `batch_shape x n x d`). If provided, perform individual
+                normalization per batch, otherwise uses a single normalization.
+            transform_on_train (bool): A boolean indicating whether to apply the
+                transforms in train() mode. Default: True.
+            transform_on_eval (bool): A boolean indicating whether to apply the
+                transform in eval() mode. Default: True.
+            transform_on_fantasize (bool): A boolean indicating whether to apply the
+                transform when called from within a `fantasize` call. Default: True.
+            reverse (bool): A boolean indicating whether the forward pass should
+                untransform the parameters. Default: False.
+            min_range (float): If the range of a parameter is smaller than `min_range`,
+                that parameter will not be normalized. This is equivalent to
+                using bounds of `[0, 1]` for this dimension, and helps avoid division
+                by zero errors and related numerical issues. See the example below.
+                NOTE: This only applies if `learn_bounds=True`. Defaults to 1e-8.
+            learn_bounds (bool): Whether to learn the bounds in train mode. Defaults
+                to False if bounds are provided, otherwise defaults to True.
+            almost_zero (float): Threshold to consider the range essentially 0 and
+                turns into a no op. Defaults to 1e-12.
+            **kwargs: Accepted to conform to API.
+        """
+        super().__init__(
+            d=d,
+            indices=indices,
+            bounds=bounds,
+            batch_shape=batch_shape,
+            transform_on_train=transform_on_train,
+            transform_on_eval=transform_on_eval,
+            transform_on_fantasize=transform_on_fantasize,
+            reverse=reverse,
+            min_range=min_range,
+            learn_bounds=learn_bounds,
+            almost_zero=almost_zero,
+        )
+
+    @classmethod
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Return a dictionary of the relevant options to initialize a NormalizeScale
+        transform for the named parameter within the config.
+
+        Args:
+            config (Config): Config to look for options in.
+            name (str, optional): Parameter to find options for.
+            options (Dict[str, Any], optional): Options to override from the config.
+
+        Return:
+            Dict[str, Any]: A dictionary of options to initialize this class with,
+                including the transformed bounds.
+        """
+        options = super().get_config_options(config=config, name=name, options=options)
+
+        # Make sure we have bounds ready
+        if "bounds" not in options:
+            options["bounds"] = get_bounds(config)
+
+        if "d" not in options:
+            options["d"] = options["bounds"].shape[1]
+
+        return options

--- a/aepsych/transforms/ops/round.py
+++ b/aepsych/transforms/ops/round.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import List, Literal, Optional
+
+import torch
+from aepsych.transforms.ops.base import Transform
+from botorch.models.transforms.input import subset_transform
+
+
+class Round(Transform, torch.nn.Module):
+    def __init__(
+        self,
+        indices: List[int],
+        transform_on_train: bool = True,
+        transform_on_eval: bool = True,
+        transform_on_fantasize: bool = True,
+        reverse: bool = False,
+        **kwargs,
+    ) -> None:
+        """Initialize a round transform. This operation rounds the inputs at the indices
+        in both direction.
+
+        Args:
+            indices (List[int]): The indices of the inputs to round.
+            transform_on_train (bool): A boolean indicating whether to apply the
+                transforms in train() mode. Default: True.
+            transform_on_eval (bool): A boolean indicating whether to apply the
+                transform in eval() mode. Default: True.
+            transform_on_fantasize (bool): Currently will not do anything, here to
+                conform to API.
+            reverse (bool): Whether to round in forward or backward passes. Does not do
+                anything, both direction rounds.
+            **kwargs: Accepted to conform to API.
+        """
+        super().__init__()
+        self.register_buffer("indices", torch.tensor(indices, dtype=torch.long))
+        self.transform_on_train = transform_on_train
+        self.transform_on_eval = transform_on_eval
+        self.transform_on_fantasize = transform_on_fantasize
+        self.reverse = reverse
+
+    @subset_transform
+    def _transform(self, X: torch.Tensor) -> torch.Tensor:
+        r"""Round the inputs to a model to be discrete. This rounding is the same both
+        in the forward and the backward pass.
+
+        Args:
+            X (torch.Tensor): A `batch_shape x n x d`-dim tensor of inputs.
+
+        Returns:
+            torch.Tensor: The input tensor with values rounded.
+        """
+        return X.round()
+
+    @subset_transform
+    def _untransform(self, X: torch.Tensor) -> torch.Tensor:
+        r"""Round the inputs to a model to be discrete. This rounding is the same both
+        in the forward and the backward pass.
+
+        Args:
+            X (torch.Tensor): A `batch_shape x n x d`-dim tensor of transformed inputs.
+
+        Returns:
+            torch.Tensor: The input tensor with values rounded.
+        """
+        return X.round()
+
+    def transform_bounds(
+        self, X: torch.Tensor, bound: Optional[Literal["lb", "ub"]] = None, **kwargs
+    ) -> torch.Tensor:
+        r"""Return the bounds X transformed.
+
+        Args:
+            X (torch.Tensor): Either a `[1, dim]` or `[2, dim]` tensor of parameter
+                bounds.
+            bound (Literal["lb", "ub"], optional): The bound that this is, if None, we
+                will assume the input is both bounds with a `[2, dim]` X.
+            **kwargs: passed to _transform_bounds
+                epsilon: will modify the offset for the rounding to ensure each discrete
+                    value has equal space in the parameter space.
+
+        Returns:
+            torch.Tensor: A transformed set of parameter bounds.
+        """
+        epsilon = kwargs.get("epsilon", 1e-6)
+        return self._transform_bounds(X, bound=bound, epsilon=epsilon)
+
+    def _transform_bounds(
+        self,
+        X: torch.Tensor,
+        bound: Optional[Literal["lb", "ub"]] = None,
+        epsilon: float = 1e-6,
+    ) -> torch.Tensor:
+        r"""Return the bounds X transformed.
+
+        Args:
+            X (torch.Tensor): Either a `[1, dim]` or `[2, dim]` tensor of parameter
+                bounds.
+            bound (Literal["lb", "ub"], optional): The bound that this is, if None, we
+                will assume the input is both bounds with a `[2, dim]` X.
+            epsilon:
+            **kwargs: other kwargs
+
+        Returns:
+            torch.Tensor: A transformed set of parameter bounds.
+        """
+        X = X.clone()
+
+        if bound == "lb":
+            X[0, self.indices] -= torch.tensor([0.5] * len(self.indices))
+        elif bound == "ub":
+            X[0, self.indices] += torch.tensor([0.5 - epsilon] * len(self.indices))
+        else:  # Both bounds
+            X[0, self.indices] -= torch.tensor([0.5] * len(self.indices))
+            X[1, self.indices] += torch.tensor([0.5 - epsilon] * len(self.indices))
+
+        return X

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -171,8 +171,8 @@ class ParameterTransforms(ChainedInputTransform, ConfigurableMixin):
             except KeyError:  # Probably because par doesn't have its own section
                 par_type = "continuous"
 
-            # Integer variable
-            if par_type == "integer":
+            # Integer or binary variable
+            if par_type in ["integer", "binary"]:
                 round = Round.from_config(
                     config=config, name=par, options=transform_options
                 )
@@ -196,7 +196,9 @@ class ParameterTransforms(ChainedInputTransform, ConfigurableMixin):
                 transform_dict[f"{par}_Log10Plus"] = log10
 
             # Normalize scale (defaults true)
-            if config.getboolean(par, "normalize_scale", fallback=True):
+            if config.getboolean(
+                par, "normalize_scale", fallback=True
+            ) and par_type not in ["discrete", "binary"]:
                 normalize = NormalizeScale.from_config(
                     config=config, name=par, options=transform_options
                 )

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -807,6 +807,24 @@ def transform_options(
 
                 if option in ["ub", "lb"]:
                     value = transforms.transform_bounds(value, bound=option)
+                elif option == "points" and len(value.shape) == 3:
+                    value = value.swapaxes(-2, -1)
+                    value = transforms.transform(value)
+                    value = value.swapaxes(-1, -2)
+                elif option == "window":
+                    # Get proportion of range covered in raw space
+                    raw_lb = config.gettensor("common", "lb")
+                    raw_ub = config.gettensor("common", "ub")
+                    raw_range = raw_ub - raw_lb
+                    window_prop = (value * 2) / raw_range
+
+                    # Calculate transformed range
+                    transformed_lb = transforms.transform_bounds(raw_lb, bound="lb")
+                    transformed_ub = transforms.transform_bounds(raw_ub, bound="ub")
+                    transformed_range = transformed_ub - transformed_lb
+
+                    # Transformed window covers the same proportion of range
+                    value = window_prop * transformed_range / 2
                 else:
                     value = transforms.transform(value)
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -27,6 +27,19 @@ parameters can have any non-infinite ranges. This means that continuous paramete
 include negative values (e.g., lower bound = -1, upper bound = 1) or have very large
 ranges (e.g., lower bound = 0, upper bound = 1,000,000).
 
+<h3>Integer<h3>
+```ini
+[parameter]
+par_type = integer
+lower_bound = -5
+upper_bound = 5
+```
+
+Integer parameters are similar to continuous parameters insofar as its possible range
+and necessity of bounds. However, integer parameters will use continuous relaxation to
+allow the models and generators to handle integer input/outputs. For example, this could
+represent the number of lights are on for a detection threshold experiment. 
+
 <h2>Parameter Transformations</h2>
 Currently, we only support a log scale transformation to parameters. More parameter
 transformations to come! In general, you can define your parameters in the raw
@@ -83,5 +96,6 @@ of operation, regardless of how the options were set in the config file. Each pa
 is transformed entirely separately. 
 
 Currently, the order is as follows:
+* Rounding for integer parameters (rounding is applied in both directions)
 * Log scale
 * Normalize scale

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -15,6 +15,7 @@ what parameter types are used and whatever transformations are used.
 Currently, we only support continuous parameters. More parameter types soon to come!
 
 <h3>Continuous<h3>
+
 ```ini
 [parameter]
 par_type = continuous
@@ -28,6 +29,7 @@ include negative values (e.g., lower bound = -1, upper bound = 1) or have very l
 ranges (e.g., lower bound = 0, upper bound = 1,000,000).
 
 <h3>Integer<h3>
+
 ```ini
 [parameter]
 par_type = integer
@@ -38,7 +40,28 @@ upper_bound = 5
 Integer parameters are similar to continuous parameters insofar as its possible range
 and necessity of bounds. However, integer parameters will use continuous relaxation to
 allow the models and generators to handle integer input/outputs. For example, this could
-represent the number of lights are on for a detection threshold experiment. 
+represent the number of lights are on for a detection threshold experiment.
+
+<h3>Binary</h3>
+
+```ini
+[parameter]
+par_type = binary
+```
+
+Binary parameters are useful for modeling any parameters that can take two distinct values,
+such as whether or not a distractor is present or whether a visual task is done with one
+eye or two, whether a haptics task is done with the left hand or the right hand, or whether
+an auditory task is done with background noise or not. Binary parameters are implemented as
+a special case of a integer parameter. No bounds should be set. It will be treated as a integer
+parameter that will either be 0 or 1. Binary parameters are equivalent to this:
+
+```ini
+[parameter]
+par_type = discrete
+lower_bound = 0
+upper_bound = 1
+```
 
 <h2>Parameter Transformations</h2>
 Currently, we only support a log scale transformation to parameters. More parameter
@@ -72,28 +95,28 @@ lower bounds that are negative, we will use a constant value of the absolute val
 the lower bound + 1 (i.e., `Log10(x + |lb| + 1)` and `10 ^ (x - |lb| - 1)`).
 
 <h3>Normalize scale</h3>
-By default, all parameters will have their scale min-max normalized to the range of 
+By default, all parameters will have their scale min-max normalized to the range of
 [0, 1]. This prevents any particular parameter with a large scale to completely dominate
-the other parameters. Very rarely, this behavior may not be desired and can be turned 
+the other parameters. Very rarely, this behavior may not be desired and can be turned
 off for specific parameters.
 
 ```ini
 [parameter]
 par_type = continuous
-lower_bound = 1 
+lower_bound = 1
 upper_bound = 100
 normalize_scale = False # turn it on with any of true/yes/on, turn it off with any of false/no/off; case insensitive
 ```
 
-By setting the `normalize_scale` option to False, this parameter will not be scaled 
+By setting the `normalize_scale` option to False, this parameter will not be scaled
 before being given to the model and therefore maintain its original magnitude. This is
-very rarely necessary and should be used with caution. 
+very rarely necessary and should be used with caution.
 
 <h2>Order of operations</h2>
-Parameter types and parameter-specific transforms are all handled by the 
+Parameter types and parameter-specific transforms are all handled by the
 `ParameterTransform` API. Transforms built from config files will have a specific order
 of operation, regardless of how the options were set in the config file. Each parameter
-is transformed entirely separately. 
+is transformed entirely separately.
 
 Currently, the order is as follows:
 * Rounding for integer parameters (rounding is applied in both directions)

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -63,6 +63,19 @@ lower_bound = 0
 upper_bound = 1
 ```
 
+<h3>Fixed</h3>
+
+```ini
+[parameter]
+par_type = fixed
+value = 4.5
+```
+
+Fixed parameters always take the same specified value, and thus are not actually modeled, but they are still included in ask and tell messages. This is useful when you would like to make changes to your experiment without having to change client code. For example, you could run the same experiment multiple times with a different fixed value for one parameter just by changing the value in the config.
+and added to tells and asks, respectively. Fixed parameters when running multiple
+conditions with certain parameters fixed; instead of removing the parameter entirely,
+a parameter can be set to fixed at a certain value in certain configs.
+
 <h2>Parameter Transformations</h2>
 Currently, we only support a log scale transformation to parameters. More parameter
 transformations to come! In general, you can define your parameters in the raw
@@ -122,3 +135,4 @@ Currently, the order is as follows:
 * Rounding for integer parameters (rounding is applied in both directions)
 * Log scale
 * Normalize scale
+* Fixed parameters are removed

--- a/tests/models/test_gp_classification.py
+++ b/tests/models/test_gp_classification.py
@@ -24,7 +24,7 @@ from aepsych.generators import OptimizeAcqfGenerator, SobolGenerator
 from aepsych.models import GPClassificationModel
 from aepsych.strategy import SequentialStrategy, Strategy
 from aepsych.transforms import ParameterTransformedModel, ParameterTransforms
-from aepsych.transforms.parameters import Normalize
+from aepsych.transforms.ops import NormalizeScale
 from botorch.acquisition import qUpperConfidenceBound
 from botorch.optim.fit import fit_gpytorch_mll_torch
 from botorch.optim.stopping import ExpMAStoppingCriterion
@@ -217,7 +217,7 @@ class GPClassificationSmoketest(unittest.TestCase):
         ub = torch.tensor([3000, 0.003])
 
         transforms = ParameterTransforms(
-            normalize=Normalize(2, bounds=torch.stack((lb, ub)))
+            normalize=NormalizeScale(2, bounds=torch.stack((lb, ub)))
         )
         model = ParameterTransformedModel(
             model=GPClassificationModel,

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -27,7 +27,7 @@ from aepsych.transforms import (
     ParameterTransformedModel,
     ParameterTransforms,
 )
-from aepsych.transforms.parameters import Normalize
+from aepsych.transforms.ops import NormalizeScale
 from botorch.acquisition import qUpperConfidenceBound
 from botorch.acquisition.active_learning import PairwiseMCPosteriorVariance
 from scipy.stats import bernoulli, norm, pearsonr
@@ -202,7 +202,7 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
         ub = torch.tensor([4.0])
         extra_acqf_args = {"beta": 3.84}
         transforms = ParameterTransforms(
-            normalize=Normalize(d=1, bounds=torch.stack([lb, ub]))
+            normalize=NormalizeScale(d=1, bounds=torch.stack([lb, ub]))
         )
         sobol_gen = ParameterTransformedGenerator(
             generator=SobolGenerator,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,7 @@ from aepsych.server import AEPsychServer
 from aepsych.server.message_handlers.handle_setup import configure
 from aepsych.strategy import SequentialStrategy, Strategy
 from aepsych.transforms import ParameterTransforms, transform_options
-from aepsych.transforms.parameters import Log10Plus, NormalizeScale
+from aepsych.transforms.ops import Log10Plus, NormalizeScale
 from aepsych.version import __version__
 from botorch.acquisition import qLogNoisyExpectedImprovement
 from botorch.acquisition.active_learning import PairwiseMCPosteriorVariance

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ import torch
 from aepsych.acquisition import EAVC, MCLevelSetEstimation
 from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
 from aepsych.acquisition.objective import FloorGumbelObjective, ProbitObjective
-from aepsych.config import Config
+from aepsych.config import Config, ParameterConfigError
 from aepsych.generators import (
     MonotonicRejectionGenerator,
     OptimizeAcqfGenerator,
@@ -1179,7 +1179,7 @@ class ConfigTestCase(unittest.TestCase):
             par_type = invalid_type
         """
         config = Config()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParameterConfigError):
             config.update(config_str=config_str)
 
     def test_continuous_parameter_lb_validation(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1274,10 +1274,8 @@ class ConfigTestCase(unittest.TestCase):
 
         transforms = ParameterTransforms.from_config(config)
         reversed_points = transforms.untransform(xformed_points)
-        reversed_window = transforms.untransform(xformed_window)
 
         self.assertTrue(torch.allclose(reversed_points, torch.tensor(points)))
-        self.assertTrue(torch.allclose(reversed_window, torch.tensor(window)))
 
     def test_build_transform(self):
         config_str = """

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -25,7 +25,7 @@ from aepsych.transforms import (
     ParameterTransformedModel,
     ParameterTransforms,
 )
-from aepsych.transforms.parameters import Normalize
+from aepsych.transforms.ops import NormalizeScale
 
 
 class TestSequenceGenerators(unittest.TestCase):
@@ -39,7 +39,7 @@ class TestSequenceGenerators(unittest.TestCase):
         extra_acqf_args = {"target": 0.75, "beta": 1.96}
 
         transforms = ParameterTransforms(
-            normalize=Normalize(d=2, bounds=torch.stack([lb, ub]))
+            normalize=NormalizeScale(d=2, bounds=torch.stack([lb, ub]))
         )
 
         self.strat = Strategy(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -17,7 +17,7 @@ from aepsych.transforms import (
     ParameterTransformedModel,
     ParameterTransforms,
 )
-from aepsych.transforms.parameters import Log10Plus, NormalizeScale
+from aepsych.transforms.ops import Log10Plus, NormalizeScale
 
 
 class TransformsConfigTest(unittest.TestCase):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -8,7 +8,7 @@ import unittest
 
 import numpy as np
 import torch
-from aepsych.config import Config
+from aepsych.config import Config, ParameterConfigError
 from aepsych.generators import SobolGenerator
 from aepsych.models import GPClassificationModel
 from aepsych.strategy import SequentialStrategy
@@ -396,6 +396,31 @@ class TransformInteger(unittest.TestCase):
         self.assertTrue(torch.all(strat._strat.generator.lb == 0))
         self.assertTrue(torch.all(strat._strat.generator.ub == 1))
 
+        bad_config_str = """
+            [common]
+            parnames = [signal1, signal2]
+            stimuli_per_trial = 1
+            outcome_types = [binary]
+            strategy_names = [init_strat]
+
+            [signal1]
+            par_type = continuous
+            lower_bound = 0
+            upper_bound = 1
+
+            [signal2]
+            par_type = discrete
+            lower_bound = 1
+            upper_bound = 4.5
+
+            [init_strat]
+            generator = SobolGenerator
+            min_asks = 1
+        """
+        config = Config()
+        with self.assertRaises(ParameterConfigError):
+            config.update(config_str=bad_config_str)
+
     def test_integer_model(self):
         np.random.seed(1)
         torch.manual_seed(1)
@@ -498,5 +523,5 @@ class TransformInteger(unittest.TestCase):
         """
         config = Config()
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParameterConfigError):
             config.update(config_str=bad_config_str)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,13 +6,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from copy import deepcopy
 
 import numpy as np
 import torch
-from aepsych.config import Config
 from aepsych.models import GPClassificationModel
-from aepsych.utils import _process_bounds, get_dim, get_parameters, make_scaled_sobol
+from aepsych.utils import _process_bounds, make_scaled_sobol
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -50,158 +48,6 @@ class UtilsTestCase(unittest.TestCase):
         # ub < lb
         with self.assertRaises(AssertionError):
             _process_bounds(np.r_[1], np.r_[0], None)
-
-
-class ParameterUtilsTestCase(unittest.TestCase):
-    def setUp(self) -> None:
-        config_str = """
-        [common]
-        parnames = [par1, par2, par3]
-        lb = [0, 0, 0]
-        ub = [1, 1000, 10]
-        choice_parnames = [par4, par5, par6, par9]
-        fixed_parnames = [par7, par8]
-
-        [par2]
-        log_scale = True
-
-        [par3]
-        value_type = int
-
-        [par4]
-        choices = [a, b]
-
-        [par5]
-        choices = [x]
-
-        [par6]
-        choices = [x, y, z]
-        is_ordered = True
-
-        [par7]
-        value = 123
-
-        [par8]
-        value = foo
-
-        [par9]
-        choices = [x, y, z]
-        """
-        self.config = Config(config_str=config_str)
-
-    def test_get_ax_parameters(self):
-        params = get_parameters(self.config)
-
-        correct_range_params = [
-            {
-                "name": "par1",
-                "type": "range",
-                "value_type": "float",
-                "log_scale": False,
-                "bounds": [0.0, 1.0],
-            },
-            {
-                "name": "par2",
-                "type": "range",
-                "value_type": "float",
-                "log_scale": True,
-                "bounds": [0.0, 1000.0],
-            },
-            {
-                "name": "par3",
-                "type": "range",
-                "value_type": "int",
-                "log_scale": False,
-                "bounds": [0.0, 10.0],
-            },
-        ]
-        correct_choice_params = [
-            {
-                "name": "par4",
-                "type": "choice",
-                "value_type": "str",
-                "is_ordered": False,
-                "values": ["a", "b"],
-            },
-            {
-                "name": "par5",
-                "type": "choice",
-                "value_type": "str",
-                "is_ordered": False,
-                "values": ["x"],
-            },
-            {
-                "name": "par6",
-                "type": "choice",
-                "value_type": "str",
-                "is_ordered": True,
-                "values": ["x", "y", "z"],
-            },
-            {
-                "name": "par9",
-                "type": "choice",
-                "value_type": "str",
-                "is_ordered": False,
-                "values": ["x", "y", "z"],
-            },
-        ]
-
-        correct_fixed_params = [
-            {
-                "name": "par7",
-                "type": "fixed",
-                "value": 123.0,
-            },
-            {
-                "name": "par8",
-                "type": "fixed",
-                "value": "foo",
-            },
-        ]
-
-        self.assertEqual(
-            params, correct_range_params + correct_choice_params + correct_fixed_params
-        )
-
-    def test_get_dim(self):
-        dim = get_dim(self.config)
-
-        # 3 dims from par1, par2, par3
-        # 1 binary dim from par4
-        # 0 dim from par5 (effectively a fixed dim)
-        # 1 dim from par6 (is_ordered makes it one continuous dim)
-        # 0 dim from par7 & par8 (fixed dims aren't modeled)
-        # 3 dim from par9 (one-hot vector with 3 elements)
-        # 8 total dims
-        self.assertEqual(8, dim)
-
-        # Count only choice dims
-        copied_config = deepcopy(self.config)
-        del copied_config["common"]["parnames"]
-        del copied_config["common"]["lb"]
-        del copied_config["common"]["ub"]
-        dim = get_dim(copied_config)
-        self.assertEqual(5, dim)
-
-        # Removing par5 does nothing
-        copied_config["common"]["choice_parnames"] = "[par4, par6, par9]"
-        dim = get_dim(copied_config)
-        self.assertEqual(5, dim)
-
-        # Removing par6 leaves us with 3 binary dimension and 1 continuous dimension
-        copied_config["common"]["choice_parnames"] = "[par4, par9]"
-        dim = get_dim(copied_config)
-        self.assertEqual(4, dim)
-
-        # Removing par9 leaves us with 1 binary dimension
-        copied_config["common"]["choice_parnames"] = "[par4]"
-        dim = get_dim(copied_config)
-        self.assertEqual(1, dim)
-
-        # Removing par7 & par8 does nothing
-        del copied_config["common"]["fixed_parnames"]
-        dim = get_dim(copied_config)
-        self.assertEqual(1, dim)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Add support for fixed parameters. These parameters are just set in the config and will be removed before any model or generator is aware of them (then added back in whenever a model or generator is asked for an output.

Differential Revision: D66012863
