### PR TITLE
fix ufmt typo and autoformat missing files

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -32,7 +32,7 @@ jobs:
           mypy --config-file mypy.ini
       - uses: omnilib/ufmt@action-v1
         with:
-          path: aespych tests tests_gpu
+          path: aepsych tests tests_gpu
           requirements: requirements-fmt.txt
           python-version: "3.10"
 

--- a/aepsych/acquisition/bvn.py
+++ b/aepsych/acquisition/bvn.py
@@ -134,7 +134,7 @@ def bvn_cdf(
         yu (torch.Tensor): Upper limits for cdf evaluation in y
         r (torch.Tensor): BVN correlation
 
-    Returns: 
+    Returns:
         Tensor of cdf evaluations of same size as xu, yu, and r.
     """
     p = 1 - _ndtr(-xu) - _ndtr(-yu) + _bvnu(xu, yu, r)

--- a/aepsych/acquisition/lookahead.py
+++ b/aepsych/acquisition/lookahead.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Callable, Literal, cast, Dict, Optional, Tuple
+from typing import Any, Callable, cast, Dict, Literal, Optional, Tuple
 
 import numpy as np
 import torch
@@ -38,7 +38,9 @@ def Hb(p: torch.Tensor) -> torch.Tensor:
     return -torch.nan_to_num(p * torch.log2(p) + (1 - p) * torch.log2(1 - p))
 
 
-def MI_fn(Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+def MI_fn(
+    Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+) -> torch.Tensor:
     """
     Average mutual information.
     H(p) - E_y*[H(p | y*)]
@@ -68,7 +70,9 @@ def ClassErr(p: torch.Tensor) -> torch.Tensor:
     return torch.min(p, 1 - p)
 
 
-def SUR_fn(Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+def SUR_fn(
+    Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+) -> torch.Tensor:
     """
     Stepwise uncertainty reduction.
 
@@ -90,7 +94,9 @@ def SUR_fn(Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tens
     return sur.sum(dim=-1)
 
 
-def EAVC_fn(Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+def EAVC_fn(
+    Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+) -> torch.Tensor:
     """
     Expected absolute value change.
 
@@ -124,7 +130,7 @@ class LookaheadAcquisitionFunction(AcquisitionFunction):
             model (GPyTorchModel): The gpytorch model to use.
             target (float, optional): Threshold value to target in p-space.
             lookahead_type (Literal["levelset", "posterior"]): The type of look-ahead to perform (default is "levelset").
-                - If the lookahead_type is "levelset", the acqf will consider the posterior probability that a point is above or below the target level set. 
+                - If the lookahead_type is "levelset", the acqf will consider the posterior probability that a point is above or below the target level set.
                 - If the lookahead_type is "posterior", the acqf will consider the posterior probability that a point will be detected or not.
         """
         super().__init__(model=model)
@@ -184,17 +190,23 @@ class LocalLookaheadAcquisitionFunction(LookaheadAcquisitionFunction):
         )  # Return shape here has m=1.
         return self._compute_acqf(Px, P1, P0, py1)
 
-    def _compute_acqf(self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+    def _compute_acqf(
+        self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+    ) -> torch.Tensor:
         raise NotImplementedError
 
 
 class LocalMI(LocalLookaheadAcquisitionFunction):
-    def _compute_acqf(self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+    def _compute_acqf(
+        self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+    ) -> torch.Tensor:
         return MI_fn(Px, P1, P0, py1)
 
 
 class LocalSUR(LocalLookaheadAcquisitionFunction):
-    def _compute_acqf(self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+    def _compute_acqf(
+        self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+    ) -> torch.Tensor:
         return SUR_fn(Px, P1, P0, py1)
 
 
@@ -208,7 +220,7 @@ def construct_inputs_local_lookahead(
     **kwargs,
 ) -> Dict[str, Any]:
     """Constructs the input dictionary for initializing local lookahead acquisition functions.
-    
+
     Args:
         model (GPyTorchModel): The gpytorch model to use.
         training_data (None): Placeholder for compatibility; not used in this function.
@@ -217,7 +229,7 @@ def construct_inputs_local_lookahead(
             - If the lookahead_type is "posterior", the acqf will consider the posterior probability that a point will be detected or not.
         target (float, optional): Target threshold value in probability space. Default is None.
         posterior_transform (PosteriorTransform, optional): Optional transformation to apply to the posterior. Default is None.
-        
+
     Returns:
         Dict[str, Any]: Dictionary of constructed inputs for local lookahead acquisition functions.
     """
@@ -300,17 +312,23 @@ class GlobalLookaheadAcquisitionFunction(LookaheadAcquisitionFunction):
             posterior_transform=self.posterior_transform,
         )
 
-    def _compute_acqf(self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+    def _compute_acqf(
+        self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+    ) -> torch.Tensor:
         raise NotImplementedError
 
 
 class GlobalMI(GlobalLookaheadAcquisitionFunction):
-    def _compute_acqf(self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+    def _compute_acqf(
+        self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+    ) -> torch.Tensor:
         return MI_fn(Px, P1, P0, py1)
 
 
 class GlobalSUR(GlobalLookaheadAcquisitionFunction):
-    def _compute_acqf(self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+    def _compute_acqf(
+        self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+    ) -> torch.Tensor:
         return SUR_fn(Px, P1, P0, py1)
 
 
@@ -318,7 +336,7 @@ class ApproxGlobalSUR(GlobalSUR):
     def __init__(
         self,
         model: GPyTorchModel,
-        lookahead_type = "levelset",
+        lookahead_type="levelset",
         target: Optional[float] = None,
         query_set_size: Optional[int] = 256,
         Xq: Optional[torch.Tensor] = None,
@@ -366,7 +384,9 @@ class ApproxGlobalSUR(GlobalSUR):
 
 
 class EAVC(GlobalLookaheadAcquisitionFunction):
-    def _compute_acqf(self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+    def _compute_acqf(
+        self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+    ) -> torch.Tensor:
         return EAVC_fn(Px, P1, P0, py1)
 
 
@@ -378,7 +398,9 @@ class MOCU(GlobalLookaheadAcquisitionFunction):
         International Conference on Learning Representations (ICLR) 2021.
     """
 
-    def _compute_acqf(self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+    def _compute_acqf(
+        self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+    ) -> torch.Tensor:
         """
         Computes the MOCU (Measure of Class Uncertainty) acquisition function.
 
@@ -434,7 +456,9 @@ class SMOCU(GlobalLookaheadAcquisitionFunction):
         )
         self.k = k
 
-    def _compute_acqf(self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+    def _compute_acqf(
+        self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+    ) -> torch.Tensor:
         """
         Computes the SMOCU acquisition function.
 
@@ -478,7 +502,9 @@ class BEMPS(GlobalLookaheadAcquisitionFunction):
         super().__init__(*args, **kwargs)
         self.scorefun = scorefun
 
-    def _compute_acqf(self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor) -> torch.Tensor:
+    def _compute_acqf(
+        self, Px: torch.Tensor, P1: torch.Tensor, P0: torch.Tensor, py1: torch.Tensor
+    ) -> torch.Tensor:
         """
         Computes the BEMPS acquisition function.
 
@@ -526,7 +552,7 @@ def construct_inputs_global_lookahead(
     Returns:
         Dict[str, Any]: Dictionary of constructed inputs for global lookahead acquisition functions.
     """
-     
+
     lb = torch.tensor([bounds[0] for bounds in kwargs["bounds"]])
     ub = torch.tensor([bounds[1] for bounds in kwargs["bounds"]])
     if Xq is None and query_set_size is None:

--- a/aepsych/acquisition/lse.py
+++ b/aepsych/acquisition/lse.py
@@ -112,7 +112,6 @@ def construct_inputs_lse(
         Dict[str, Any]: Dictionary of constructed inputs for the MCLevelSetEstimation acquisition function.
     """
 
-
     return {
         "model": model,
         "objective": objective,

--- a/aepsych/acquisition/mc_posterior_variance.py
+++ b/aepsych/acquisition/mc_posterior_variance.py
@@ -80,11 +80,11 @@ class MCPosteriorVariance(MCAcquisitionFunction):
 
     def acquisition(self, obj_samples: torch.Tensor) -> torch.Tensor:
         """Evaluate the acquisition based on objective samples.
-        
+
         Args:
             obj_samples (torch.Tensor): Samples from the GP, transformed by the objective.
                 Should be samples x batch_shape.
-        
+
         Returns:
             torch.Tensor: Acquisition function at the sampled values.
         """

--- a/aepsych/acquisition/objective/objective.py
+++ b/aepsych/acquisition/objective/objective.py
@@ -60,7 +60,7 @@ class FloorLinkObjective(AEPsychObjective):
     the probability is known not to go below it.
     """
 
-    def __init__(self, floor: float=0.5) -> None:
+    def __init__(self, floor: float = 0.5) -> None:
         """Initialize the objective with a floor value.
 
         Args:
@@ -97,27 +97,27 @@ class FloorLinkObjective(AEPsychObjective):
 
     def link(self, samples: Tensor) -> Tensor:
         """Evaluates the link function for input x and floor f
-        
+
         Args:
             samples (Tensor): GP samples.
-            
+
         Returns:
             Tensor: outcome probability.
-            
+
         Note:
-            This is an abstract method that should be implemented by subclasses.    
+            This is an abstract method that should be implemented by subclasses.
         """
         raise NotImplementedError
 
     def inverse_link(self, samples: Tensor) -> Tensor:
         """Evaluates the inverse link function for input x and floor f
-        
+
         Args:
             samples (Tensor): GP samples.
-            
+
         Returns:
             Tensor: outcome probability.
-            
+
         Note:
             This is an abstract method that should be implemented by subclasses.
         """
@@ -126,7 +126,7 @@ class FloorLinkObjective(AEPsychObjective):
     @classmethod
     def from_config(cls, config: Config) -> FloorLinkObjective:
         """Create a FloorLinkObjective from a configuration.
-        
+
         Args:
             config (Config): Configuration object containing the initialization parameters.
 
@@ -146,10 +146,10 @@ class FloorLogitObjective(FloorLinkObjective):
 
     def link(self, samples: Tensor) -> Tensor:
         """Evaluates the link function for input x and floor f
-        
+
         Args:
             samples (Tensor): GP samples.
-            
+
         Returns:
             Tensor: The Expit function applied to the input samples.
         """
@@ -179,10 +179,10 @@ class FloorGumbelObjective(FloorLinkObjective):
 
     def link(self, samples: Tensor) -> Tensor:
         """Evaluates the link function for input x and floor f
-        
+
         Args:
             samples (Tensor): GP samples.
-            
+
         Returns:
             Tensor: Transformed tensor with the link function applied, where positive infinity values are replaced with 1.0 and negative infinity values are replaced with 0.0.
         """
@@ -192,10 +192,10 @@ class FloorGumbelObjective(FloorLinkObjective):
 
     def inverse_link(self, samples: Tensor) -> Tensor:
         """Evaluates the inverse link function for input x and floor f
-        
+
         Args:
             samples (Tensor): GP samples.
-            
+
         Returns:
             Tensor: The logarithm of the inverse link function applied to the input samples.
         """
@@ -221,10 +221,10 @@ class FloorProbitObjective(FloorLinkObjective):
 
     def inverse_link(self, samples: Tensor) -> Tensor:
         """Evaluates the inverse link function for input x and floor f
-        
+
         Args:
             samples (Tensor): GP samples.
-            
+
         Returns:
             Tensor: the inverse cumulative distribution function of the standard normal distribution of the input samples.
         """

--- a/aepsych/acquisition/objective/semi_p.py
+++ b/aepsych/acquisition/objective/semi_p.py
@@ -28,7 +28,7 @@ class SemiPObjectiveBase(MCAcquisitionObjective):
 
     def __init__(self, stim_dim: int = 0) -> None:
         """Initialize the SemiPObjectiveBase.
-        
+
         Args:
             stim_dim (int): The stimulus dimension. Defaults to 0.
         """
@@ -112,7 +112,7 @@ class SemiPThresholdObjective(SemiPObjectiveBase):
         Args:
             target (float): the threshold to evaluate.
             likelihood (LinearBernoulliLikelihood, optional): Underlying SemiP likelihood (which we use for its inverse link). Defaults to None.
-            
+
             other arguments are passed to the base class (notably, stim_dim).
         """
         super().__init__(*args, **kwargs)
@@ -137,10 +137,10 @@ class SemiPThresholdObjective(SemiPObjectiveBase):
     @classmethod
     def from_config(cls, config: Config) -> SemiPThresholdObjective:
         """Create a SemiPThresholdObjective from a config object.
-        
+
         Args:
             config (Config): Configuration object containing the initialization parameters.
-            
+
         Returns:
             SemiPThresholdObjective: A SemiPThresholdObjective object.
         """

--- a/aepsych/acquisition/rejection_sampler.py
+++ b/aepsych/acquisition/rejection_sampler.py
@@ -22,7 +22,10 @@ class RejectionSampler(MCSampler):
     """
 
     def __init__(
-        self, num_samples: int, num_rejection_samples: int, constrained_idx: torch.Tensor
+        self,
+        num_samples: int,
+        num_rejection_samples: int,
+        constrained_idx: torch.Tensor,
     ):
         """Initialize RejectionSampler
 

--- a/aepsych/factory/default.py
+++ b/aepsych/factory/default.py
@@ -103,13 +103,13 @@ def _get_default_cov_function(
     active_dims: Optional[List[int]] = None,
 ) -> gpytorch.kernels.Kernel:
     """Creates a default covariance function for Gaussian Processes.
-    
+
     Args:
         config (Config, optional): Configuration object.
         dim (int): Dimensionality of the parameter space.
         stimuli_per_trial (int): Number of stimuli per trial.
         active_dims (List[int], optional): List of dimensions to use in the covariance function. Defaults to None.
-        
+
     Returns:
         gpytorch.kernels.Kernel: An instantiated kernel with appropriate priors based on the configuration.
     """

--- a/aepsych/factory/ordinal.py
+++ b/aepsych/factory/ordinal.py
@@ -17,11 +17,11 @@ from .default import default_mean_covar_factory
 def ordinal_mean_covar_factory(
     config: Config,
 ) -> Tuple[gpytorch.means.ConstantMean, gpytorch.kernels.ScaleKernel]:
-    """ Create a mean and covariance function for ordinal GPs.
-    
+    """Create a mean and covariance function for ordinal GPs.
+
     Args:
         config (Config): Config object containing bounds.
-        
+
     Returns:
         Tuple[gpytorch.means.ConstantMean, gpytorch.kernels.ScaleKernel]: A tuple containing
         the mean function (ConstantMean) and the covariance function (ScaleKernel).

--- a/aepsych/factory/pairwise.py
+++ b/aepsych/factory/pairwise.py
@@ -15,11 +15,11 @@ from aepsych.kernels.pairwisekernel import PairwiseKernel
 def pairwise_mean_covar_factory(
     config: Config,
 ) -> Tuple[gpytorch.means.ConstantMean, gpytorch.kernels.ScaleKernel]:
-    """ Creates a mean and covariance function for pairwise GPs.
-    
+    """Creates a mean and covariance function for pairwise GPs.
+
     Args:
         config (Config): Config object containing bounds.
-        
+
     Returns:
         Tuple[gpytorch.means.ConstantMean, gpytorch.kernels.ScaleKernel]: A tuple containing
         the mean function (ConstantMean) and the covariance function (ScaleKernel)."""

--- a/aepsych/kernels/pairwisekernel.py
+++ b/aepsych/kernels/pairwisekernel.py
@@ -16,12 +16,12 @@ class PairwiseKernel(Kernel):
     """
 
     def __init__(
-          self, latent_kernel: Kernel, is_partial_obs: bool=False, **kwargs
+        self, latent_kernel: Kernel, is_partial_obs: bool = False, **kwargs
     ) -> None:
         """
-         Args:
-            latent_kernel (Kernel): The underlying kernel used to compute the covariance for the GP.
-            is_partial_obs (bool): If the kernel should handle partial observations. Defaults to False.
+        Args:
+           latent_kernel (Kernel): The underlying kernel used to compute the covariance for the GP.
+           is_partial_obs (bool): If the kernel should handle partial observations. Defaults to False.
         """
         super(PairwiseKernel, self).__init__(**kwargs)
 
@@ -40,11 +40,11 @@ class PairwiseKernel(Kernel):
             x1 (torch.Tensor): A `b x n x d` or `n x d` tensor, where `d = 2k` and `k` is the dimension of the latent space.
             x2 (torch.Tensor): A `b x m x d` or `m x d` tensor, where `d = 2k` and `k` is the dimension of the latent space.
             diag (bool): Should the Kernel compute the whole covariance matrix or just the diagonal? Defaults to False.
-            
+
 
         Returns:
             torch.Tensor (or :class:`gpytorch.lazy.LazyTensor`) : A `b x n x m` or `n x m` tensor representing
-            the covariance matrix between `x1` and `x2`. 
+            the covariance matrix between `x1` and `x2`.
             The exact size depends on the kernel's evaluation mode:
             * `full_covar`: `n x m` or `b x n x m`
             * `diag`: `n` or `b x n`

--- a/aepsych/kernels/rbf_partial_grad.py
+++ b/aepsych/kernels/rbf_partial_grad.py
@@ -31,14 +31,14 @@ class RBFKernelPartialObsGrad(RBFKernelGrad):
         self, x1: torch.Tensor, x2: torch.Tensor, diag: bool = False, **params: Any
     ) -> torch.Tensor:
         """Computes the covariance matrix between x1 and x2 based on the RBF
-        
+
         Args:
             x1 (torch.Tensor): A `b x n x d` or `n x d` tensor, where `d = 2k` and `k` is the dimension of the latent space.
             x2 (torch.Tensor): A `b x m x d` or `m x d` tensor, where `d = 2k` and `k` is the dimension of the latent space.
             diag (bool): Should the Kernel compute the whole covariance matrix (False) or just the diagonal (True)? Defaults to False.
 
-        
-        
+
+
         Returns:
             torch.Tensor: A `b x n x m` or `n x m` tensor representing the covariance matrix between `x1` and `x2`.
             The exact size depends on the kernel's evaluation mode:

--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -250,7 +250,7 @@ class AEPsychMixin(GPyTorchModel):
 
         Args:
             grid (torch.Tensor, optional): Mesh grid over which to find the JND.
-                Defaults to a square grid of size as determined by aepsych.utils.dim_grid. 
+                Defaults to a square grid of size as determined by aepsych.utils.dim_grid.
             cred_level (float, optional): Credible level for computing an interval.
                 Defaults to None, computing no interval.
             intensity_dim (int): Dimension over which to compute the JND.
@@ -324,7 +324,7 @@ class AEPsychMixin(GPyTorchModel):
         slice_dims: Optional[Mapping[int, float]] = None,
     ) -> torch.Tensor:
         """Generate a grid based on lower, upper, and dim.
-        
+
         Args:
             gridsize (int): Number of points in each dimension. Defaults to 30.
             slice_dims (Mapping[int, float], optional): Dimensions to fix at a certain value. Defaults to None.
@@ -339,7 +339,7 @@ class AEPsychMixin(GPyTorchModel):
     ):
         """
         Set the training data for the model.
-        
+
         Args:
             inputs (torch.Tensor, optional):  The new training inputs.
             targets (torch.Tensor, optional): The new training targets.
@@ -377,7 +377,7 @@ class AEPsychMixin(GPyTorchModel):
         **kwargs,
     ) -> None:
         """Fits the model by maximizing the marginal log likelihood.
-        
+
         Args:
             mll (MarginalLogLikelihood): Marginal log likelihood object.
             optimizer_kwargs (Dict[str, Any], optional): Keyword arguments for the optimizer.
@@ -409,16 +409,14 @@ class AEPsychMixin(GPyTorchModel):
         return res
 
     def p_below_threshold(
-        self,
-        x: torch.Tensor,
-        f_thresh: torch.Tensor
-        ) -> torch.Tensor: 
+        self, x: torch.Tensor, f_thresh: torch.Tensor
+    ) -> torch.Tensor:
         """Compute the probability that the latent function is below a threshold.
-        
+
         Args:
             x (torch.Tensor): Points at which to evaluate the probability.
             f_thresh (torch.Tensor): Threshold value.
-            
+
         Returns:
             torch.Tensor: Probability that the latent function is below the threshold.
         """
@@ -435,14 +433,19 @@ class AEPsychModelDeviceMixin(AEPsychMixin):
     _train_inputs: Optional[Tuple[torch.Tensor]]
     _train_targets: Optional[torch.Tensor]
 
-    def set_train_data(self, inputs: Optional[torch.Tensor] = None, targets: Optional[torch.Tensor] = None, strict: bool = False) -> None:
+    def set_train_data(
+        self,
+        inputs: Optional[torch.Tensor] = None,
+        targets: Optional[torch.Tensor] = None,
+        strict: bool = False,
+    ) -> None:
         """Set the training data for the model.
 
         Args:
             inputs (torch.Tensor, optional): The new training inputs X.
             targets (torch.Tensor, optional): The new training targets Y.
             strict (bool): Whether to strictly enforce the device of the inputs and targets.
-        
+
         input transformers. TODO: actually use this arg or change input transforms
         to not require it.
         """
@@ -456,7 +459,7 @@ class AEPsychModelDeviceMixin(AEPsychMixin):
     @property
     def device(self) -> torch.device:
         """Get the device of the model.
-        
+
         Returns:
             torch.device: Device of the model.
         """
@@ -467,7 +470,7 @@ class AEPsychModelDeviceMixin(AEPsychMixin):
     @property
     def train_inputs(self) -> Optional[Tuple[torch.Tensor]]:
         """Get the training inputs.
-        
+
         Returns:
             Optional[Tuple[torch.Tensor]]: Training inputs.
         """

--- a/aepsych/models/gp_regression.py
+++ b/aepsych/models/gp_regression.py
@@ -89,10 +89,10 @@ class GPRegressionModel(AEPsychModelDeviceMixin, ExactGP):
     @classmethod
     def construct_inputs(cls, config: Config) -> Dict:
         """Construct inputs for the GP regression model from configuration.
-        
+
         Args:
             config (Config): A configuration containing keys/values matching this class.
-            
+
         Returns:
             Dict: Dictionary of inputs for the GP regression model.
         """
@@ -176,7 +176,7 @@ class GPRegressionModel(AEPsychModelDeviceMixin, ExactGP):
 
     def update(self, train_x: torch.Tensor, train_y: torch.Tensor, **kwargs):
         """Perform a warm-start update of the model from previous fit.
-        
+
         Args:
             train_x (torch.Tensor): Inputs.
             train_y (torch.Tensor): Responses.

--- a/aepsych/models/monotonic_projection_gp.py
+++ b/aepsych/models/monotonic_projection_gp.py
@@ -108,7 +108,7 @@ class MonotonicProjectionGP(GPClassificationModel):
         optimizer_options: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Initialize the MonotonicProjectionGP model.
-        
+
         Args:
             lb (torch.Tensor): Lower bounds of the parameters.
             ub (torch.Tensor): Upper bounds of the parameters.

--- a/aepsych/models/monotonic_rejection_gp.py
+++ b/aepsych/models/monotonic_rejection_gp.py
@@ -81,7 +81,7 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
             num_induc (int): Number of inducing points for variational GP.]. Defaults to 25.
             num_samples (int): Number of samples for estimating posterior on preDict or
             acquisition function evaluation. Defaults to 250.
-            num_rejection_samples (int): Number of samples used for rejection sampling. Defaults to 4096. 
+            num_rejection_samples (int): Number of samples used for rejection sampling. Defaults to 4096.
             inducing_point_method (str): Method for selecting inducing points. Defaults to "auto".
             optimizer_options (Dict[str, Any], optional): Optimizer options to pass to the SciPy optimizer during
                 fitting. Assumes we are using L-BFGS-B.
@@ -178,7 +178,7 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
         likelihood_state_dict: Optional[Dict[str, torch.Tensor]] = None,
     ) -> None:
         """Sets the model with the given data and state dicts.
-        
+
         Args:
             train_x (torch.Tensor): Training x points
             train_y (torch.Tensor): Training y points. Should be (n x 1).
@@ -199,7 +199,9 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
         )
         mll = fit_gpytorch_mll(mll, optimizer_kwargs=self.optimizer_options)
 
-    def update(self, train_x: torch.Tensor, train_y: torch.Tensor, warmstart: bool = True) -> None:
+    def update(
+        self, train_x: torch.Tensor, train_y: torch.Tensor, warmstart: bool = True
+    ) -> None:
         """
         Update the model with new data.
 
@@ -280,7 +282,7 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
             x (torch.Tensor): tensor of n points at which to predict.
             probability_space (bool): whether to return in probability space. Defaults to False.
 
-        Returns: 
+        Returns:
             Tuple[torch.Tensor, torch.Tensor]: Posterior mean and variance at query points.
         """
         samples_f = self.sample(x)
@@ -295,14 +297,12 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
 
         return mean, variance
 
-    def predict_probability(
-        self, x: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    def predict_probability(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         """Predict in probability space
 
         Args:
             x (torch.Tensor): Points at which to predict.
-        
+
         Returns:
             Tuple[torch.Tensor, torch.Tensor]: Posterior mean and variance at query points.
         """
@@ -314,7 +314,7 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
         Args:
             x (torch.Tensor): Input tensor
             indx (int): Derivative index
-        
+
         Returns:
             torch.Tensor: Augmented tensor
         """
@@ -333,11 +333,11 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
 
     @classmethod
     def from_config(cls, config: Config) -> MonotonicRejectionGP:
-        """ Alternate constructor for MonotonicRejectionGP
-        
+        """Alternate constructor for MonotonicRejectionGP
+
         Args:
             config (Config): a configuration containing keys/values matching this class
-            
+
         Returns:
             MonotonicRejectionGP: configured class instance
         """

--- a/aepsych/models/multitask_regression.py
+++ b/aepsych/models/multitask_regression.py
@@ -79,11 +79,11 @@ class MultitaskGPRModel(GPRegressionModel):
     def forward(
         self, x: torch.Tensor
     ) -> gpytorch.distributions.MultitaskMultivariateNormal:
-        """ Evaluate GP.
-        
+        """Evaluate GP.
+
         Args:
             x (torch.Tensor): Tensor of points at which GP should be evaluated.
-            
+
         Returns:
             gpytorch.distributions.MultitaskMultivariateNormal: Distribution object
                 holding the mean and covariance at x."""
@@ -94,7 +94,7 @@ class MultitaskGPRModel(GPRegressionModel):
     @classmethod
     def construct_inputs(cls, config: Config):
         """Construct inputs for the Multitask GPR model from configuration.
-        
+
         Args:
             config (Config): A configuration containing keys/values matching this class.
         """
@@ -164,7 +164,7 @@ class IndependentMultitaskGPRModel(GPRegressionModel):
     def forward(
         self, x: torch.Tensor
     ) -> gpytorch.distributions.MultitaskMultivariateNormal:
-        """ Evaluate GP.
+        """Evaluate GP.
 
         Args:
             x (torch.Tensor): Tensor of points at which GP should be evaluated.

--- a/aepsych/models/ordinal_gp.py
+++ b/aepsych/models/ordinal_gp.py
@@ -26,7 +26,7 @@ class OrdinalGPModel(GPClassificationModel):
 
     def __init__(self, likelihood=None, *args, **kwargs):
         """Initialize the OrdinalGPModel
-        
+
         Args:
             likelihood (Likelihood): The likelihood function to use. If None defaults to
                 Ordinal likelihood.
@@ -56,7 +56,7 @@ class OrdinalGPModel(GPClassificationModel):
             **kwargs,
         )
 
-    def predict_probs(self, xgrid:torch.Tensor) -> torch.Tensor:
+    def predict_probs(self, xgrid: torch.Tensor) -> torch.Tensor:
         """Predict probabilities of each ordinal level at xgrid
 
         Args:

--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -270,7 +270,7 @@ class PairwiseProbitModel(PairwiseGP, AEPsychMixin):
             return -samps + samps_ref
 
     @classmethod
-    def from_config(cls, config: Config) -> 'PairwiseProbitModel':
+    def from_config(cls, config: Config) -> "PairwiseProbitModel":
         """Initialize the model from a config object.
 
         Args:

--- a/aepsych/models/semi_p.py
+++ b/aepsych/models/semi_p.py
@@ -75,10 +75,10 @@ def _hadamard_mvn_approx(
 
 def semi_p_posterior_transform(posterior: GPyTorchPosterior) -> GPyTorchPosterior:
     """Transform a posterior from a SemiP model to a Hadamard model.
-    
+
     Args:
         posterior (GPyTorchPosterior): The posterior to transform
-        
+
     Returns:
         GPyTorchPosterior: The transformed posterior.
     """
@@ -108,13 +108,13 @@ class SemiPPosterior(GPyTorchPosterior):
         Xi: torch.Tensor,
     ) -> None:
         """Initialize a SemiPPosterior object.
-        
+
         Args:
             mvn (MultivariateNormal): The MVN object to use
             likelihood (LinearBernoulliLikelihood): The likelihood object
             Xi (torch.Tensor): The intensity dimension
         """
-        
+
         super().__init__(distribution=mvn)
         self.likelihood = likelihood
         self.Xi = Xi
@@ -150,11 +150,11 @@ class SemiPPosterior(GPyTorchPosterior):
         base_samples: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Sample from the posterior distribution using the reparameterization trick
-        
+
         Args:
             sample_shape (torch.Size, optional): The desired shape of the samples. Defaults to None.
             base_samples (torch.Tensor, optional): The base samples. Defaults to None.
-            
+
         Returns:
             torch.Tensor: The sampled values from the posterior distribution.
         """
@@ -177,11 +177,11 @@ class SemiPPosterior(GPyTorchPosterior):
         base_samples: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Sample from the likelihood distribution of the modeled function.
-        
+
         Args:
             sample_shape (torch.Size, optional): The desired shape of the samples. Defaults to None.
             base_samples (torch.Tensor, optional): The base samples. Defaults to None.
-            
+
         Returns:
             torch.Tensor: The sampled values from the likelihood distribution.
         """
@@ -194,15 +194,15 @@ class SemiPPosterior(GPyTorchPosterior):
         base_samples: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Sample from the function values of the modeled distribution.
-        
+
         Args:
             sample_shape (torch.Size, optional): The desired shape of the samples. Defaults to None.
             base_samples (torch.Tensor, optional): The base samples. Defaults to None.
-            
+
         Returns:
             torch.Tensor: The sampled function values from the likelihood.
         """
-        
+
         kcsamps = self.rsample(sample_shape=sample_shape, base_samples=base_samples)
         return self.likelihood.f(function_samples=kcsamps, Xi=self.Xi).squeeze(-1)
 
@@ -213,7 +213,7 @@ class SemiPPosterior(GPyTorchPosterior):
         base_samples: Optional[torch.Tensor] = None,
     ) -> SemiPThresholdObjective:
         """Sample the thresholds based on the given threshold level.
-        
+
         Args:
         threshold_level (float): The target threshold level for sampling.
         sample_shape (torch.Size, optional): The desired shape of the samples. Defaults to None.
@@ -422,7 +422,7 @@ class SemiParametricGPModel(GPClassificationModel):
         """Sample from underlying model.
 
         Args:
-            
+
             x (torch.Tensor): `n x d` Points at which to sample.
             num_samples (int): Number of samples to return. Defaults to None.
             probability_space (bool): Whether to sample from the probability space (True) or the latent function. Defaults to False.

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -75,7 +75,7 @@ def select_inducing_points(
         bounds (torch.Tensor, optional): The bounds of the input space.
         method (str): The method to use for inducing point selection. One of
             "pivoted_chol", "kmeans++", "auto", or "sobol".
-        
+
     Returns:
         torch.Tensor: The selected inducing points.
     """
@@ -273,10 +273,12 @@ def inv_query(
 
 class TargetDistancePosteriorTransform(PosteriorTransform):
     def __init__(
-        self, target_value: Union[float, torch.Tensor], weights: Optional[torch.Tensor] = None
+        self,
+        target_value: Union[float, torch.Tensor],
+        weights: Optional[torch.Tensor] = None,
     ) -> None:
         """Initialize the TargetDistancePosteriorTransform
-        
+
         Args:
             target_value (Union[float, torch.Tensor]): The target value to transform the posterior to.
             weights (torch.Tensor, optional): Weights to apply to the target value. Defaults to None.
@@ -287,10 +289,10 @@ class TargetDistancePosteriorTransform(PosteriorTransform):
 
     def evaluate(self, Y: torch.Tensor) -> torch.Tensor:
         """Evaluate the squared distance from the target value.
-        
+
         Args:
             Y (torch.Tensor): The tensor to evaluate.
-            
+
         Returns:
             torch.Tensor: The squared distance from the target value.
         """
@@ -298,11 +300,11 @@ class TargetDistancePosteriorTransform(PosteriorTransform):
 
     def _forward(self, mean: torch.Tensor, var: torch.Tensor) -> GPyTorchPosterior:
         """Transform the posterior mean and variance based on the target value.
-        
+
         Args:
             mean (torch.Tensor): The posterior mean.
             var (torch.Tensor): The posterior variance.
-            
+
         Returns:
             GPyTorchPosterior: The transformed posterior.
         """
@@ -321,10 +323,10 @@ class TargetDistancePosteriorTransform(PosteriorTransform):
 
     def forward(self, posterior: GPyTorchPosterior) -> GPyTorchPosterior:
         """Transform the given posterior distribution to reflect the target distance.
-        
+
         Args:
             posterior (GPyTorchPosterior): The posterior to transform.
-            
+
         Returns:
             GPyTorchPosterior: The transformed posterior.
         """
@@ -337,10 +339,10 @@ class TargetDistancePosteriorTransform(PosteriorTransform):
 class TargetProbabilityDistancePosteriorTransform(TargetDistancePosteriorTransform):
     def forward(self, posterior: GPyTorchPosterior) -> GPyTorchPosterior:
         """Transform the given posterior distribution to reflect the target probability distance.
-        
+
         Args:
             posterior (GPyTorchPosterior): The posterior to transform.
-            
+
         Returns:
             GPyTorchPosterior: The transformed posterior distribution reflecting the target probability distance.
         """


### PR DESCRIPTION
Summary:
workflow was pointed to the wrong place and thus was not checking formatting for external. Fixed this.

Autoformatted all files that were missed.

Differential Revision: D66378781


