### PR TITLE
ensure handle_query can handle any type of model

### DIFF
--- a/aepsych/server/message_handlers/handle_query.py
+++ b/aepsych/server/message_handlers/handle_query.py
@@ -63,7 +63,7 @@ def query(
                 server._config_to_tensor(x).unsqueeze(axis=0)
             )
         response["x"] = x
-        response["y"] = np.array(mean)  # mean.item()
+        response["y"] = np.array(mean.item())  # mean.item()
 
     elif query_type == "inverse":
         # expect constraints to be a dictionary; values are float arrays size 1 (exact) or 2 (upper/lower bnd)

--- a/tests/server/message_handlers/test_query_handlers.py
+++ b/tests/server/message_handlers/test_query_handlers.py
@@ -65,6 +65,84 @@ class QueryHandlerTestCase(BaseServerTestCase):
         self.s.handle_request(query_max_req)
         self.s.handle_request(query_inv_req)
 
+    def test_grad_model(self):
+        # Some models return values with gradients that need to be handled
+        config_str = """
+            [common]
+            lb = [0, 0]
+            ub = [1, 1]
+            parnames = [x, y]
+            stimuli_per_trial = 2
+            outcome_types = [binary]
+            strategy_names = [init_strat, opt_strat]
+
+            [init_strat]
+            min_asks = 2
+            generator = SobolGenerator
+            min_total_outcome_occurrences = 0
+
+            [opt_strat]
+            min_asks = 2
+            generator = OptimizeAcqfGenerator
+            acqf = qLogNoisyExpectedImprovement
+            model = PairwiseProbitModel
+            min_total_outcome_occurrences = 0
+
+            [qLogNoisyExpectedImprovement]
+            objective = ProbitObjective
+        """
+
+        setup_request = {
+            "type": "setup",
+            "version": "0.01",
+            "message": {"config_str": config_str},
+        }
+        ask_request = {"type": "ask", "message": ""}
+        tell_request = {
+            "type": "tell",
+            "message": [
+                {"config": {"x": [0.5, 0.5], "y": [0.25, 0.75]}, "outcome": 1},
+                {"config": {"x": [0.25, 0.75], "y": [0.5, 0.5]}, "outcome": 0},
+                {"config": {"x": [0.2, 0.6], "y": [0.3, 0.9]}, "outcome": 0},
+            ],
+        }
+
+        self.s.handle_request(setup_request)
+        while not self.s.strat.finished:
+            self.s.handle_request(ask_request)
+            self.s.handle_request(tell_request)
+
+        query_max_req = {
+            "type": "query",
+            "message": {
+                "query_type": "max",
+            },
+        }
+        query_min_req = {
+            "type": "query",
+            "message": {
+                "query_type": "min",
+            },
+        }
+        query_pred_req = {
+            "type": "query",
+            "message": {
+                "query_type": "prediction",
+                "x": {"x": [0.0], "y": [1.0]},
+            },
+        }
+        query_inv_req = {
+            "type": "query",
+            "message": {
+                "query_type": "inverse",
+                "y": 5.0,
+            },
+        }
+        self.s.handle_request(query_min_req)
+        self.s.handle_request(query_pred_req)
+        self.s.handle_request(query_max_req)
+        self.s.handle_request(query_inv_req)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary: Handle_query may get a tensor that still has gradients and thus cannot be instantly cast to an array. This can be avoided by just using tensor.item().

Differential Revision: D66477594


