### PR TITLE
interpolate monotonic supports tensor inputs

### DIFF
--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -182,8 +182,6 @@ def _plot_strat_1d(
 
         threshold_samps = [
             interpolate_monotonic(grid, s, target_level, strat.lb[0], strat.ub[0])
-            .cpu()
-            .numpy()
             for s in samps
         ]
         thresh_med = np.mean(threshold_samps)
@@ -203,16 +201,12 @@ def _plot_strat_1d(
         true_f = true_testfun(grid)
         ax.plot(grid, true_f.squeeze(), label="True function")
         if target_level is not None:
-            true_thresh = (
-                interpolate_monotonic(
-                    grid,
-                    true_f.squeeze(),
-                    target_level,
-                    strat.lb[0],
-                    strat.ub[0],
-                )
-                .cpu()
-                .numpy()
+            true_thresh = interpolate_monotonic(
+                grid,
+                true_f.squeeze(),
+                target_level,
+                strat.lb[0],
+                strat.ub[0],
             )
 
             ax.plot(

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -122,7 +122,7 @@ def interpolate_monotonic(x, y, z, min_x=-np.inf, max_x=np.inf):
     y1 = y[idx]
 
     x_star = x0 + (x1 - x0) * (z - y0) / (y1 - y0)
-    return x_star
+    return x_star.cpu().item()
 
 
 def get_lse_interval(


### PR DESCRIPTION
Summary: `interplotate_monotonic` should always return a float but it will return a tensor most of the time, we make it always return a float

Reviewed By: crasanders

Differential Revision: D66513243


