### PR TITLE
update db master table spec and corresponding helper functions

### DIFF
--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -150,14 +150,33 @@ class Config(configparser.ConfigParser):
         return _dict
 
     # Turn the metadata section into JSON.
-    def jsonifyMetadata(self) -> str:
-        """Turn the metadata section into JSON.
+    def jsonifyMetadata(self, only_extra: bool = False) -> str:
+        """Return a json string of the metadata section.
+
+        Args:
+            only_extra (bool): Only jsonify the extra meta data.
 
         Returns:
-            str: JSON representation of the metadata section.
+            str: A json string representing the metadata dictionary or an empty string
+                if there is no metadata to return.
         """
         configdict = self.to_dict()
-        return json.dumps(configdict["metadata"])
+        metadata = configdict["metadata"].copy()
+
+        if only_extra:
+            default_metadata = [
+                "experiment_name",
+                "experiment_description",
+                "experiment_id",
+                "participant_id",
+            ]
+            for name in default_metadata:
+                metadata.pop(name, None)
+
+        if len(metadata.keys()) == 0:
+            return ""
+        else:
+            return json.dumps(metadata)
 
     # Turn the entire config into JSON format.
     def jsonifyAll(self) -> str:

--- a/aepsych/server/replay.py
+++ b/aepsych/server/replay.py
@@ -17,11 +17,15 @@ logger = utils_logging.getLogger(logging.INFO)
 
 def replay(server, uuid_to_replay, skip_computations=False):
     """
-    Run a replay against the server. The UUID will be looked up in the database.
+    Run a replay against the server. The unique ID will be looked up in the database.
     if skip_computations is true, skip all the asks and queries, which should make the replay much faster.
     """
+    warnings.warn(
+        "replay arg 'uuid_to_replay` is not actually a uuid, just the unique ID in the DB of the specific run of an experiment. This argument will change soon.",
+        DeprecationWarning,
+    )
     if uuid_to_replay is None:
-        raise RuntimeError("UUID is a required parameter to perform a replay")
+        raise RuntimeError("unique ID is a required parameter to perform a replay")
 
     if server.db is None:
         raise RuntimeError("A database is required to perform a replay")
@@ -35,7 +39,7 @@ def replay(server, uuid_to_replay, skip_computations=False):
 
     if master_record is None:
         raise RuntimeError(
-            f"The UUID {uuid_to_replay} isn't in the database. Unable to perform replay."
+            f"The unique ID {uuid_to_replay} isn't in the database. Unable to perform replay."
         )
 
     # this prevents writing back to the DB and creating a circular firing squad
@@ -52,10 +56,14 @@ def replay(server, uuid_to_replay, skip_computations=False):
 
 
 def get_strats_from_replay(server, uuid_of_replay=None, force_replay=False):
+    warnings.warn(
+        "replay arg 'uuid_of_replay` is not actually a uuid, just the unique ID in the DB of the specific run of an experiment. This argument will change soon.",
+        DeprecationWarning,
+    )
     if uuid_of_replay is None:
         records = server.db.get_master_records()
         if len(records) > 0:
-            uuid_of_replay = records[-1].experiment_id
+            uuid_of_replay = records[-1].unique_id
         else:
             raise RuntimeError("Server has no experiment records!")
 
@@ -76,10 +84,14 @@ def get_strats_from_replay(server, uuid_of_replay=None, force_replay=False):
 
 
 def get_strat_from_replay(server, uuid_of_replay=None, strat_id=-1):
+    warnings.warn(
+        "replay arg 'uuid_to_replay` is not actually a uuid, just the unique ID in the DB of the specific run of an experiment. This argument will change soon.",
+        DeprecationWarning,
+    )
     if uuid_of_replay is None:
         records = server.db.get_master_records()
         if len(records) > 0:
-            uuid_of_replay = records[-1].experiment_id
+            uuid_of_replay = records[-1].unique_id
         else:
             raise RuntimeError("Server has no experiment records!")
 
@@ -105,6 +117,10 @@ def get_strat_from_replay(server, uuid_of_replay=None, strat_id=-1):
 
 def get_dataframe_from_replay(server, uuid_of_replay=None, force_replay=False):
     warnings.warn(
+        "replay arg 'uuid_to_replay` is not actually a uuid, just the unique ID in the DB of the specific run of an experiment. This argument will change soon.",
+        DeprecationWarning,
+    )
+    warnings.warn(
         "get_dataframe_from_replay is deprecated."
         + " Use generate_experiment_table with return_df = True instead.",
         DeprecationWarning,
@@ -114,7 +130,7 @@ def get_dataframe_from_replay(server, uuid_of_replay=None, force_replay=False):
     if uuid_of_replay is None:
         records = server.db.get_master_records()
         if len(records) > 0:
-            uuid_of_replay = records[-1].experiment_id
+            uuid_of_replay = records[-1].unique_id
         else:
             raise RuntimeError("Server has no experiment records!")
 

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -373,7 +373,7 @@ class AEPsychServer(object):
 
 #! THIS IS WHAT START THE SERVER
 def startServerAndRun(
-    server_class, socket=None, database_path=None, config_path=None, uuid_of_replay=None
+    server_class, socket=None, database_path=None, config_path=None, id_of_replay=None
 ):
     server = server_class(socket=socket, database_path=database_path)
     try:
@@ -383,16 +383,16 @@ def startServerAndRun(
             configure(server, config_str=config_str)
 
         if socket is not None:
-            if uuid_of_replay is not None:
-                server.replay(uuid_of_replay, skip_computations=True)
-                server._db_master_record = server.db.get_master_record(uuid_of_replay)
+            if id_of_replay is not None:
+                server.replay(id_of_replay, skip_computations=True)
+                server._db_master_record = server.db.get_master_record(id_of_replay)
             server.serve()
         else:
             if config_path is not None:
                 logger.info(
                     "You have passed in a config path but this is a replay. If there's a config in the database it will be used instead of the passed in config path."
                 )
-            server.replay(uuid_of_replay)
+            server.replay(id_of_replay)
     except KeyboardInterrupt:
         exception_type = "CTRL+C"
         dump_type = "dump"
@@ -442,7 +442,7 @@ def parse_argument():
         default=None,
     )
     parser.add_argument(
-        "-r", "--replay", type=str, help="UUID of the experiment to replay."
+        "-r", "--replay", type=str, help="Unique id of the experiment to replay."
     )
 
     parser.add_argument(

--- a/docs/db_overview.md
+++ b/docs/db_overview.md
@@ -25,9 +25,9 @@ Each table is described as follows:
 |unique_id | A unique ID generated for each entry in this table.|
 |experiment_name | A name given to the experiment through the experiment's configuration file. If not specified, defaults to "default name".|
 |experiment_description | A text description of the experiment. This value is configurable in the experiment's configuration file. If not specified, defaults to "default description".|
-|experiment_id | A unique ID for an experiment. If not specified in the experiment's configuration file, it will be automatically generated through Python's [Unique Universal Identifier](https://docs.python.org/3/library/uuid.html) module.|
-|participant_id | A unique ID for a specific participant in an experiment. If not specified in the experiment's configuration file, it will be left empty.|
-|extra_metadata | Any special metadata specified in the configuration file under the section "Metadata". This metadata is stored as JSON so that it may be easily serialized/deserialized at a later time period. If no metadata is specified in the configuration file, this field will be empty. |
+|experiment_id | An ID for an experiment. If not specified in the experiment's configuration file, it will be automatically generated through Python's [Unique Universal Identifier](https://docs.python.org/3/library/uuid.html) module.|
+|participant_id | A ID for a specific participant in an experiment. If not specified in the experiment's configuration file, it will be another generated UUID as in experiment_id.|
+|extra_metadata | Any special metadata specified in the configuration file under the section "Metadata". This metadata is stored as JSON so that it may be easily serialized/deserialized at a later time period. If no metadata is specified in the configuration file, this field will be empty, keys set as distinct columns in this table will not be duplicated here. |
 
 
 - **replay_data Table**: The replay table contains the messages sent between the client and the server on each trial so that previous experiments can be replayed again. The columns are described as follows:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -42,7 +42,7 @@ class DBTestCase(unittest.TestCase):
             request={"test": "this is a test request"},
         )
 
-        result = self._database.get_replay_for(master_table.experiment_id)
+        result = self._database.get_replay_for(master_table.unique_id)
 
         self.assertNotEqual(None, result)
         self.assertEqual(len(result), 1)
@@ -52,43 +52,9 @@ class DBTestCase(unittest.TestCase):
             request={"test": "this is a follow on request"},
         )
 
-        result = self._database.get_replay_for(master_table.experiment_id)
+        result = self._database.get_replay_for(master_table.unique_id)
         self.assertNotEqual(None, result)
         self.assertEqual(len(result), 2)
-
-    def test_record_setup_doublesetup_goodid(self):
-        master_table = self._database.record_setup(
-            description="test description",
-            name="test name",
-            request={"test": "this is a test request"},
-        )
-        self.assertIsNotNone(master_table)
-        self.assertEqual(len(master_table.children_replay), 1)
-        master_table = self._database.record_setup(
-            description="test description",
-            name="test name",
-            request={"test": "this is a test request"},
-            id=master_table.experiment_id,
-        )
-        self.assertIsNotNone(master_table)
-        self.assertEqual(len(master_table.children_replay), 2)
-
-    def test_record_setup_doublesetup_badid(self):
-        master_table = self._database.record_setup(
-            description="test description",
-            name="test name",
-            request={"test": "this is a test request"},
-        )
-        self.assertIsNotNone(master_table)
-        self.assertEqual(len(master_table.children_replay), 1)
-        self.assertRaises(
-            RuntimeError,
-            self._database.record_setup,
-            description="test description",
-            name="test name",
-            request={"test": "this is a test request"},
-            id=1,
-        )
 
     def test_record_setup_master_children(self):
         master_table = self._database.record_setup(
@@ -117,7 +83,7 @@ class DBTestCase(unittest.TestCase):
             request={"test": "this is a test request", "extra_info": extra_info_record},
         )
 
-        new_master = self._database.get_master_record(master_table.experiment_id)
+        new_master = self._database.get_master_record(master_table.unique_id)
         self.assertEqual(new_master.children_replay[0].extra_info, extra_info_setup)
         self.assertEqual(new_master.children_replay[1].extra_info, extra_info_record)
 
@@ -315,8 +281,8 @@ class DBTestCase(unittest.TestCase):
         )
         # record a strat
         self._database.record_strat(master_table, strat=test_strat)
-        experiment_id = master_table.experiment_id
-        strat = self._database.get_strat_for(experiment_id)
+        unique_id = master_table.unique_id
+        strat = self._database.get_strat_for(unique_id)
         self.assertEqual(test_strat, strat)
 
     def test_config_table(self):
@@ -329,9 +295,9 @@ class DBTestCase(unittest.TestCase):
         # record a strat
         self._database.record_config(master_table, config=test_config)
 
-        experiment_id = master_table.experiment_id
+        unique_id = master_table.unique_id
 
-        config = self._database.get_config_for(experiment_id)
+        config = self._database.get_config_for(unique_id)
 
         self.assertEqual(test_config, config)
 
@@ -344,8 +310,8 @@ class DBTestCase(unittest.TestCase):
         )
         # Record a raw data entry
         self._database.record_raw(master_table, model_data=model_data)
-        experiment_id = master_table.experiment_id
-        raw_data = self._database.get_raw_for(experiment_id)
+        unique_id = master_table.unique_id
+        raw_data = self._database.get_raw_for(unique_id)
         self.assertEqual(len(raw_data), 1)
         self.assertEqual(raw_data[0].model_data, model_data)
 
@@ -360,9 +326,8 @@ class DBTestCase(unittest.TestCase):
         raw_table = self._database.record_raw(master_table, model_data=True)
         # Record a param data entry
         self._database.record_param(raw_table, param_name, param_value)
-        experiment_id = master_table.experiment_id
         iteration_id = raw_table.unique_id
-        param_data = self._database.get_param_for(experiment_id, iteration_id)
+        param_data = self._database.get_param_for(iteration_id)
         self.assertEqual(len(param_data), 1)
         self.assertEqual(param_data[0].param_name, param_name)
         self.assertEqual(float(param_data[0].param_value), param_value)
@@ -378,9 +343,8 @@ class DBTestCase(unittest.TestCase):
         raw_table = self._database.record_raw(master_table, model_data=True)
         # Record an outcome data entry
         self._database.record_outcome(raw_table, outcome_name, outcome_value)
-        experiment_id = master_table.experiment_id
         iteration_id = raw_table.unique_id
-        outcome_data = self._database.get_outcome_for(experiment_id, iteration_id)
+        outcome_data = self._database.get_outcome_for(iteration_id)
         self.assertEqual(len(outcome_data), 1)
         self.assertEqual(outcome_data[0].outcome_name, outcome_name)
         self.assertEqual(outcome_data[0].outcome_value, outcome_value)


### PR DESCRIPTION
Summary:
Update db master table spec such that experiment ID and participant is not unique.

Functions that used experiment_id as a key have been swapped to use the master table's master key (unique_id). Functions appeared to expect that it's possible to get multiple entries back from a single experiment ID existed but didn't make sense since it was unique, this means nothing really needs to be changed.

Replay functions used to leverage the experiment_id, here it is assumed to be unique, which it was. Now replay functions use the master table's unique_id to pick which experiment to replay, which conveniently also means it's a lot easier to just try integers starting from 0 (instead of finding a uuid).

Metadata reading has been changed to correctly get all the information from the config to match the master table spec.

These are technically breaking changes that may affect old scripts but it's not clear what db utility functions may be used in weird scripts trying to use experiment_ids to identify experiments. Still old dbs should all work and be compatible.

Differential Revision: D66526187


