### PR TITLE
remove whitespace delimiter for _str_to_list

### DIFF
--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -207,8 +207,6 @@ class Config(configparser.ConfigParser):
     def _str_to_list(
         self, v: str, element_type: Callable[[_T], _T] = float
     ) -> List[_T]:
-        v = re.sub(r"\n ", ",", v)
-        v = re.sub(r"(?<!,)\s+", ",", v)
         v = re.sub(r",]", "]", v)
         if re.search(r"^\[.*\]$", v, flags=re.DOTALL):
             if v == "[]":  # empty list

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -917,7 +917,7 @@ class ConfigTestCase(unittest.TestCase):
             stimuli_per_trial = 1
             outcome_types = [binary]
             parnames = [par1, par2]
-            strategy_names = [init_strat, opt_strat]
+            strategy_names = [init strat, opt_strat]
 
             [par1]
             par_type = continuous
@@ -929,7 +929,7 @@ class ConfigTestCase(unittest.TestCase):
             lower_bound = 0
             upper_bound = 1
 
-            [init_strat]
+            [init strat]
             generator = SobolGenerator
             model = GPClassificationModel
 
@@ -964,7 +964,8 @@ class ConfigTestCase(unittest.TestCase):
         bad_config = Config(config_str=bad_str)
 
         # this should work
-        SequentialStrategy.from_config(good_config)
+        strat = SequentialStrategy.from_config(good_config)
+        self.assertTrue(strat.strat_list[0].name == "init strat")
 
         # this should fail
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
Summary:
Whitespace not preceded by a comma used to be replaced with a comma and thus treats whitespaces as a delimter for _str_to_list. This causes parsing list of strings to potentially separate out text like "my experiment".

Similar, new line (not technically a whitespace) was also turned into a comma and thus treated as a delimiter. 

This functionality has been removed.

Differential Revision: D66790374


