### PR TITLE
fix handling of query outputs to return config correctly

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -277,7 +277,22 @@ class AEPsychServer(object):
         return self.strat is not None and self.enable_pregen
 
     def _tensor_to_config(self, next_x):
-        next_x = self.strat.transforms.indices_to_str(next_x.unsqueeze(0))[0]
+        stim_per_trial = self.strat.stimuli_per_trial
+        dim = self.strat.dim
+        if (
+            stim_per_trial > 1 and len(next_x.shape) == 2
+        ):  # Multi stimuli case are complex
+            # We need to find out next_x is from an ask or a query
+            if stim_per_trial == next_x.shape[-1] and dim == next_x.shape[-2]:
+                # From an ask, so we need to add a batch dim
+                next_x = next_x.unsqueeze(0)
+            # If we're a query, the 2D-ness of it is actually correct
+
+        if len(next_x.shape) == 1:
+            # We always need a batch dimension for transformations
+            next_x = next_x.unsqueeze(0)
+
+        next_x = self.strat.transforms.indices_to_str(next_x)[0]
         config = {}
         for name, val in zip(self.parnames, next_x):
             if isinstance(val, str):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -539,7 +539,7 @@ class TransformsFixed(unittest.TestCase):
 
         config_str = """
             [common]
-            parnames = [signal1, signal2, signal3]
+            parnames = [signal1, signal2, signal3, signal4]
             stimuli_per_trial = 1
             outcome_types = [binary]
             strategy_names = [init_strat, opt_strat]
@@ -556,6 +556,10 @@ class TransformsFixed(unittest.TestCase):
             lower_bound = 1
             upper_bound = 100
             log_scale = True
+
+            [signal4]
+            par_type = fixed
+            value = blue
 
             [init_strat]
             generator = SobolGenerator
@@ -641,3 +645,12 @@ class TransformsFixed(unittest.TestCase):
         self.assertTrue(
             torch.all(torch.tensor([2, 0.1, 0.2, 0.3, 2]) == untransformed[1])
         )
+
+    def test_fixed_conflict(self):
+        fixed1 = Fixed([3], values=[0], string_map={3: ["blue"]})
+        fixed2 = Fixed(
+            [1, 2], values=[0, 0.2], string_map={1: ["red"], 3: ["green", "blue"]}
+        )
+
+        with self.assertRaises(RuntimeError):
+            transforms = ParameterTransforms(fixed1=fixed1, fixed2=fixed2)


### PR DESCRIPTION
Summary:
When a model is queried via a client-server interaction, the min, max, and inverse queries would give a dictionary where the parameters were not separated out by parameter (which is a problem for models with more than one parameter).

This is further complicated by the shapeof the tensors going into the `_tensor_to_config` method from multi-stimuli models is always 2D but not always 2 stimuli (2D but 1 stimuli case  for queries).

We fix both of these as they require additional logic in `_tensor_to_config`.

Differential Revision: D66853925


