### PR TITLE
Fix constrained query messages

### DIFF
--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -125,7 +125,7 @@ class AEPsychMixin(GPyTorchModel):
 
     def get_max(
         self: ModelProtocol,
-        locked_dims: Optional[Mapping[int, List[float]]] = None,
+        locked_dims: Optional[Mapping[int, float]] = None,
         probability_space: bool = False,
         n_samples: int = 1000,
         max_time: Optional[float] = None,
@@ -134,7 +134,7 @@ class AEPsychMixin(GPyTorchModel):
 
         Args:
             locked_dims (Mapping[int, List[float]], optional): Dimensions to fix, so that the
-                inverse is along a slice of the full surface. Defaults to None.
+                max is along a slice of the full surface. Defaults to None.
             probability_space (bool): Is y (and therefore the returned nearest_y) in
                 probability space instead of latent function space? Defaults to False.
             n_samples (int): number of coarse grid points to sample for optimization estimate.
@@ -156,7 +156,7 @@ class AEPsychMixin(GPyTorchModel):
 
     def get_min(
         self: ModelProtocol,
-        locked_dims: Optional[Mapping[int, List[float]]] = None,
+        locked_dims: Optional[Mapping[int, float]] = None,
         probability_space: bool = False,
         n_samples: int = 1000,
         max_time: Optional[float] = None,
@@ -164,7 +164,7 @@ class AEPsychMixin(GPyTorchModel):
         """Return the minimum of the modeled function, subject to constraints
         Args:
             locked_dims (Mapping[int, List[float]], optional): Dimensions to fix, so that the
-                inverse is along a slice of the full surface.
+                min is along a slice of the full surface.
             probability_space (bool): Is y (and therefore the returned nearest_y) in
                 probability space instead of latent function space? Defaults to False.
             n_samples (int): number of coarse grid points to sample for optimization estimate.
@@ -187,7 +187,7 @@ class AEPsychMixin(GPyTorchModel):
     def inv_query(
         self,
         y: float,
-        locked_dims: Optional[Mapping[int, List[float]]] = None,
+        locked_dims: Optional[Mapping[int, float]] = None,
         probability_space: bool = False,
         n_samples: int = 1000,
         max_time: Optional[float] = None,
@@ -199,7 +199,7 @@ class AEPsychMixin(GPyTorchModel):
 
         Args:
             y (float): Points at which to find the inverse.
-            locked_dims (Mapping[int, List[float]], optional): Dimensions to fix, so that the
+            locked_dims (Mapping[int, float], optional): Dimensions to fix, so that the
                 inverse is along a slice of the full surface.
             probability_space (bool): Is y (and therefore the returned nearest_y) in
                 probability space instead of latent function space? Defaults to False.

--- a/aepsych/server/message_handlers/handle_query.py
+++ b/aepsych/server/message_handlers/handle_query.py
@@ -66,8 +66,6 @@ def query(
         response["y"] = np.array(mean.item())  # mean.item()
 
     elif query_type == "inverse":
-        # expect constraints to be a dictionary; values are float arrays size 1 (exact) or 2 (upper/lower bnd)
-        constraints = {server.parnames.index(k): v for k, v in constraints.items()}
         nearest_y, nearest_loc = server.strat.inv_query(
             y, constraints, probability_space=probability_space, **kwargs
         )

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -334,14 +334,14 @@ class Strategy(object):
     @ensure_model_is_fresh
     def get_max(
         self,
-        constraints: Optional[Mapping[int, List[float]]] = None,
+        constraints: Optional[Mapping[int, float]] = None,
         probability_space: bool = False,
         max_time: Optional[float] = None,
     ) -> Tuple[float, torch.Tensor]:
         """Get the maximum value of the acquisition function.
 
         Args:
-            constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
+            constraints (Mapping[int, float], optional): Which parameters to fix at specfic points. Defaults to None.
             probability_space (bool): Whether to return the max in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
 
@@ -360,14 +360,14 @@ class Strategy(object):
     @ensure_model_is_fresh
     def get_min(
         self,
-        constraints: Optional[Mapping[int, List[float]]] = None,
+        constraints: Optional[Mapping[int, float]] = None,
         probability_space: bool = False,
         max_time: Optional[float] = None,
     ) -> Tuple[float, torch.Tensor]:
         """Get the minimum value of the acquisition function.
 
         Args:
-            constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
+            constraints (Mapping[int, float], optional): Which parameters to fix at specific points. Defaults to None.
             probability_space (bool): Whether to return the min in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
 
@@ -387,7 +387,7 @@ class Strategy(object):
     def inv_query(
         self,
         y: int,
-        constraints: Optional[Mapping[int, List[float]]] = None,
+        constraints: Optional[Mapping[int, float]] = None,
         probability_space: bool = False,
         max_time: Optional[float] = None,
     ) -> Tuple[float, torch.Tensor]:
@@ -395,7 +395,7 @@ class Strategy(object):
 
         Args:
             y (int): The output value.
-            constraints (Mapping[int, List[float]], optional): Constraints on the input space. Defaults to None.
+            constraints (Mapping[int, List[float]], optional): Which parameters to fix at specific points. Defaults to None.
             probability_space (bool): Whether to return the input in probability space. Defaults to False.
             max_time (float, optional): Maximum time to run the optimization. Defaults to None.
 

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -656,7 +656,7 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
 
     def get_max(
         self,
-        locked_dims: Optional[Mapping[int, List[float]]] = None,
+        locked_dims: Optional[Mapping[int, float]] = None,
         probability_space: bool = False,
         n_samples: int = 1000,
         max_time: Optional[float] = None,
@@ -664,8 +664,8 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
         """Return the maximum of the modeled function, subject to constraints
 
         Args:
-            locked_dims (Mapping[int, List[float]], optional): Dimensions to fix, so that the
-                inverse is along a slice of the full surface. Defaults to None.
+            locked_dims (Mapping[int, float], optional): Dimensions to fix, so that the
+                max is along a slice of the full surface. Defaults to None.
             probability_space (bool): Is y (and therefore the returned nearest_y) in
                 probability space instead of latent function space? Defaults to False.
             n_samples (int): number of coarse grid points to sample for optimization estimate.
@@ -676,6 +676,18 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
             Tuple[float, torch.Tensor]: Tuple containing the max and its untransformed
                 location (argmax).
         """
+        locked_dims = locked_dims or {}
+
+        # Transform locked dims
+        tmp = {}
+        for key, value in locked_dims.items():
+            dims = list(self.transforms.values())[0]._d
+            tensor = torch.zeros(dims)
+            tensor[key] = value
+            tensor = self.transforms.transform(tensor)
+            tmp[key] = tensor[key].item()
+        locked_dims = tmp
+
         max_, loc = self._base_obj.get_max(  # type: ignore
             locked_dims=locked_dims,
             probability_space=probability_space,
@@ -688,7 +700,7 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
 
     def get_min(
         self,
-        locked_dims: Optional[Mapping[int, List[float]]] = None,
+        locked_dims: Optional[Mapping[int, float]] = None,
         probability_space: bool = False,
         n_samples: int = 1000,
         max_time: Optional[float] = None,
@@ -696,8 +708,8 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
         """Return the minimum of the modeled function, subject to constraints
 
         Args:
-            locked_dims (Mapping[int, List[float]], optional): Dimensions to fix, so that the
-                inverse is along a slice of the full surface.
+            locked_dims (Mapping[int, float], optional): Dimensions to fix, so that the
+                min is along a slice of the full surface.
             probability_space (bool): Is y (and therefore the returned nearest_y) in
                 probability space instead of latent function space? Defaults to False.
             n_samples (int): number of coarse grid points to sample for optimization estimate.
@@ -707,6 +719,18 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
         Returns:
             Tuple[float, torch.Tensor]: Tuple containing the min and its untransformed location (argmin).
         """
+        locked_dims = locked_dims or {}
+
+        # Transform locked dims
+        tmp = {}
+        for key, value in locked_dims.items():
+            dims = list(self.transforms.values())[0]._d
+            tensor = torch.zeros(dims)
+            tensor[key] = value
+            tensor = self.transforms.transform(tensor)
+            tmp[key] = tensor[key].item()
+        locked_dims = tmp
+
         min_, loc = self._base_obj.get_min(  # type: ignore
             locked_dims=locked_dims,
             probability_space=probability_space,
@@ -720,7 +744,7 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
     def inv_query(
         self,
         y: float,
-        locked_dims: Optional[Mapping[int, List[float]]] = None,
+        locked_dims: Optional[Mapping[int, float]] = None,
         probability_space: bool = False,
         n_samples: int = 1000,
         max_time: Optional[float] = None,
@@ -733,7 +757,7 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
 
         Args:
             y (float): Points at which to find the inverse.
-            locked_dims (Mapping[int, List[float]], optional): Dimensions to fix, so that the
+            locked_dims (Mapping[int, float], optional): Dimensions to fix, so that the
                 inverse is along a slice of the full surface.
             probability_space (bool): Is y (and therefore the returned nearest_y) in
                 probability space instead of latent function space? Defaults to False.
@@ -745,6 +769,18 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
             Tuple[float, torch.Tensor]: Tuple containing the value of f
                 nearest to queried y and the untransformed x position of this value.
         """
+        locked_dims = locked_dims or {}
+
+        # Transform locked dims
+        tmp = {}
+        for key, value in locked_dims.items():
+            dims = list(self.transforms.values())[0]._d
+            tensor = torch.zeros(dims)
+            tensor[key] = value
+            tensor = self.transforms.transform(tensor)
+            tmp[key] = tensor[key].item()
+        locked_dims = tmp
+
         val, loc = self._base_obj.inv_query(  # type: ignore
             y=y,
             locked_dims=locked_dims,

--- a/tests/server/message_handlers/test_query_handlers.py
+++ b/tests/server/message_handlers/test_query_handlers.py
@@ -94,6 +94,20 @@ class QueryHandlerTestCase(BaseServerTestCase):
                 "y": 5.0,
             },
         }
+
+        query_max_const = {
+            "type": "query",
+            "message": {"query_type": "max", "constraints": {1: 0}},
+        }
+        query_min_const = {
+            "type": "query",
+            "message": {"query_type": "min", "constraints": {0: 0.25}},
+        }
+        query_inv_const = {
+            "type": "query",
+            "message": {"query_type": "inverse", "y": 5.0, "constraints": {1: 0}},
+        }
+
         response = self.s.handle_request(query_min_req)
         self.assertTrue(len(response["x"]["par1"]) == 1)
         self.assertTrue(len(response["x"]["par2"]) == 1)
@@ -109,6 +123,15 @@ class QueryHandlerTestCase(BaseServerTestCase):
         response = self.s.handle_request(query_pred_req)
         self.assertTrue(len(response["x"]["par1"]) == 1)
         self.assertTrue(len(response["x"]["par2"]) == 1)
+
+        response = self.s.handle_request(query_max_const)
+        self.assertTrue(response["x"]["par2"][0] == 0)
+
+        response = self.s.handle_request(query_min_const)
+        self.assertTrue(response["x"]["par1"][0] == 0.25)
+
+        response = self.s.handle_request(query_inv_const)
+        self.assertTrue(response["x"]["par2"][0] == 0)
 
     def test_grad_model_smoketest(self):
         # Some models return values with gradients that need to be handled


### PR DESCRIPTION
Summary:
Queries did not properly respect the constraint option in message when transforms are used (which is most of the time, because of the NormalizeScale transform). Now the constraints (which are just fixed dimensions) are properly transformed when running queries with ParameterTransformedModels.

The docstring and documentation also had incorrect call signatures and docstring that made this more confusing, this is also fixed.

Differential Revision: D66994705


