### PR TITLE
Make prediction query actually work with the probability_space option.

### DIFF
--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -202,8 +202,8 @@ class PairwiseProbitModel(PairwiseGP, AEPsychMixin):
 
         if probability_space:
             return (
-                promote_0d(norm.cdf(fmean)),
-                promote_0d(norm.cdf(fvar)),
+                promote_0d(norm.cdf(fmean.detach().numpy())),
+                promote_0d(norm.cdf(fvar.detach().numpy())),
             )
         else:
             return fmean, fvar

--- a/aepsych/server/message_handlers/handle_query.py
+++ b/aepsych/server/message_handlers/handle_query.py
@@ -54,16 +54,14 @@ def query(
         # returns the model value at x
         if x is None:  # TODO: ensure if x is between lb and ub
             raise RuntimeError("Cannot query model at location = None!")
-        if probability_space:
-            mean, _var = server.strat.predict_probability(
-                server._config_to_tensor(x).unsqueeze(axis=0),
-            )
-        else:
-            mean, _var = server.strat.predict(
-                server._config_to_tensor(x).unsqueeze(axis=0)
-            )
+
+        mean, _var = server.strat.predict(
+            server._config_to_tensor(x).unsqueeze(axis=0),
+            probability_space=probability_space,
+        )
         response["x"] = x
-        response["y"] = np.array(mean.item())  # mean.item()
+        y = mean.item() if isinstance(mean, torch.Tensor) else mean[0]
+        response["y"] = np.array(y)  # mean.item()
 
     elif query_type == "inverse":
         # expect constraints to be a dictionary; values are float arrays size 1 (exact) or 2 (upper/lower bnd)

--- a/tests/server/message_handlers/test_query_handlers.py
+++ b/tests/server/message_handlers/test_query_handlers.py
@@ -176,6 +176,14 @@ class QueryHandlerTestCase(BaseServerTestCase):
                 "x": {"x": [0.0], "y": [1.0]},
             },
         }
+        query_pred_prob = {
+            "type": "query",
+            "message": {
+                "query_type": "prediction",
+                "x": {"x": [0.0], "y": [1.0]},
+                "probability_space": True,
+            },
+        }
         query_inv_req = {
             "type": "query",
             "message": {
@@ -183,8 +191,10 @@ class QueryHandlerTestCase(BaseServerTestCase):
                 "y": 5.0,
             },
         }
+
         self.s.handle_request(query_min_req)
         self.s.handle_request(query_pred_req)
+        self.s.handle_request(query_pred_prob)
         self.s.handle_request(query_max_req)
         self.s.handle_request(query_inv_req)
 


### PR DESCRIPTION
Summary:
Prediction query messages used to called a non-existent strategy method called predict_probability. This meant that there would be an exception whenever this is tried. The method hasn't existed for at least 2 years.

Fixed to use `strat.predict()` with the correct probability_space flag instead.

Because of this change, further changes was necessary to ensure models that would return tneors with gradients would work (e.g., pairwise probit).

Differential Revision: D66997335


