### PR TITLE
Refactor Models to Fully Utilize Allocators and Remove Bounds Dependency (#468)

### DIFF
--- a/aepsych/benchmark/benchmark.py
+++ b/aepsych/benchmark/benchmark.py
@@ -16,6 +16,8 @@ import numpy as np
 import pandas as pd
 import torch
 from aepsych.config import Config
+
+from aepsych.models.inducing_point_allocators import AutoAllocator
 from aepsych.strategy import ensure_model_is_fresh, SequentialStrategy
 from tqdm.contrib.itertools import product as tproduct
 
@@ -155,6 +157,7 @@ class Benchmark:
         np.random.seed(seed)
         config_dict["common"]["lb"] = str(problem.lb.tolist())
         config_dict["common"]["ub"] = str(problem.ub.tolist())
+        config_dict["common"]["dim"] = str(problem.lb.shape[0])
         config_dict["common"]["parnames"] = str(
             [f"par{i}" for i in range(len(problem.ub.tolist()))]
         )

--- a/aepsych/benchmark/example_problems.py
+++ b/aepsych/benchmark/example_problems.py
@@ -11,7 +11,8 @@ from aepsych.benchmark.test_functions import (
     novel_discrimination_testfun,
 )
 from aepsych.models import GPClassificationModel
-from aepsych.models.inducing_point_allocators import KMeansAllocator
+from aepsych.models.inducing_point_allocators import KMeansAllocator, SobolAllocator
+from aepsych.models.utils import select_inducing_points
 
 """The DiscrimLowDim, DiscrimHighDim, ContrastSensitivity6d, and Hartmann6Binary classes
 are copied from bernoulli_lse github repository (https://github.com/facebookresearch/bernoulli_lse)
@@ -104,12 +105,12 @@ class ContrastSensitivity6d(LSEProblemWithEdgeLogging):
         )
         y = torch.LongTensor(self.data[:, 0])
         x = torch.Tensor(self.data[:, 1:])
+        inducing_size = 100
 
         # Fit a model, with a large number of inducing points
         self.m = GPClassificationModel(
-            lb=self.bounds[0],
-            ub=self.bounds[1],
-            inducing_size=100,
+            dim=6,
+            inducing_size=inducing_size,
             inducing_point_method=KMeansAllocator(bounds=self.bounds),
         )
 

--- a/aepsych/generators/epsilon_greedy_generator.py
+++ b/aepsych/generators/epsilon_greedy_generator.py
@@ -15,15 +15,25 @@ from .optimize_acqf_generator import OptimizeAcqfGenerator
 
 
 class EpsilonGreedyGenerator(AEPsychGenerator):
-    def __init__(self, subgenerator: AEPsychGenerator, epsilon: float = 0.1) -> None:
+    def __init__(
+        self,
+        lb: torch.Tensor,
+        ub: torch.Tensor,
+        subgenerator: AEPsychGenerator,
+        epsilon: float = 0.1,
+    ) -> None:
         """Initialize EpsilonGreedyGenerator.
 
         Args:
+            lb (torch.Tensor): Lower bounds for the optimization.
+            ub (torch.Tensor): Upper bounds for the optimization.
             subgenerator (AEPsychGenerator): The generator to use when not exploiting.
             epsilon (float): The probability of exploration. Defaults to 0.1.
         """
         self.subgenerator = subgenerator
         self.epsilon = epsilon
+        self.lb = lb
+        self.ub = ub
 
     @classmethod
     def from_config(cls, config: Config) -> "EpsilonGreedyGenerator":
@@ -36,12 +46,14 @@ class EpsilonGreedyGenerator(AEPsychGenerator):
             EpsilonGreedyGenerator: The generator.
         """
         classname = cls.__name__
+        lb = torch.tensor(config.getlist(classname, "lb"))
+        ub = torch.tensor(config.getlist(classname, "ub"))
         subgen_cls = config.getobj(
             classname, "subgenerator", fallback=OptimizeAcqfGenerator
         )
         subgen = subgen_cls.from_config(config)
         epsilon = config.getfloat(classname, "epsilon", fallback=0.1)
-        return cls(subgenerator=subgen, epsilon=epsilon)
+        return cls(lb=lb, ub=ub, subgenerator=subgen, epsilon=epsilon)
 
     def gen(self, num_points: int, model: ModelProtocol) -> torch.Tensor:
         """Query next point(s) to run by sampling from the subgenerator with probability 1-epsilon, and randomly otherwise.
@@ -53,7 +65,7 @@ class EpsilonGreedyGenerator(AEPsychGenerator):
         if num_points > 1:
             raise NotImplementedError("Epsilon-greedy batched gen is not implemented!")
         if np.random.uniform() < self.epsilon:
-            sample = np.random.uniform(low=model.lb, high=model.ub)
+            sample = np.random.uniform(low=self.lb, high=self.ub)
             return torch.tensor(sample).reshape(1, -1)
         else:
             return self.subgenerator.gen(num_points, model)

--- a/aepsych/generators/monotonic_rejection_generator.py
+++ b/aepsych/generators/monotonic_rejection_generator.py
@@ -12,6 +12,7 @@ from aepsych.acquisition.monotonic_rejection import MonotonicMCAcquisition
 from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator
 from aepsych.models.monotonic_rejection_gp import MonotonicRejectionGP
+from aepsych.utils import _process_bounds
 from botorch.acquisition import AcquisitionFunction
 from botorch.logging import logger
 from botorch.optim.initializers import gen_batch_initial_conditions
@@ -43,13 +44,17 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
     def __init__(
         self,
         acqf: MonotonicMCAcquisition,
+        lb: torch.Tensor,
+        ub: torch.Tensor,
         acqf_kwargs: Optional[Dict[str, Any]] = None,
         model_gen_options: Optional[Dict[str, Any]] = None,
         explore_features: Optional[Sequence[int]] = None,
     ) -> None:
         """Initialize MonotonicRejectionGenerator.
         Args:
-            acqf (MonotonicMCAcquisition): Acquisition function to use.
+            acqf (AcquisitionFunction): Acquisition function to use.
+            lb (torch.Tensor): Lower bounds for the optimization.
+            ub (torch.Tensor): Upper bounds for the optimization.
             acqf_kwargs (Dict[str, object], optional): Extra arguments to
                 pass to acquisition function. Defaults to None.
             model_gen_options (Dict[str, Any], optional): Dictionary with options for generating candidate, such as
@@ -63,6 +68,8 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         self.acqf_kwargs = acqf_kwargs
         self.model_gen_options = model_gen_options
         self.explore_features = explore_features
+        self.lb, self.ub, _ = _process_bounds(lb, ub, None)
+        self.bounds = torch.stack((self.lb, self.ub))
 
     def _instantiate_acquisition_fn(
         self, model: MonotonicRejectionGP
@@ -110,7 +117,7 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         )
 
         # Augment bounds with deriv indicator
-        bounds = torch.cat((model.bounds_, torch.zeros(2, 1)), dim=1)
+        bounds = torch.cat((self.bounds, torch.zeros(2, 1)), dim=1)
         # Fix deriv indicator to 0 during optimization
         fixed_features = {(bounds.shape[1] - 1): 0.0}
         # Fix explore features to random values
@@ -192,6 +199,8 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         classname = cls.__name__
         acqf = config.getobj("common", "acqf", fallback=None)
         extra_acqf_args = cls._get_acqf_options(acqf, config)
+        lb = torch.tensor(config.getlist(classname, "lb"))
+        ub = torch.tensor(config.getlist(classname, "ub"))
 
         options = {}
         options["num_restarts"] = config.getint(classname, "restarts", fallback=10)
@@ -217,6 +226,8 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
 
         return cls(
             acqf=acqf,
+            lb=lb,
+            ub=ub,
             acqf_kwargs=extra_acqf_args,
             model_gen_options=options,
             explore_features=explore_features,

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-import numpy as np
 import torch
 from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator

--- a/aepsych/models/inducing_point_allocators.py
+++ b/aepsych/models/inducing_point_allocators.py
@@ -5,14 +5,12 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Union
+from abc import abstractmethod
+from typing import Any, Dict, Optional
 
-import numpy as np
 import torch
 
 from aepsych.config import Config, ConfigurableMixin
-from aepsych.utils import get_bounds
 from botorch.models.utils.inducing_point_allocators import (
     GreedyVarianceReduction as BaseGreedyVarianceReduction,
     InducingPointAllocator,
@@ -45,6 +43,7 @@ class BaseAllocator(InducingPointAllocator, ConfigurableMixin):
             # Validate bounds and extract dimension
             assert self.bounds.shape[0] == 2, "Bounds must have shape (2, d)!"
             lb, ub = self.bounds[0], self.bounds[1]
+            self.lb, self.ub = lb, ub
             for i, (l, u) in enumerate(zip(lb, ub)):
                 assert (
                     l <= u

--- a/aepsych/models/monotonic_rejection_gp.py
+++ b/aepsych/models/monotonic_rejection_gp.py
@@ -11,7 +11,6 @@ import warnings
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import gpytorch
-import numpy as np
 import torch
 from aepsych.acquisition.rejection_sampler import RejectionSampler
 from aepsych.config import Config
@@ -21,7 +20,7 @@ from aepsych.means.constant_partial_grad import ConstantMeanPartialObsGrad
 from aepsych.models.base import AEPsychMixin
 from aepsych.models.inducing_point_allocators import AutoAllocator, SobolAllocator
 from aepsych.models.utils import select_inducing_points
-from aepsych.utils import _process_bounds, get_optimizer_options, promote_0d
+from aepsych.utils import _process_bounds, get_dims, get_optimizer_options, promote_0d
 from botorch.fit import fit_gpytorch_mll
 from botorch.models.utils.inducing_point_allocators import (
     GreedyVarianceReduction,
@@ -172,7 +171,6 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
             inducing_size=self.inducing_size,
             covar_module=self.covar_module,
             X=self.train_inputs[0],
-            bounds=self.bounds,
         )
         self._set_model(train_x, train_y)
 
@@ -356,7 +354,7 @@ class MonotonicRejectionGP(AEPsychMixin, ApproximateGP):
 
         lb = config.gettensor(classname, "lb")
         ub = config.gettensor(classname, "ub")
-        dim = config.getint(classname, "dim", fallback=None)
+        dim = get_dims(config)
 
         mean_covar_factory = config.getobj(
             classname, "mean_covar_factory", fallback=monotonic_mean_covar_factory

--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -12,7 +12,7 @@ import torch
 from aepsych.config import Config
 from aepsych.factory import default_mean_covar_factory
 from aepsych.models.base import AEPsychMixin
-from aepsych.utils import _process_bounds, get_optimizer_options, promote_0d
+from aepsych.utils import _process_bounds, get_dims, get_optimizer_options, promote_0d
 from aepsych.utils_logging import getLogger
 from botorch.fit import fit_gpytorch_mll
 from botorch.models import PairwiseGP, PairwiseLaplaceMarginalLogLikelihood
@@ -292,7 +292,7 @@ class PairwiseProbitModel(PairwiseGP, AEPsychMixin):
 
         lb = config.gettensor(classname, "lb")
         ub = config.gettensor(classname, "ub")
-        dim = lb.shape[0]
+        dim = get_dims(config)
 
         max_fit_time = config.getfloat(classname, "max_fit_time", fallback=None)
 

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -11,7 +11,10 @@ from typing import List, Mapping, Optional, Tuple, Union
 
 import numpy as np
 import torch
+
+from aepsych.models.base import ModelProtocol
 from aepsych.models.inducing_point_allocators import GreedyVarianceReduction
+from aepsych.utils import _process_bounds, dim_grid, get_jnd_multid
 from botorch.acquisition import PosteriorMean
 from botorch.acquisition.objective import (
     PosteriorTransform,
@@ -23,7 +26,6 @@ from botorch.optim import optimize_acqf
 from botorch.posteriors import GPyTorchPosterior
 from botorch.utils.sampling import draw_sobol_samples
 from gpytorch.distributions import MultivariateNormal
-from gpytorch.kernels import Kernel
 from gpytorch.likelihoods import BernoulliLikelihood, Likelihood
 from scipy.cluster.vq import kmeans2
 from scipy.special import owens_t
@@ -289,6 +291,107 @@ def inv_query(
         weights,
     )
     return val, arg
+
+
+def get_jnd(
+    model: ModelProtocol,
+    lb: torch.Tensor,
+    ub: torch.Tensor,
+    dim: int,
+    grid: Optional[Union[np.ndarray, torch.Tensor]] = None,
+    cred_level: Optional[float] = None,
+    intensity_dim: int = -1,
+    confsamps: int = 500,
+    method: str = "step",
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """Calculate the JND.
+
+    Note that JND can have multiple plausible definitions
+    outside of the linear case, so we provide options for how to compute it.
+    For method="step", we report how far one needs to go over in stimulus
+    space to move 1 unit up in latent space (this is a lot of people's
+    conventional understanding of the JND).
+    For method="taylor", we report the local derivative, which also maps to a
+    1st-order Taylor expansion of the latent function. This is a formal
+    generalization of JND as defined in Weber's law.
+    Both definitions are equivalent for linear psychometric functions.
+
+    Args:
+        model (ModelProtocol): Model to use for prediction.
+        lb (torch.Tensor): Lower bounds of the input space.
+        ub (torch.Tensor): Upper bounds of the input space.
+        dim (int): Dimensionality of the input space.
+        grid (Optional[np.ndarray], optional): Mesh grid over which to find the JND.
+            Defaults to a square grid of size as determined by aepsych.utils.dim_grid
+        cred_level (float, optional): Credible level for computing an interval.
+            Defaults to None, computing no interval.
+        intensity_dim (int, optional): Dimension over which to compute the JND.
+            Defaults to -1.
+        confsamps (int, optional): Number of posterior samples to use for
+            computing the credible interval. Defaults to 500.
+        method (str, optional): "taylor" or "step" method (see docstring).
+            Defaults to "step".
+
+    Raises:
+        RuntimeError: for passing an unknown method.
+
+    Returns:
+        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]: either the
+            mean JND, or a median, lower, upper tuple of the JND posterior.
+    """
+    if grid is None:
+        grid = dim_grid(lower=lb, upper=ub, gridsize=30, slice_dims=None)
+    elif isinstance(grid, np.ndarray):
+        grid = torch.tensor(grid)
+
+    # this is super awkward, back into intensity dim grid assuming a square grid
+    gridsize = int(grid.shape[0] ** (1 / grid.shape[1]))
+    coords = torch.linspace(
+        lb[intensity_dim].item(), ub[intensity_dim].item(), gridsize
+    )
+
+    if cred_level is None:
+        fmean, _ = model.predict(grid)
+        fmean = fmean.reshape(*[gridsize for i in range(dim)])
+
+        if method == "taylor":
+            return torch.tensor(1 / np.gradient(fmean, coords, axis=intensity_dim))
+        elif method == "step":
+            return torch.clip(
+                get_jnd_multid(
+                    fmean,
+                    coords,
+                    mono_dim=intensity_dim,
+                ),
+                0,
+                np.inf,
+            )
+
+    alpha = 1 - cred_level  # type: ignore
+    qlower = alpha / 2
+    qupper = 1 - alpha / 2
+
+    fsamps = model.sample(grid, confsamps)
+    if method == "taylor":
+        jnds = torch.tensor(
+            1
+            / np.gradient(
+                fsamps.reshape(confsamps, *[gridsize for i in range(dim)]),
+                coords,
+                axis=intensity_dim,
+            )
+        )
+    elif method == "step":
+        samps = [s.reshape((gridsize,) * dim) for s in fsamps]
+        jnds = torch.stack(
+            [get_jnd_multid(s, coords, mono_dim=intensity_dim) for s in samps]
+        )
+    else:
+        raise RuntimeError(f"Unknown method {method}!")
+    upper = torch.clip(torch.quantile(jnds, qupper, axis=0), 0, np.inf)  # type: ignore
+    lower = torch.clip(torch.quantile(jnds, qlower, axis=0), 0, np.inf)  # type: ignore
+    median = torch.clip(torch.quantile(jnds, 0.5, axis=0), 0, np.inf)  # type: ignore
+    return median, lower, upper
 
 
 class TargetDistancePosteriorTransform(PosteriorTransform):

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -508,10 +508,6 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
         """
         # Alternative instantiation method for analysis (and not live)
         if isinstance(model, type):
-            if "lb" in kwargs:
-                kwargs["lb"] = transforms.transform(kwargs["lb"].to(torch.float64))
-            if "ub" in kwargs:
-                kwargs["ub"] = transforms.transform(kwargs["ub"].to(torch.float64))
             _base_obj = model(**kwargs)
         else:
             _base_obj = model

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -405,3 +405,29 @@ def get_optimizer_options(config: Config, name: str) -> Dict[str, Any]:
     # Filter all the nones out, which could just come back as an empty dict
     options = {key: value for key, value in options.items() if value is not None}
     return options
+
+
+def get_dims(config: Config) -> int:
+    """Return the number of dimensions in the parameter space. This accounts for any
+    transforms that may modify the the parameter space for the model (e.g., Fixed
+    parameters will not be included).
+
+    Args:
+        config (Config): The config to look for the number of dimensions.
+
+    Return:
+        int: The number of dimensions in the search space.
+    """
+    parnames = config.getlist("common", "parnames", element_type=str)
+
+    # This is pretty weak but fixed is currently the only thing that will changed the
+    # search space dims, when categorial transforms go in, this function needs to be
+    # smarter.
+    try:
+        valid_pars = [
+            parname for parname in parnames if config[parname]["par_type"] != "fixed"
+        ]
+        return len(valid_pars)
+    except KeyError:
+        # Likely old style of parameter definition, fallback to looking at parnames
+        return len(config.getlist("common", "parnames", element_type=str))

--- a/pubs/owenetal/code/prior_plots.py
+++ b/pubs/owenetal/code/prior_plots.py
@@ -80,6 +80,8 @@ def plot_prior_samps_1d():
 
         mono_mean, mono_covar = monotonic_mean_covar_factory(config)
         mono_model = MonotonicRejectionGP(
+            lb=lb,
+            ub=ub,
             likelihood="probit-bernoulli",
             monotonic_idxs=[0],
             mean_module=mono_mean,
@@ -176,6 +178,8 @@ def plot_prior_samps_2d():
 
         mono_mean, mono_covar = monotonic_mean_covar_factory(config)
         mono_model = MonotonicRejectionGP(
+            lb=lb,
+            ub=ub,
             likelihood="probit-bernoulli",
             monotonic_idxs=[1],
             mean_module=mono_mean,

--- a/tests/generators/test_epsilon_greedy_generator.py
+++ b/tests/generators/test_epsilon_greedy_generator.py
@@ -22,13 +22,17 @@ class TestEpsilonGreedyGenerator(unittest.TestCase):
         np.random.seed(seed)
         total_trials = 2000
         extra_acqf_args = {"target": 0.75, "beta": 1.96}
+        lb = torch.tensor([0.0])
+        ub = torch.tensor([1.0])
 
         for epsilon in (0.1, 0.5):
             gen = EpsilonGreedyGenerator(
                 subgenerator=MonotonicRejectionGenerator(
-                    acqf=MonotonicMCLSE, acqf_kwargs=extra_acqf_args
+                    acqf=MonotonicMCLSE, acqf_kwargs=extra_acqf_args, lb=lb, ub=ub
                 ),
                 epsilon=epsilon,
+                lb=lb,
+                ub=ub,
             )
             model = MagicMock()
             gen.subgenerator.gen = MagicMock()
@@ -44,6 +48,8 @@ class TestEpsilonGreedyGenerator(unittest.TestCase):
         config_str = """
             [common]
             acqf = MonotonicMCLSE
+            lb = [0]
+            ub = [1]
             [EpsilonGreedyGenerator]
             subgenerator = MonotonicRejectionGenerator
             epsilon = .5

--- a/tests/models/test_gp_regression.py
+++ b/tests/models/test_gp_regression.py
@@ -59,6 +59,8 @@ class GPRegressionTest(unittest.TestCase):
             [GPRegressionModel]
             likelihood = GaussianLikelihood
             max_fit_time = 1
+            dim = 1
+            inducing_point_method = AutoAllocator
         """
         self.server = AEPsychServer(database_path=dbname)
         configure(self.server, config_str=config)
@@ -88,9 +90,9 @@ class GPRegressionTest(unittest.TestCase):
 
     def test_from_config(self):
         model = self.server.strat.model
-        npt.assert_allclose(model.transforms.untransform(model.lb), [-1.0])
-        npt.assert_allclose(model.transforms.untransform(model.ub), [3.0])
-        self.assertEqual(model.dim, 1)
+        generator = self.server.strat.generator
+        npt.assert_allclose(model.transforms.untransform(generator.lb), [-1.0])
+        npt.assert_allclose(model.transforms.untransform(generator.ub), [3.0])
         self.assertIsInstance(model.likelihood, GaussianLikelihood)
         self.assertEqual(model.max_fit_time, 1)
 

--- a/tests/models/test_monotonic_rejection_gp.py
+++ b/tests/models/test_monotonic_rejection_gp.py
@@ -20,6 +20,8 @@ from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
 from aepsych.acquisition.objective import ProbitObjective
 from aepsych.generators import MonotonicRejectionGenerator
 from aepsych.models import MonotonicRejectionGP
+from aepsych.models.inducing_point_allocators import SobolAllocator
+from aepsych.models.utils import select_inducing_points
 from aepsych.strategy import Strategy
 from botorch.acquisition.objective import IdentityMCObjective
 from botorch.utils.testing import BotorchTestCase
@@ -32,18 +34,21 @@ class MonotonicRejectionGPLSETest(BotorchTestCase):
         # Init
         target = 1.5
         model_gen_options = {"num_restarts": 1, "raw_samples": 3, "epochs": 5}
-        lb = torch.tensor([0, 0])
-        ub = torch.tensor([4, 4])
+        lb = torch.tensor([0.0, 0.0])
+        ub = torch.tensor([4.0, 4.0])
+        inducing_size = 2
+        bounds = torch.stack([lb, ub])
+
         m = MonotonicRejectionGP(
             lb=lb,
             ub=ub,
             likelihood=GaussianLikelihood(),
             fixed_prior_mean=target,
             monotonic_idxs=[1],
-            num_induc=2,
+            num_induc=inducing_size,
             num_samples=3,
             num_rejection_samples=4,
-            inducing_point_method=AutoAllocator(bounds=torch.stack((lb, ub))),
+            inducing_point_method=AutoAllocator(bounds=bounds),
         )
         strat = Strategy(
             lb=lb,
@@ -53,6 +58,8 @@ class MonotonicRejectionGPLSETest(BotorchTestCase):
                 MonotonicMCLSE,
                 acqf_kwargs={"target": target},
                 model_gen_options=model_gen_options,
+                lb=lb,
+                ub=ub,
             ),
             min_asks=1,
             stimuli_per_trial=1,
@@ -85,18 +92,21 @@ class MonotonicRejectionGPLSETest(BotorchTestCase):
         # Init
         target = 0.75
         model_gen_options = {"num_restarts": 1, "raw_samples": 3, "epochs": 5}
-        lb = torch.tensor([0, 0])
-        ub = torch.tensor([4, 4])
+        lb = torch.tensor([0.0, 0.0])
+        ub = torch.tensor([4.0, 4.0])
+        inducing_size = 2
+        bounds = torch.stack([lb, ub])
+
         m = MonotonicRejectionGP(
             lb=lb,
             ub=ub,
             likelihood=BernoulliLikelihood(),
             fixed_prior_mean=target,
             monotonic_idxs=[1],
-            num_induc=2,
+            num_induc=inducing_size,
             num_samples=3,
             num_rejection_samples=4,
-            inducing_point_method=AutoAllocator(bounds=torch.stack((lb, ub))),
+            inducing_point_method=AutoAllocator(bounds=bounds),
         )
         strat = Strategy(
             lb=lb,
@@ -106,6 +116,8 @@ class MonotonicRejectionGPLSETest(BotorchTestCase):
                 MonotonicMCLSE,
                 acqf_kwargs={"target": target, "objective": ProbitObjective()},
                 model_gen_options=model_gen_options,
+                lb=lb,
+                ub=ub,
             ),
             min_asks=1,
             stimuli_per_trial=1,

--- a/tests/models/test_multitask_regression.py
+++ b/tests/models/test_multitask_regression.py
@@ -19,8 +19,19 @@ if "CI" in os.environ or "SANDCASTLE" in os.environ:
     torch.set_num_threads(1)
 
 models = [
-    (MultitaskGPRModel(num_outputs=2, rank=2, lb=[-1], ub=[3]),),
-    (IndependentMultitaskGPRModel(num_outputs=2, lb=[-1], ub=[3]),),
+    (
+        MultitaskGPRModel(
+            num_outputs=2,
+            rank=2,
+            dim=1,
+        ),
+    ),
+    (
+        IndependentMultitaskGPRModel(
+            num_outputs=2,
+            dim=1,
+        ),
+    ),
 ]
 
 

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -93,8 +93,8 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
         np.random.seed(seed)
         n_init = 20
         n_opt = 1
-        lb = [-4.0, 1e-5]
-        ub = [-1e-5, 4.0]
+        lb = torch.tensor([-4.0, 1e-5])
+        ub = torch.tensor([-1e-5, 4.0])
         extra_acqf_args = {"beta": 3.84}
         model_list = [
             Strategy(
@@ -113,6 +113,8 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
                     acqf=qUpperConfidenceBound,
                     acqf_kwargs=extra_acqf_args,
                     stimuli_per_trial=2,
+                    lb=lb,
+                    ub=ub,
                 ),
                 min_asks=n_opt,
                 stimuli_per_trial=2,
@@ -218,6 +220,8 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
             acqf_kwargs=extra_acqf_args,
             stimuli_per_trial=2,
             transforms=transforms,
+            lb=lb,
+            ub=ub,
         )
         probit_model = ParameterTransformedModel(
             model=PairwiseProbitModel, lb=lb, ub=ub, transforms=transforms
@@ -264,8 +268,8 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
         np.random.seed(seed)
         n_init = 50
         n_opt = 1
-        lb = -2.0
-        ub = 2.0
+        lb = torch.tensor([-2.0])
+        ub = torch.tensor([2.0])
 
         acqf = PairwiseMCPosteriorVariance
         extra_acqf_args = {"objective": ProbitObjective()}
@@ -284,7 +288,11 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
                 ub=ub,
                 model=PairwiseProbitModel(lb=lb, ub=ub),
                 generator=OptimizeAcqfGenerator(
-                    acqf=acqf, acqf_kwargs=extra_acqf_args, stimuli_per_trial=2
+                    acqf=acqf,
+                    acqf_kwargs=extra_acqf_args,
+                    stimuli_per_trial=2,
+                    lb=lb,
+                    ub=ub,
                 ),
                 min_asks=n_opt,
                 stimuli_per_trial=2,
@@ -328,8 +336,8 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
         np.random.seed(seed)
         n_init = 20
         n_opt = 1
-        lb = np.r_[-1, -1]
-        ub = np.r_[1, 1]
+        lb = torch.tensor([-1.0, -1.0])
+        ub = torch.tensor([1.0, 1.0])
         extra_acqf_args = {"beta": 3.84}
 
         model_list = [
@@ -349,6 +357,8 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
                     acqf=qUpperConfidenceBound,
                     acqf_kwargs=extra_acqf_args,
                     stimuli_per_trial=2,
+                    lb=lb,
+                    ub=ub,
                 ),
                 min_asks=n_opt,
                 stimuli_per_trial=2,
@@ -377,8 +387,8 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
         np.random.seed(seed)
         n_init = 20
         n_opt = 1
-        lb = np.r_[-1, -1]
-        ub = np.r_[1, 1]
+        lb = torch.tensor([-1.0, -1.0])
+        ub = torch.tensor([1.0, 1.0])
         acqf = PairwiseMCPosteriorVariance
         extra_acqf_args = {"objective": ProbitObjective()}
 
@@ -396,7 +406,11 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
                 ub=ub,
                 model=PairwiseProbitModel(lb=lb, ub=ub),
                 generator=OptimizeAcqfGenerator(
-                    acqf=acqf, acqf_kwargs=extra_acqf_args, stimuli_per_trial=2
+                    acqf=acqf,
+                    acqf_kwargs=extra_acqf_args,
+                    stimuli_per_trial=2,
+                    lb=lb,
+                    ub=ub,
                 ),
                 min_asks=n_opt,
                 stimuli_per_trial=2,
@@ -454,7 +468,11 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
         m1 = PairwiseProbitModel(lb=[1, 2], ub=[3, 4])
 
         m2 = PairwiseProbitModel.from_config(
-            config=Config(config_dict={"common": {"lb": "[1,2]", "ub": "[3,4]"}})
+            config=Config(
+                config_dict={
+                    "common": {"lb": "[1,2]", "ub": "[3,4]", "parnames": "[par1, par2]"}
+                }
+            )
         )
 
         self.assertTrue(isinstance(m1.covar_module, type(m2.covar_module)))

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -37,14 +37,14 @@ class UtilsTestCase(unittest.TestCase):
         )
         X, y = torch.Tensor(X), torch.Tensor(y)
         inducing_size = 20
+        lb = torch.Tensor([-3])
+        ub = torch.Tensor([3])
+        bounds = torch.stack([lb, ub])
 
         model = GPClassificationModel(
-            torch.Tensor([-3]),
-            torch.Tensor([3]),
+            dim=1,
             inducing_size=inducing_size,
-            inducing_point_method=AutoAllocator(
-                bounds=torch.stack((torch.Tensor([-3]), torch.Tensor([3])))
-            ),
+            inducing_point_method=AutoAllocator(bounds=bounds),
         )
         model.set_train_data(X[:10, ...], y[:10])
 
@@ -52,11 +52,10 @@ class UtilsTestCase(unittest.TestCase):
         self.assertTrue(
             np.allclose(
                 select_inducing_points(
-                    allocator=AutoAllocator(),
+                    allocator=AutoAllocator(bounds=bounds),
                     inducing_size=inducing_size,
                     covar_module=model.covar_module,
                     X=model.train_inputs[0],
-                    bounds=model.bounds,
                 ),
                 X[:10].sort(0).values,
             )
@@ -67,11 +66,10 @@ class UtilsTestCase(unittest.TestCase):
         self.assertTrue(
             len(
                 select_inducing_points(
-                    allocator=AutoAllocator(),
+                    allocator=AutoAllocator(bounds=bounds),
                     inducing_size=inducing_size,
                     covar_module=model.covar_module,
                     X=model.train_inputs[0],
-                    bounds=model.bounds,
                 )
             )
             <= 20
@@ -92,11 +90,10 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(
             len(
                 select_inducing_points(
-                    allocator=KMeansAllocator(),
+                    allocator=KMeansAllocator(bounds=bounds),
                     inducing_size=inducing_size,
                     covar_module=model.covar_module,
                     X=model.train_inputs[0],
-                    bounds=model.bounds,
                 )
             ),
             20,
@@ -108,7 +105,6 @@ class UtilsTestCase(unittest.TestCase):
                     inducing_size=inducing_size,
                     covar_module=model.covar_module,
                     X=model.train_inputs[0],
-                    bounds=model.bounds,
                 )
             )
             <= 20
@@ -122,7 +118,6 @@ class UtilsTestCase(unittest.TestCase):
                     inducing_size=inducing_size,
                     covar_module=model.covar_module,
                     X=model.train_inputs[0],
-                    bounds=model.bounds,
                 )
             )
             <= 20
@@ -136,7 +131,6 @@ class UtilsTestCase(unittest.TestCase):
                     inducing_size=inducing_size,
                     covar_module=model.covar_module,
                     X=model.train_inputs[0],
-                    bounds=model.bounds,
                 )
             )
             <= 20
@@ -148,7 +142,6 @@ class UtilsTestCase(unittest.TestCase):
                     inducing_size=inducing_size,
                     covar_module=model.covar_module,
                     X=model.train_inputs[0],
-                    bounds=model.bounds,
                 )
             )
             <= 20

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -23,7 +23,6 @@ from aepsych.benchmark import (
 from aepsych.models import GPClassificationModel
 
 from aepsych.models.inducing_point_allocators import AutoAllocator
-from scipy.stats import norm
 
 torch.set_num_threads(1)
 torch.set_num_interop_threads(1)
@@ -74,9 +73,9 @@ class MultipleLSETestCase(unittest.TestCase):
         self.n_thresholds = 5
         self.thresholds = torch.linspace(0.55, 0.95, self.n_thresholds)
         self.test_problem = example_problems.DiscrimLowDim(thresholds=self.thresholds)
+
         self.model = GPClassificationModel(
-            lb=self.test_problem.lb,
-            ub=self.test_problem.ub,
+            dim=2,
             inducing_point_method=AutoAllocator(bounds=self.test_problem.bounds),
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,18 +126,17 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(torch.all(strat.strat_list[0].lb == strat.strat_list[1].lb))
         self.assertTrue(
             torch.all(
-                strat.transforms.untransform(strat.strat_list[1].model.lb)
+                strat.transforms.untransform(strat.strat_list[1].generator.lb)
                 == torch.Tensor([1, -1])
             )
         )
         self.assertTrue(torch.all(strat.strat_list[0].ub == strat.strat_list[1].ub))
         self.assertTrue(
             torch.all(
-                strat.transforms.untransform(strat.strat_list[1].model.ub)
+                strat.transforms.untransform(strat.strat_list[1].generator.ub)
                 == torch.Tensor([10, 1])
             )
         )
-
         self.assertEqual(strat.strat_list[0].min_total_outcome_occurrences, 5)
         self.assertEqual(strat.strat_list[0].min_post_range, None)
         self.assertEqual(strat.strat_list[0].keep_most_recent, None)
@@ -171,7 +170,8 @@ class ConfigTestCase(unittest.TestCase):
         )
         self.assertTrue(strat.strat_list[1].generator.acqf is EAVC)
         self.assertTrue(
-            set(strat.strat_list[1].generator.acqf_kwargs.keys()) == {"target"}
+            set(strat.strat_list[1].generator.acqf_kwargs.keys())
+            == {"lb", "ub", "target"}
         )
         self.assertTrue(strat.strat_list[1].generator.acqf_kwargs["target"] == 0.75)
         self.assertTrue(strat.strat_list[1].generator.samps == 1000)
@@ -180,9 +180,13 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(strat.strat_list[0].outcome_types == ["binary"])
         self.assertTrue(strat.strat_list[1].min_asks == 20)
         self.assertTrue(torch.all(strat.strat_list[0].lb == strat.strat_list[1].lb))
-        self.assertTrue(torch.all(strat.strat_list[1].model.lb == torch.Tensor([0, 0])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.lb == torch.Tensor([0, 0]))
+        )
         self.assertTrue(torch.all(strat.strat_list[0].ub == strat.strat_list[1].ub))
-        self.assertTrue(torch.all(strat.strat_list[1].model.ub == torch.Tensor([1, 1])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.ub == torch.Tensor([1, 1]))
+        )
 
     def test_nonmonotonic_optimization_config_file(self):
         config_file = "../configs/nonmonotonic_optimization_example.ini"
@@ -216,9 +220,13 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(strat.strat_list[0].outcome_types == ["binary"])
         self.assertTrue(strat.strat_list[1].min_asks == 20)
         self.assertTrue(torch.all(strat.strat_list[0].lb == strat.strat_list[1].lb))
-        self.assertTrue(torch.all(strat.strat_list[1].model.lb == torch.Tensor([0, 0])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.lb == torch.Tensor([0, 0]))
+        )
         self.assertTrue(torch.all(strat.strat_list[0].ub == strat.strat_list[1].ub))
-        self.assertTrue(torch.all(strat.strat_list[1].model.ub == torch.Tensor([1, 1])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.ub == torch.Tensor([1, 1]))
+        )
 
     def test_name_conflict_warns(self):
         class DummyMod:
@@ -519,9 +527,13 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(strat.strat_list[0].outcome_types == ["binary"])
         self.assertTrue(strat.strat_list[1].min_asks == 20)
         self.assertTrue(torch.all(strat.strat_list[0].lb == strat.strat_list[1].lb))
-        self.assertTrue(torch.all(strat.strat_list[1].model.lb == torch.Tensor([0, 0])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.lb == torch.Tensor([0, 0]))
+        )
         self.assertTrue(torch.all(strat.strat_list[0].ub == strat.strat_list[1].ub))
-        self.assertTrue(torch.all(strat.strat_list[1].model.ub == torch.Tensor([1, 1])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.ub == torch.Tensor([1, 1]))
+        )
 
     def test_pairwise_probit_config_file(self):
         config_file = "../configs/pairwise_al_example.ini"
@@ -557,9 +569,13 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(strat.strat_list[0].outcome_types == ["binary"])
         self.assertTrue(strat.strat_list[1].min_asks == 20)
         self.assertTrue(torch.all(strat.strat_list[0].lb == strat.strat_list[1].lb))
-        self.assertTrue(torch.all(strat.strat_list[1].model.lb == torch.Tensor([0, 0])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.lb == torch.Tensor([0, 0]))
+        )
         self.assertTrue(torch.all(strat.strat_list[0].ub == strat.strat_list[1].ub))
-        self.assertTrue(torch.all(strat.strat_list[1].model.ub == torch.Tensor([1, 1])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.ub == torch.Tensor([1, 1]))
+        )
 
     def test_pairwise_al_config_file(self):
         # random datebase path name without dashes
@@ -598,9 +614,13 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(strat.strat_list[0].outcome_types == ["binary"])
         self.assertTrue(strat.strat_list[1].min_asks == 20)
         self.assertTrue(torch.all(strat.strat_list[0].lb == strat.strat_list[1].lb))
-        self.assertTrue(torch.all(strat.strat_list[1].model.lb == torch.Tensor([0, 0])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.lb == torch.Tensor([0, 0]))
+        )
         self.assertTrue(torch.all(strat.strat_list[0].ub == strat.strat_list[1].ub))
-        self.assertTrue(torch.all(strat.strat_list[1].model.ub == torch.Tensor([1, 1])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.ub == torch.Tensor([1, 1]))
+        )
         # cleanup the db
         if server.db is not None:
             server.db.delete_db()
@@ -640,9 +660,13 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(strat.strat_list[0].outcome_types == ["binary"])
         self.assertTrue(strat.strat_list[1].min_asks == 20)
         self.assertTrue(torch.all(strat.strat_list[0].lb == strat.strat_list[1].lb))
-        self.assertTrue(torch.all(strat.strat_list[1].model.lb == torch.Tensor([0, 0])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.lb == torch.Tensor([0, 0]))
+        )
         self.assertTrue(torch.all(strat.strat_list[0].ub == strat.strat_list[1].ub))
-        self.assertTrue(torch.all(strat.strat_list[1].model.ub == torch.Tensor([1, 1])))
+        self.assertTrue(
+            torch.all(strat.strat_list[1].generator.ub == torch.Tensor([1, 1]))
+        )
         # cleanup the db
         if server.db is not None:
             server.db.delete_db()
@@ -896,6 +920,7 @@ class ConfigTestCase(unittest.TestCase):
             [init_strat]
             generator = SobolGenerator
             model = GPRegressionModel
+            inducing_point_method = AutoAllocator
             """
         config3 = Config()
         config3.update(config_str=config_str3)
@@ -1024,11 +1049,11 @@ class ConfigTestCase(unittest.TestCase):
         strat = SequentialStrategy.from_config(config)
         opt_strat = strat.strat_list[1]
         model = opt_strat.model
+        generator = opt_strat.generator
 
         self.assertTrue(isinstance(model, HadamardSemiPModel))
-        self.assertTrue(torch.all(model.lb == torch.Tensor([0, 0])))
-        self.assertTrue(torch.all(model.ub == torch.Tensor([1, 1])))
-        self.assertTrue(model.dim == 2)
+        self.assertTrue(torch.all(generator.lb == torch.Tensor([0, 0])))
+        self.assertTrue(torch.all(generator.ub == torch.Tensor([1, 1])))
         self.assertTrue(model.inducing_size == 10)
         self.assertTrue(model.stim_dim == 1)
 
@@ -1079,10 +1104,9 @@ class ConfigTestCase(unittest.TestCase):
 
         strat = SequentialStrategy.from_config(config)
         opt_strat = strat.strat_list[1]
-        model = opt_strat.model
 
-        self.assertTrue(torch.all(model.lb == torch.Tensor([0, -10])))
-        self.assertTrue(torch.all(model.ub == torch.Tensor([1, 10])))
+        self.assertTrue(torch.all(opt_strat.lb == torch.Tensor([0, -10])))
+        self.assertTrue(torch.all(opt_strat.ub == torch.Tensor([1, 10])))
 
     def test_ignore_common_bounds(self):
         config_str = """
@@ -1123,10 +1147,9 @@ class ConfigTestCase(unittest.TestCase):
 
         strat = SequentialStrategy.from_config(config)
         opt_strat = strat.strat_list[1]
-        model = opt_strat.model
 
-        self.assertTrue(torch.all(model.lb == torch.Tensor([0, -5])))
-        self.assertTrue(torch.all(model.ub == torch.Tensor([1, 1])))
+        self.assertTrue(torch.all(opt_strat.lb == torch.Tensor([0, -5])))
+        self.assertTrue(torch.all(opt_strat.ub == torch.Tensor([1, 1])))
 
     def test_common_fallback_bounds(self):
         config_str = """
@@ -1167,10 +1190,9 @@ class ConfigTestCase(unittest.TestCase):
 
         strat = SequentialStrategy.from_config(config)
         opt_strat = strat.strat_list[1]
-        model = opt_strat.model
 
-        self.assertTrue(torch.all(model.lb == torch.Tensor([0, 0])))
-        self.assertTrue(torch.all(model.ub == torch.Tensor([1, 100])))
+        self.assertTrue(torch.all(opt_strat.lb == torch.Tensor([0, 0])))
+        self.assertTrue(torch.all(opt_strat.ub == torch.Tensor([1, 100])))
 
     def test_parameter_setting_block_validation(self):
         config_str = """

--- a/tests/test_points_allocators.py
+++ b/tests/test_points_allocators.py
@@ -76,8 +76,13 @@ class TestInducingPointAllocators(unittest.TestCase):
         config.update(config_str=config_str)
         allocator = AutoAllocator.from_config(config)
 
-        # Check if fallback allocator is an instance of SobolAllocator with correct bounds
+        # Check if fallback allocator is an instance of KMeansAllocator with correct bounds
         self.assertTrue(isinstance(allocator.fallback_allocator, KMeansAllocator))
+
+        expected_bounds = torch.tensor([[0.0], [1.0]])
+        self.assertTrue(
+            torch.equal(allocator.fallback_allocator.bounds, expected_bounds)
+        )
 
     def test_sobol_allocator_allocate_inducing_points(self):
         bounds = torch.tensor([[0.0], [1.0]])
@@ -130,8 +135,7 @@ class TestInducingPointAllocators(unittest.TestCase):
         ub = torch.tensor([4, 4])
         bounds = torch.stack([lb, ub])
         model = GPClassificationModel(
-            lb=lb,
-            ub=ub,
+            dim=2,
             inducing_point_method=AutoAllocator(bounds=bounds),
             inducing_size=3,
         )
@@ -516,8 +520,7 @@ class TestGreedyAllocators(unittest.TestCase):
         ub = torch.tensor([1])
         bounds = torch.stack([lb, ub])
         model = GPClassificationModel(
-            lb=lb,
-            ub=ub,
+            dim=1,
             inducing_point_method=GreedyVarianceReduction(bounds=bounds),
             inducing_size=10,
         )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -69,8 +69,8 @@ class TransformsConfigTest(unittest.TestCase):
 
         class_gen = ParameterTransformedGenerator(
             generator=SobolGenerator,
-            lb=torch.tensor([1, 1]),
-            ub=torch.tensor([100, 100]),
+            lb=torch.tensor([1.0, 1.0]),
+            ub=torch.tensor([100.0, 100.0]),
             seed=12345,
             transforms=self.strat.strat_list[0].transforms,
         )
@@ -89,21 +89,26 @@ class TransformsConfigTest(unittest.TestCase):
 
     def test_model_init_equivalent(self):
         config_model = self.strat.strat_list[1].model
+        config_generator = self.strat.strat_list[1].generator
 
         obj_model = ParameterTransformedModel(
             model=GPClassificationModel,
-            lb=torch.tensor([1, 1]),
-            ub=torch.tensor([100, 100]),
             inducing_point_method=AutoAllocator(
                 bounds=torch.stack((torch.tensor([1, 1]), torch.tensor([100, 100])))
             ),
             transforms=self.strat.strat_list[1].transforms,
+            dim=2,
+        )
+        obj_generator = ParameterTransformedGenerator(
+            generator=SobolGenerator,
+            lb=torch.tensor([1.0, 1.0]),
+            ub=torch.tensor([100.0, 100.0]),
+            transforms=self.strat.strat_list[1].transforms,
         )
 
         self.assertTrue(type(config_model._base_obj) is type(obj_model._base_obj))
-        self.assertTrue(torch.equal(config_model.bounds, obj_model.bounds))
-        self.assertTrue(torch.equal(config_model.bounds, obj_model.bounds))
-
+        self.assertTrue(torch.equal(config_generator.lb, obj_generator.lb))
+        self.assertTrue(torch.equal(config_generator.ub, obj_generator.ub))
         self.assertEqual(
             len(config_model.transforms.values()), len(obj_model.transforms.values())
         )
@@ -209,8 +214,8 @@ class TransformsConfigTest(unittest.TestCase):
 
 class TransformsLog10Test(unittest.TestCase):
     def test_transform_reshape3D(self):
-        lb = torch.tensor([-1, 0, 10])
-        ub = torch.tensor([-1e-6, 9, 99])
+        lb = torch.tensor([-1.0, 0.0, 10.0])
+        ub = torch.tensor([-1e-6, 9.0, 99.0])
         x = SobolGenerator(lb=lb, ub=ub, stimuli_per_trial=2).gen(4)
 
         transforms = ParameterTransforms(
@@ -583,6 +588,7 @@ class TransformsFixed(unittest.TestCase):
 
         self.assertTrue(len(strat.strat_list[0].generator.lb) == 2)
         self.assertTrue(len(strat.strat_list[0].generator.ub) == 2)
+        self.assertTrue(strat.strat_list[-1].model.dim == 2)
 
         bad_config_str = """
             [common]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,14 +33,14 @@ class UtilsTestCase(unittest.TestCase):
         dim = 1
         gridsize = 10
         mb = GPClassificationModel(
-            lb=lb,
-            ub=ub,
-            dim=dim,
+            dim=1,
             inducing_point_method=AutoAllocator(
                 bounds=torch.stack([torch.tensor([lb]), torch.tensor([ub])])
             ),
         )
-        grid = GPClassificationModel.dim_grid(mb, gridsize=gridsize)
+        grid = dim_grid(
+            lower=torch.tensor([lb]), upper=torch.tensor([ub]), gridsize=gridsize
+        )
         self.assertEqual(grid.shape, torch.Size([10, 1]))
 
     def test_dim_grid_slice(self):

--- a/tests_gpu/generators/test_optimize_acqf_generator.py
+++ b/tests_gpu/generators/test_optimize_acqf_generator.py
@@ -49,16 +49,23 @@ acqfs = [
 class TestOptimizeAcqfGenerator(unittest.TestCase):
     @parameterized.expand(acqfs)
     def test_gpu_smoketest(self, acqf, acqf_kwargs):
-        lb = torch.tensor([0])
-        ub = torch.tensor([1])
+        lb = torch.tensor([0.0])
+        ub = torch.tensor([1.0])
+        bounds = torch.stack([lb, ub])
+        inducing_size = 10
+
         model = GPClassificationModel(
-            lb=lb,
-            ub=ub,
-            inducing_size=10,
-            inducing_point_method=GreedyVarianceReduction(bounds=torch.stack([lb, ub])),
+            dim=1,
+            inducing_size=inducing_size,
+            inducing_point_method=GreedyVarianceReduction(bounds=bounds),
         )
 
-        generator = OptimizeAcqfGenerator(acqf=acqf, acqf_kwargs=acqf_kwargs)
+        generator = OptimizeAcqfGenerator(
+            acqf=acqf,
+            acqf_kwargs=acqf_kwargs,
+            lb=torch.tensor([0.0]),
+            ub=torch.tensor([1.0]),
+        )
 
         strat = Strategy(
             lb=torch.tensor([0]),

--- a/tests_gpu/models/test_gp_classification.py
+++ b/tests_gpu/models/test_gp_classification.py
@@ -19,6 +19,7 @@ if "CI" in os.environ or "SANDCASTLE" in os.environ:
 import numpy as np
 import numpy.testing as npt
 from aepsych.models import GPClassificationModel
+from aepsych.models.inducing_point_allocators import SobolAllocator
 from scipy.stats import norm
 from sklearn.datasets import make_classification
 
@@ -107,14 +108,13 @@ class GPClassificationSmoketest(unittest.TestCase):
         Just see if we memorize the training set but on gpu
         """
         X, y = self.X, self.y
+        inducing_size = 10
+        bounds = torch.stack([torch.tensor([-3.0]), torch.tensor([3.0])])
 
         model = GPClassificationModel(
-            torch.Tensor([-3]),
-            torch.Tensor([3]),
-            inducing_size=10,
-            inducing_point_method=SobolAllocator(
-                bounds=torch.stack([torch.tensor([-3]), torch.tensor([3])])
-            ),
+            dim=1,
+            inducing_size=inducing_size,
+            inducing_point_method=SobolAllocator(bounds=bounds),
         ).to("cuda")
 
         model.fit(X[:50], y[:50])

--- a/tests_gpu/models/test_gp_regression.py
+++ b/tests_gpu/models/test_gp_regression.py
@@ -57,6 +57,7 @@ class GPRegressionTest(unittest.TestCase):
             [GPRegressionModel]
             likelihood = GaussianLikelihood
             max_fit_time = 1
+            inducing_point_method = AutoAllocator
         """
         self.server = AEPsychServer(database_path=dbname)
         configure(self.server, config_str=config)

--- a/tests_gpu/test_strategy.py
+++ b/tests_gpu/test_strategy.py
@@ -8,7 +8,6 @@
 import unittest
 
 import torch
-
 from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
 from aepsych.generators import OptimizeAcqfGenerator, SobolGenerator
 from aepsych.models.gp_classification import GPClassificationModel
@@ -20,8 +19,8 @@ class TestStrategyGPU(unittest.TestCase):
     def test_gpu_no_model_generator_warn(self):
         with self.assertWarns(UserWarning):
             Strategy(
-                lb=[0],
-                ub=[1],
+                lb=[0.0],
+                ub=[1.0],
                 stimuli_per_trial=1,
                 outcome_types=["binary"],
                 min_asks=1,
@@ -32,19 +31,18 @@ class TestStrategyGPU(unittest.TestCase):
     def test_no_gpu_acqf(self):
         with self.assertWarns(UserWarning):
             Strategy(
-                lb=[0],
-                ub=[1],
+                lb=[0.0],
+                ub=[1.0],
                 stimuli_per_trial=1,
                 outcome_types=["binary"],
                 min_asks=1,
                 model=GPClassificationModel(
-                    lb=[0],
-                    ub=[1],
+                    dim=1,
                     inducing_point_method=AutoAllocator(
                         bounds=torch.stack([torch.tensor([0]), torch.tensor([1])])
                     ),
                 ),
-                generator=OptimizeAcqfGenerator(acqf=MonotonicMCLSE),
+                generator=OptimizeAcqfGenerator(acqf=MonotonicMCLSE, lb=[0], ub=[1]),
                 use_gpu_generating=True,
             )
 


### PR DESCRIPTION
Summary:
#### PR Description:
This PR builds upon the changes introduced in https://github.com/facebookresearch/aepsych/issues/467 by fully removing the usage of lower and upper bounds within all models.

## Key updates include:

- **Removal of Bounds and Dimension from Models:**
  All `lb`, `ub`, and `dim` parameters have been fully removed from all models. The responsibility for computing inducing points is now entirely managed by allocators, ensuring a cleaner and more modular design.

- **Dependency Shift to Allocators:**
  All model dependencies on dimensions (e.g., for computing the `covar_module`) are now managed through the `dim` property of the allocator object. This centralizes the handling of bounds and dimensions in the allocator system.

- **Updated Allocators Functionality:**
  Allocators like `AutoAllocator` and `KMeansAllocator` now optionally take bounds. Bounds are essential in scenarios where no input data is provided, as they ensure fallback to the `DummyAllocator` (e.g., during initialization from configuration).

- **Tests:**
  - All tests have been updated to make use of the allocator object as a requirement.
  - Most tests pass bounds to the allocator, while others initialize bounds via configuration.
  - Tests now fully align with the updated model-allocator interaction and function as expected.

Let me know if any changes are needed! :)


Differential Revision: D66968212

Pulled By: JasonKChow
