### PR TITLE
Warm start a stratey based on config provided seed conditions

### DIFF
--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -149,16 +149,14 @@ class Config(configparser.ConfigParser):
                 _dict[section][setting] = self[section][setting]
         return _dict
 
-    # Turn the metadata section into JSON.
-    def jsonifyMetadata(self, only_extra: bool = False) -> str:
-        """Return a json string of the metadata section.
+    def get_metadata(self, only_extra: bool = False) -> Dict[Any, Any]:
+        """Return a dictionary of the metadata section.
 
         Args:
-            only_extra (bool): Only jsonify the extra meta data.
+            only_extra (bool, optional): Only gather the extra metadata. Defaults to False.
 
         Returns:
-            str: A json string representing the metadata dictionary or an empty string
-                if there is no metadata to return.
+            Dict[Any, Any]: a collection of the metadata stored in this conig.
         """
         configdict = self.to_dict()
         metadata = configdict["metadata"].copy()
@@ -173,6 +171,20 @@ class Config(configparser.ConfigParser):
             for name in default_metadata:
                 metadata.pop(name, None)
 
+        return metadata
+
+    # Turn the metadata section into JSON.
+    def jsonifyMetadata(self, only_extra: bool = False) -> str:
+        """Return a json string of the metadata section.
+
+        Args:
+            only_extra (bool): Only jsonify the extra meta data.
+
+        Returns:
+            str: A json string representing the metadata dictionary or an empty string
+                if there is no metadata to return.
+        """
+        metadata = self.get_metadata(only_extra)
         if len(metadata.keys()) == 0:
             return ""
         else:

--- a/aepsych/database/data_fetcher.py
+++ b/aepsych/database/data_fetcher.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import torch
+
+from aepsych.config import Config, ConfigurableMixin
+from aepsych.database.tables import DBMasterTable
+from aepsych.strategy import Strategy
+from aepsych.utils import generate_default_outcome_names
+from aepsych.utils_logging import getLogger
+
+logger = getLogger()
+
+# !!!!!! WARNING !!!!!
+#
+# If you modify the parameter order in the query in _get_data ensure you update these to match!
+# The order in which you place the parameters in a sql query dictates the placement in the results
+# array.
+#
+# For example:
+# select iteration_id, param_name, param_val, outcome_id results in this list:
+#   [iteration_id, param_name, param_val, outcome_id]
+#
+# !!!!!! WARNING !!!!!
+# "const" variable identifiers to avoid magic number indexing into the query results
+
+ITERATION_ID = 0
+PARAM_NAME_ID = 1
+PARAM_VAL_ID = 2
+OUTCOME_ID = 3
+
+
+class DataFetcher(ConfigurableMixin):
+    def __init__(
+        self,
+        exp_names: Optional[List[str]] = None,
+        exp_desc: Optional[List[str]] = None,
+        exp_ids: Optional[List[str]] = None,
+        par_ids: Optional[List[str]] = None,
+        ex_data: Optional[Dict[str, str]] = None,
+        **kwargs,
+    ):
+        """Initialize the DataFetcher object.
+
+        Args:
+            exp_names (List[str], optional): A list of experiment names to use as a filter on warm start data.
+            exp_desc (List[str], optional): A list of experiment descriptions to use as a filter on warm start data.
+            exp_ids (List[str], optional): A list of experiment ids to use as a filter on warm start data.
+            par_ids (List[str], optional): A list of participant ids to use as a filter on warm start data.
+            ex_data (Dict[str, str], optional): A map of key-value pairs to use as a filter on warm start data.
+        """
+        self.experiment_names: Optional[List[str]] = exp_names
+        self.experiment_desc: Optional[List[str]] = exp_desc
+        self.experiment_ids: Optional[List[str]] = exp_ids
+        self.participant_ids: Optional[List[str]] = par_ids
+        self.extra_metadata: Optional[Dict[str, str]] = ex_data
+
+    @property
+    def _has_search_criteria(self) -> bool:
+        """Checks to see if the search criteria necessary for warm starting a strategy exists.
+
+        Returns:
+            bool: are any filter critera set.
+        """
+        return (
+            self.experiment_ids is not None
+            or self.experiment_names is not None
+            or self.experiment_desc is not None
+            or self.participant_ids is not None
+            or self.extra_metadata is not None
+        )
+
+    def _build_query(self) -> str:
+        query_clauses: List[str] = []
+        if self.experiment_names is not None:
+            query_clauses.append(
+                f"experiment_name in {_print_in_params(self.experiment_names)}"
+            )
+        if self.experiment_ids is not None:
+            query_clauses.append(
+                f"experiment_id in {_print_in_params(self.experiment_ids)}"
+            )
+        if self.experiment_desc is not None:
+            query_clauses.append(
+                f"experiment_description in {_print_in_params(self.experiment_desc)}"
+            )
+        if self.participant_ids is not None:
+            query_clauses.append(
+                f"participant_id in {_print_in_params(self.participant_ids)}"
+            )
+        if self.extra_metadata is not None:
+            query_clauses.append(
+                f"{_print_like_params('extra_metadata', self.extra_metadata)}"
+            )
+        query = "select unique_id from master where "
+        for i, clause in enumerate(query_clauses):
+            query += clause
+            if i < len(query_clauses) - 1:
+                query += " and "
+        return query
+
+    def _are_stimuli_valid(self, server, config: Config, id: int) -> bool:
+        pickeld_stimuli_per_trial = config.get(
+            "common", "stimuli_per_trial", fallback=-1
+        )
+        active_stimuli_per_trial = server.config.get(
+            "common", "stimuli_per_trial", fallback=0
+        )
+
+        if pickeld_stimuli_per_trial != active_stimuli_per_trial:
+            _print_warning(
+                self,
+                server.db.get_master_record(id),
+                f"Data with master id: {id} was matched with {{0}} but is invalid because it has "
+                + f"{pickeld_stimuli_per_trial} stimuli and the current experiment has {active_stimuli_per_trial} stimuli. "
+                + "Skipping this entry.",
+            )
+
+            return False  # trial stimuli don't match this isn't valid data
+        return True
+
+    def _are_parameters_valid(self, server, config: Config, id: int) -> bool:
+        param_names = set(config.getlist("common", "parnames", element_type=str))
+        if len(param_names.intersection(set(server.parnames))) == len(server.parnames):
+            match = True
+            for param in param_names:
+                match = config[param]["par_type"] == server.config[param]["par_type"]
+                if not match:
+                    break
+                if config[param]["par_type"] == "continuous":
+                    pickled_lb = config[param]["lower_bound"]
+                    pickled_ub = config[param]["upper_bound"]
+
+                    active_lb = server.config[param]["lower_bound"]
+                    active_ub = server.config[param]["upper_bound"]
+                    if pickled_lb != active_lb or pickled_ub != active_ub:
+                        _print_warning(
+                            self,
+                            server.db.get_master_record(id),
+                            f"Data with master id: {id} was matched with {{0}} but its parameter {param} "
+                            + f"has bounds ({pickled_lb}, {pickled_ub}) compared to the active bounds "
+                            + f"({active_lb}, {active_ub}).",
+                        )
+            if not match:
+                _print_warning(
+                    self,
+                    server.db.get_master_record(id),
+                    f"Data with master id: {id} was matched with {{0}} but is invalid due to parameter "
+                    + f"{param} having the type {config[param]['par_type']} while its active type "
+                    + f"is {server.config[param]['par_type']}. Skipping this entry.",
+                )
+                return False  # param types don't match this isn't valid data
+        else:
+            _print_warning(
+                self,
+                server.db.get_master_record(id),
+                f"Data with master id: {id} was matched with {{0}} but is invalid due to "
+                + "a mismatch of parameter names. Skipping this entry.",
+            )
+            return False  # param names don't match this isn't valid data
+        return True
+
+    def _are_outcomes_valid(self, server, config: Config, id: int) -> bool:
+        pickled_outcome_types = config.getlist(
+            "common", "outcome_types", element_type=str
+        )
+        active_outcome_types = server.config.getlist(
+            "common", "outcome_types", element_type=str
+        )
+
+        # this doesn't ensure order i.e. the types may match but could be applied to different outcomes
+
+        outcome_types_match = len(pickled_outcome_types) == len(active_outcome_types)
+        for i, outcome_type in enumerate(pickled_outcome_types):
+            if not outcome_types_match:
+                break
+            if outcome_type != active_outcome_types[i]:
+                outcome_types_match = False
+        if outcome_types_match:
+            pickled_outcome_names = set(
+                config.getlist(
+                    "common",
+                    "outcome_names",
+                    element_type=str,
+                    fallback=generate_default_outcome_names(len(pickled_outcome_types)),
+                )
+            )
+
+            active_outcome_names = set(
+                server.config.getlist(
+                    "common",
+                    "outcome_names",
+                    element_type=str,
+                    fallback=generate_default_outcome_names(len(active_outcome_types)),
+                )
+            )
+
+            if len(pickled_outcome_names.intersection(active_outcome_names)) != len(
+                active_outcome_names
+            ):
+                _print_warning(
+                    self,
+                    server.db.get_master_record(id),
+                    f"Data with master id: {id} was matched with {{0}} but is invalid due to "
+                    + "a mismatch in outcome names. Skipping this entry.",
+                )
+                return False  # outcome types donot match this isn't valid data
+        else:
+            _print_warning(
+                self,
+                server.db.get_master_record(id),
+                f"Data with master id: {id} was matched with {{0}} but is invalid due to "
+                + "a mismatch in outcome types. Skipping this entry.",
+            )
+            return False  # outcome names dont match this isn't valid data
+        return True
+
+    def _is_ex_metadata_match_valid(self, config: Config) -> bool:
+        if not self.extra_metadata:
+            return True
+        pickled_ex_data = config.get_metadata(only_extra=True)
+        if len(pickled_ex_data) == 0:
+            return True
+        potential_matches = pickled_ex_data.keys() & self.extra_metadata.keys()
+        for key in potential_matches:
+            if pickled_ex_data[key] == self.extra_metadata[key] or (
+                isinstance(self.extra_metadata[key], Iterable)
+                and pickled_ex_data[key] in self.extra_metadata[key]
+            ):
+                return True
+        # don't warn about skipping this data since it was part of the initial filter criteria and
+        # we don't warn about any of that filtering.
+
+        return False
+
+    def _get_valid_data_ids(self, server) -> List[int]:
+        """Gets all master table ids associated with the data defined by provided search criteria.
+           The data is then filtered by the current strategy's properties to see if it would be valid for use.
+
+        Args:
+            server (AEPsychServer): the instance of the server.
+
+        Returns:
+            List[int]: a list of master table ids that meet all criteria to be valid for use in the current strategy.
+        """
+        valid_match_ids = []
+        query = self._build_query()
+        potential_match_ids = server.db.execute_sql_query(query, None)
+
+        for id in potential_match_ids:
+            config: Config = server.db.get_config_for(id[0])
+
+            # ensure that any data matched on metadata keys actually have matching values in their configs.
+
+            if not self._is_ex_metadata_match_valid(config):
+                continue
+            # check that stimuli_per_trial match between current + pickled config
+
+            if not self._are_stimuli_valid(server, config, id[0]):
+                continue
+            # check param names + types match between current + pickeld config
+
+            if not self._are_parameters_valid(server, config, id[0]):
+                continue
+            # check outcome names + types match between current + pickled config
+
+            if not self._are_outcomes_valid(server, config, id[0]):
+                continue
+            # we found a valid match keep a record of it
+
+            valid_match_ids.append(id[0])
+        return valid_match_ids
+
+    def _construct_data_query(self, ids: List[int]) -> str:
+        # !!!!!! WARNING !!!!!
+        # If you modify the parameter order in the query
+        # ensure you update the "const" id values to match!
+        #
+        # see comment at line 45
+        # !!!!!! WARNING !!!!!
+
+        return f"""select param_data.iteration_id, param_data.param_name,
+                param_data.param_value, outcome_data.outcome_value from param_data
+                inner join outcome_data on param_data.iteration_id = outcome_data.iteration_id
+                inner join raw_data on param_data.iteration_id = raw_data.unique_id
+                inner join master on raw_data.master_table_id = master.unique_id
+                where master.unique_id in {_print_in_params(ids)}"""
+
+    def _get_data(self, server, ids: List[int]) -> List[Tuple[Any]]:
+        """Gets the actual data to be fed into the strategy's tensors.
+
+        Args:
+            server (AEPsychServer): The instance of the server.
+            ids (List[int]): A list of master table ids used to identify and retrive experiment data.
+
+        Returns:
+            results (List[Tuple[Any]]): a list of all data to be fed into the strategy's tensors.
+        """
+        query = self._construct_data_query(ids)
+        results = server.db.execute_sql_query(query, None)
+        return results if results is not None else []
+
+    def warm_start_strat(self, server, strat: Strategy):
+        """Warm start the current strategy with data from previous experiments.
+
+        Args:
+            server (AEPsychServer): The instance of the server
+            strat (Strategy): The strategy to warm start.
+        """
+        if not self._has_search_criteria:
+            return  # no data to process
+        valid_match_ids = self._get_valid_data_ids(server)
+        data = self._get_data(server, valid_match_ids)
+
+        # since we append param names with _stimuli + n when writing the record to the database
+        # we need to parse the param name to ensure it will match the names stored in server.parname
+        # otherwise server._config_to_tensor will fail.
+
+        def trim_param_name(name: str) -> str:
+            end = name.rfind("_stimuli")
+            if end == -1:
+                end = None
+            return name[0:end]
+
+        i = 0
+        fetch_count = 0
+        while i < len(data):
+            # recreate the config dictionary ensuring that all related stimuli are grouped
+            # together. This way we can ensure they're being fed into the model correctly.
+
+            config = {
+                trim_param_name(data[i][PARAM_NAME_ID]): float(data[i][PARAM_VAL_ID])
+            }
+            outcome = torch.tensor(data[i][OUTCOME_ID], dtype=torch.float64)
+
+            # while the parameters iteration id matches keep adding data to the dictionary
+            # we can do this since all data is pre-sorted by iteration when fed into the database
+            # and maintains that sorting when pulled from it.
+
+            j = 1
+            while (
+                i + j < len(data) and data[i][ITERATION_ID] == data[i + j][ITERATION_ID]
+            ):
+                config[trim_param_name(data[i + j][PARAM_NAME_ID])] = float(
+                    data[i + j][PARAM_VAL_ID]
+                )
+                j += 1
+
+            i += j
+            x = server._config_to_tensor(config)
+
+            # only use data to warm model if it is still defined after passing it through
+            # the strategy's transforms.
+
+            res = strat.transforms.transform(x)
+            if not (res.isinf().any() or res.isnan().any()):
+                fetch_count += 1
+                strat.pre_warm_model(x, outcome)
+        if len(data) - fetch_count > 0:
+            logger.warning(
+                f"""{len(data) - fetch_count} rows of data had parameters that were undefined in the bounds 
+                of the current experiment, discarding."""
+            )
+        logger.info(
+            f"Strategy {strat.name} was warm started with {fetch_count} rows of data."
+        )
+
+    @classmethod
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Populate an instance of DataFetcher with search criteria provided in the experiment's config.
+
+        Args:
+            config (Config): Config to look for options in.
+            name (str, optional): The name of the strategy to warm start (Not actually optional here.)
+            options (Dict[str, Any], optional): options are ignored.
+
+        Raises:
+            ValueError: the name of the strategy is necessary to identify warm start search criteria.
+            KeyError: the config specified this strategy should be warm started but the associated config section wasn't defined.
+
+        Returns:
+            Dict[str, Any]: a dictionary of the search criteria described in the experiment's config
+        """
+        if name is None:
+            raise ValueError("name of strategy must be set to warm start strategy.")
+        if not config.has_option(name, "seed_data_conditions"):
+            return {
+                "exp_names": None,
+                "exp_ids": None,
+                "exp_desc": None,
+                "par_ids": None,
+                "ex_data": None,
+            }
+        experiment_names = None
+        experiment_ids = None
+        experiment_descriptions = None
+        participant_ids = None
+        extra_metadata = None
+
+        seed_conds_name = config.get(name, "seed_data_conditions")
+        if config.has_section(seed_conds_name):
+            seed_conds_data = config.to_dict()[seed_conds_name].copy()
+            if "experiment_name" in seed_conds_data:
+                experiment_names = config.getlist(
+                    seed_conds_name, "experiment_name", element_type=str
+                )
+                seed_conds_data.pop("experiment_name", None)
+            if "experiment_id" in seed_conds_data:
+                experiment_ids = config.getlist(
+                    seed_conds_name, "experiment_id", element_type=str
+                )
+                seed_conds_data.pop("experiment_id", None)
+            if "experiment_description" in seed_conds_data:
+                experiment_descriptions = config.getlist(
+                    seed_conds_name, "experiment_description", element_type=str
+                )
+                seed_conds_data.pop("experiment_description", None)
+            if "participant_id" in seed_conds_data:
+                participant_ids = config.getlist(
+                    seed_conds_name, "participant_id", element_type=str
+                )
+                seed_conds_data.pop("participant_id", None)
+            extra_metadata = seed_conds_data if len(seed_conds_data) > 0 else None
+        else:
+            raise KeyError(
+                f"config must have section {seed_conds_name} to warm start strategy."
+            )
+        return {
+            "exp_names": experiment_names,
+            "exp_ids": experiment_ids,
+            "exp_desc": experiment_descriptions,
+            "par_ids": participant_ids,
+            "ex_data": extra_metadata,
+        }
+
+
+def _print_in_params(list_to_print: List[Any]) -> str:
+    # This prints a list of values to be used in a sql in statement
+
+    out_string = "("
+    for i, val in enumerate(list_to_print):
+        out_string += f"'{val}'"
+        if i < len(list_to_print) - 1:
+            out_string += ", "
+    out_string += ")"
+    return out_string
+
+
+def _print_like_params(column_name: str, dict_to_print: Dict[str, str]) -> str:
+    # This prints a list of values to be in a sequence of sql like statments
+    # that are combined using a binary or operation.
+
+    out_string = "("
+    for i, (key, val) in enumerate(dict_to_print.items()):
+        out_string += f"{column_name} like '%\"{key}\":%'"
+        if i < len(dict_to_print) - 1:
+            out_string += " or "
+    out_string += ")"
+    return out_string
+
+
+def _print_warning(fetcher: DataFetcher, query_record: DBMasterTable, format: str):
+    first_match = True
+    match_str = ""
+    if (
+        fetcher.experiment_names
+        and query_record.experiment_name in fetcher.experiment_names
+    ):
+        match_str += f"experiment_name = {query_record.experiment_name}"
+        first_match = False
+    if (
+        fetcher.experiment_desc
+        and query_record.experiment_description in fetcher.experiment_desc
+    ):
+        if not first_match:
+            match_str += " and "
+        match_str += f"experimend_desc = {query_record.experiment_description}"
+        first_match = False
+    if fetcher.experiment_ids and query_record.experiment_id in fetcher.experiment_ids:
+        if not first_match:
+            match_str += " and "
+        match_str += f"experimend_id = {query_record.experiment_id}"
+        first_match = False
+    if (
+        fetcher.participant_ids
+        and query_record.participant_id in fetcher.participant_ids
+    ):
+        if not first_match:
+            match_str += " and "
+        match_str += f"participant_id = {query_record.participant_id}"
+        first_match = False
+    # assumes that all false positive metadata matches have been filtered out.
+
+    if fetcher.extra_metadata and query_record.extra_metadata:
+        ex_data_str = "" if first_match else " and "
+        ex_data = json.loads(query_record.extra_metadata)
+
+        first_ex_match = True
+        for i, (key, val) in enumerate(fetcher.extra_metadata.items()):
+            if key in ex_data and (
+                val == ex_data[key]
+                or (isinstance(val, Iterable) and ex_data[key] in val)
+            ):
+                if not first_ex_match:
+                    ex_data_str = ex_data_str + ", "
+                    if i == len(fetcher.extra_metadata) - 1:
+                        ex_data_str += " and "
+                ex_data_str += f"{key} = {val}"
+                first_ex_match = False
+        if not first_ex_match:
+            match_str += ex_data_str
+    logger.warning(format.format(match_str))

--- a/aepsych/database/db.py
+++ b/aepsych/database/db.py
@@ -128,7 +128,7 @@ class Database:
             List[Any]: The results of the query.
         """
         with self.session_scope() as session:
-            return session.execute(query, vals).fetchall()
+            return session.execute(query, vals).all()
 
     def get_master_records(self) -> List[tables.DBMasterTable]:
         """Grab the list of master records.
@@ -239,14 +239,14 @@ class Database:
 
         return None
 
-    def get_all_params_for(self, master_id: int) -> Optional[List[tables.DbRawTable]]:
+    def get_all_params_for(self, master_id: int) -> Optional[List[tables.DbParamTable]]:
         """Get the parameters for all the iterations of a specific experiment.
 
         Args:
             master_id (int): The master id.
 
         Returns:
-            List[tables.DbRawTable] or None: The parameters or None if they don't exist.
+            List[tables.DbParamTable] or None: The parameters or None if they don't exist.
         """
         warnings.warn(
             "get_all_params_for is the same as get_param_for since there can only be one instance of any master_id",
@@ -266,14 +266,14 @@ class Database:
 
         return None
 
-    def get_param_for(self, master_id: int) -> Optional[List[tables.DbRawTable]]:
+    def get_param_for(self, master_id: int) -> Optional[List[tables.DbParamTable]]:
         """Get the parameters for a specific iteration of a specific experiment.
 
         Args:
             master_id (int): The master id.
 
         Returns:
-            List[tables.DbRawTable] or None: The parameters or None if they don't exist.
+            List[tables.DbParamTable] or None: The parameters or None if they don't exist.
         """
         raw_record = self.get_raw_for(master_id)
 
@@ -284,14 +284,16 @@ class Database:
 
         return None
 
-    def get_all_outcomes_for(self, master_id: int) -> Optional[List[tables.DbRawTable]]:
+    def get_all_outcomes_for(
+        self, master_id: int
+    ) -> Optional[List[tables.DbOutcomeTable]]:
         """Get the outcomes for all the iterations of a specific experiment.
 
         Args:
             master_id (int): The master id.
 
         Returns:
-            List[tables.DbRawTable] or None: The outcomes or None if they don't exist.
+            List[tables.DbOutcomeTable] or None: The outcomes or None if they don't exist.
         """
         warnings.warn(
             "get_all_outcomes_for is the same as get_outcome_for since there can only be one instance of any master_id",
@@ -311,14 +313,14 @@ class Database:
 
         return None
 
-    def get_outcome_for(self, master_id: int) -> Optional[List[tables.DbRawTable]]:
+    def get_outcome_for(self, master_id: int) -> Optional[List[tables.DbOutcomeTable]]:
         """Get the outcomes for a specific iteration of a specific experiment.
 
         Args:
             master_id (int): The master id.
 
         Returns:
-            List[tables.DbRawTable] or None: The outcomes or None if they don't exist.
+            List[tables.DbOutcomeTable] or None: The outcomes or None if they don't exist.
         """
         raw_record = self.get_raw_for(master_id)
 

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -61,7 +61,7 @@ class AEPsychServer(object):
         self.exit_server_loop = False
         self._db_master_record = None
         self._db_raw_record = None
-        self.db = db.Database(database_path)
+        self.db: db.Database = db.Database(database_path)
         self.skip_computations = False
         self.strat_names = None
 

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -542,6 +542,21 @@ class Strategy(object):
         )
         return self.min_asks
 
+    def pre_warm_model(self, x: torch.Tensor, y: torch.Tensor) -> None:
+        """
+        Adds new data points to the strategy, and normalizes the inputs.
+        We speceifically disregard the n return value of normalize_inputs here in order
+        to stop warm start data from affecting the trials run length.
+
+        Args:
+            x torch.Tensor: The input data points.
+            y torch.Tensor: The output data points.
+
+        """
+        # warming the model shouldn't affect strategy.n
+        self.x, self.y, n = self.normalize_inputs(x, y)
+        self._model_is_fresh = False
+
     def add_data(
         self, x: Union[np.ndarray, torch.Tensor], y: Union[np.ndarray, torch.Tensor]
     ) -> None:

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -443,3 +443,10 @@ def get_dims(config: Config) -> int:
     except KeyError:
         # Likely old style of parameter definition, fallback to looking at a bound
         return len(config.getlist("common", "lb", element_type=float))
+
+
+def generate_default_outcome_names(count: int) -> List[str]:
+    if count == 1:
+        return ["outcome"]
+
+    return [f"outcome_{i}" for i in range(count)]

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -57,13 +57,18 @@ n_points = 2
 
 
 class BaseServerTestCase(unittest.TestCase):
+    # so that this can be overridden for tests that require specific databases.
+    @property
+    def database_path(self):
+        return "./{}_test_server.db".format(str(uuid.uuid4().hex))
+
     def setUp(self):
         # setup logger
         server.logger = utils_logging.getLogger(logging.DEBUG, "logs")
         # random port
         socket = server.sockets.PySocket(port=0)
         # random datebase path name without dashes
-        database_path = "./{}_test_server.db".format(str(uuid.uuid4().hex))
+        database_path = self.database_path
         self.s = server.AEPsychServer(socket=socket, database_path=database_path)
         self.db_name = database_path.split("/")[1]
         self.db_path = database_path

--- a/tests/test_datafetcher.py
+++ b/tests/test_datafetcher.py
@@ -1,0 +1,451 @@
+import logging
+import os
+import unittest
+from unittest.mock import MagicMock
+
+import aepsych.server as server
+import aepsych.utils_logging as utils_logging
+from aepsych.config import Config
+from aepsych.database.data_fetcher import (
+    DataFetcher,
+    ITERATION_ID,
+    OUTCOME_ID,
+    PARAM_NAME_ID,
+    PARAM_VAL_ID,
+)
+
+
+class DataFetcherTestCase(unittest.TestCase):
+    def default_config(
+        self,
+        outcome_names=["outcome"],
+        outcome_types=["binary"],
+        par_data={
+            "par1": ["continuous", 0, 1, False],
+            "par2": ["continuous", 0, 1, False],
+        },
+        model_name="GPClassificationModel",
+        num_stim=1,
+    ):
+        def print_par_data(data):
+            par_string = ""
+            for k, v in data.items():
+                par_string += f"""
+                                [{k}]
+                                par_type = {v[0]}
+                                lower_bound = {v[1]}
+                                upper_bound = {v[2]}
+                                log_scale = {v[3] if len(v) == 4 else False}
+                                """
+            return par_string
+
+        return f"""[metadata]
+                  experiment_name = my_exp
+                  participant_id = pid3
+
+                  [common]
+                  parnames = [{', '.join(name for name in par_data)}]
+                  stimuli_per_trial = {num_stim}
+                  outcome_names = [{', '.join(name for name in outcome_names)}]
+                  outcome_types = [{', '.join(type for type in outcome_types)}]
+                  strategy_names = [my_strat]
+
+                  {print_par_data(par_data)}
+
+                  [my_strat]
+                  min_asks = 5
+                  generator = SobolGenerator
+                  model = {model_name}
+               """
+
+    def pre_seed_config(
+        self,
+        conds_name,
+        exp_names=None,
+        exp_ids=None,
+        exp_desc=None,
+        par_ids=None,
+        ex_data=None,
+    ):
+        config_str = f"""seed_data_conditions = {conds_name}
+        
+                  [{conds_name}]"""
+
+        if exp_names:
+            config_str += (
+                f"\nexperiment_name = [{', '.join(name for name in exp_names)}]"
+            )
+        if exp_ids:
+            config_str += (
+                f"\nexperiment_id = [{', '.join(exp_id for exp_id in exp_ids)}]"
+            )
+        if exp_desc:
+            config_str += (
+                f"\nexperiment_description = [{', '.join(desc for desc in exp_desc)}]"
+            )
+        if par_ids:
+            config_str += (
+                f"\nparticipant_id = [{', '.join(par_id for par_id in par_ids)}]"
+            )
+        if ex_data:
+            config_str += "\n" + "\n".join(f"{k} = {v}" for k, v in ex_data.items())
+        return config_str
+
+    @property
+    def database_path(self):
+        # the parent directory for locally run tests
+
+        dirs = os.path.split(os.getcwd())
+        if dirs[len(dirs) - 1] == "ae":
+            return "./aepsych/tests/test_databases/1000_outcome.db"
+        elif dirs[len(dirs) - 1] == "tests":
+            return "./test_databases/1000_outcome.db"
+        else:  # using cwd to get appropriate path for internal tests.
+            return f"{os.getcwd()}/frl/ae/aepsych/tests/test_databases/1000_outcome.db"
+
+    def setUp(self):
+        # setup logger
+
+        server.logger = utils_logging.getLogger(logging.DEBUG, "logs")
+        # random port
+
+        socket = server.sockets.PySocket(port=0)
+        # random datebase path name without dashes
+
+        database_path = self.database_path
+        self.s = server.AEPsychServer(socket=socket, database_path=database_path)
+        self.db_name = database_path.split("/")[1]
+        self.db_path = database_path
+
+        setup_message = {
+            "type": "setup",
+            "version": "0.01",
+            "message": {"config_str": self.default_config()},
+        }
+
+        self.s.db.record_config = MagicMock()
+        self.s.db.record_message = MagicMock()
+        self.s.db.record_setup = MagicMock()
+
+        self.s.handle_request(setup_message)
+
+    def tearDown(self):
+        self.s.cleanup()
+
+    def test_create_from_config(self):
+        test_names = ["my experiment", "my_exp"]
+        test_exp_ids = ["exp1", "exp2", "exp3"]
+        test_desc = ["desc1", "desc2"]
+        test_par_ids = [
+            "d6e6afba-8a38-49c8-82f8-6b58846b2b34",
+            "bb9c9c60-45cd-4102-aead-30888cc35d9f",
+        ]
+
+        test_ex_data = {
+            "some data": "[[1, 2], 2]",
+            "another thing": "bb9c9c60-45cd-4102-aead-30888cc35d9f",
+        }
+
+        config_str = self.default_config() + self.pre_seed_config(
+            "seed_conds",
+            test_names,
+            test_exp_ids,
+            test_desc,
+            test_par_ids,
+            test_ex_data,
+        )
+
+        test_fetcher = DataFetcher.from_config(
+            Config(config_str=config_str), "my_strat"
+        )
+
+        self.assertTrue(
+            test_fetcher.experiment_names is not None
+            and len(test_fetcher.experiment_names) == len(test_names)
+            and x == test_names[i]
+            for i, x in enumerate(test_fetcher.experiment_names)
+        )
+
+        self.assertTrue(
+            test_fetcher.experiment_ids is not None
+            and len(test_fetcher.experiment_ids) == len(test_exp_ids)
+            and x == test_exp_ids[i]
+            for i, x in enumerate(test_fetcher.experiment_ids)
+        )
+
+        self.assertTrue(
+            test_fetcher.experiment_desc is not None
+            and len(test_fetcher.experiment_desc) == len(test_desc)
+            and x == test_desc[i]
+            for i, x in enumerate(test_fetcher.experiment_desc)
+        )
+
+        self.assertTrue(
+            test_fetcher.participant_ids is not None
+            and len(test_fetcher.participant_ids) == len(test_par_ids)
+            and x == test_par_ids[i]
+            for i, x in enumerate(test_fetcher.participant_ids)
+        )
+
+        self.assertTrue(
+            test_fetcher.extra_metadata is not None
+            and len(test_fetcher.extra_metadata) == len(test_ex_data)
+            and (
+                k in test_ex_data and test_ex_data[k] == v
+                for k, v in test_fetcher.extra_metadata.items()
+            )
+        )
+
+    def test_experiment_name_match(self):
+        # the ids associated with the multi param experiment
+
+        # turn formatting off here since linter was putting a single entry
+        # per line
+        # fmt: off
+        validation_set = set(
+            [
+                1, 7, 9, 15, 18, 20, 27, 31, 32, 33, 34,
+                35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
+                45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+                55, 56, 57, 58, 59, 60, 61, 62, 63,
+            ]
+        )
+        # fmt: on
+
+        # should filter out pairwise on # of stim
+        # should filter out negative on outcome type
+
+        config_str = self.default_config() + self.pre_seed_config(
+            "seed_conds",
+            ["multi_param_gen", "pairwise_opt_gen", "negative_param_exp"],
+        )
+
+        test_fetcher = DataFetcher.from_config(
+            Config(config_str=config_str), "my_strat"
+        )
+
+        valid_ids = test_fetcher._get_valid_data_ids(self.s)
+
+        self.assertTrue(
+            len(validation_set.intersection(set(valid_ids))) == len(validation_set)
+            and len(validation_set) == len(valid_ids)
+        )
+
+    def test_experiment_desc_match(self):
+        # the ids associated with the multi param experiment
+
+        # turn formatting off here since linter was putting a single entry
+        # per line
+        # fmt: off
+        validation_set = set(
+            [
+                1, 7, 9, 15, 18, 20, 27, 31, 32, 33, 34,
+                35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
+                45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+                55, 56, 57, 58, 59, 60, 61, 62, 63,
+            ]
+        )
+        # fmt: on
+
+        # should filter out pairwise and negative on same basis
+
+        config_str = self.default_config() + self.pre_seed_config(
+            "seed_conds",
+            exp_desc=[
+                '"generating data with multiple params for tests"',
+                '"generating pairwise data for tests"',
+                '"generating data with negative param vals for tests"',
+            ],
+        )
+
+        test_fetcher = DataFetcher.from_config(
+            Config(config_str=config_str), "my_strat"
+        )
+
+        valid_ids = test_fetcher._get_valid_data_ids(self.s)
+
+        self.assertTrue(
+            len(validation_set.intersection(set(valid_ids))) == len(validation_set)
+            and len(validation_set) == len(valid_ids)
+        )
+
+    def test_experiment_id_match(self):
+        # the ids associated with the multi param experiment
+
+        validation_set = set([1, 7, 9, 15, 18, 20, 27])
+
+        # though this will match every test in the db it should filter down to only
+        # the multi param experiment because of the config fitlering
+
+        config_str = self.default_config() + self.pre_seed_config(
+            "seed_conds", exp_ids=["f18d43aa-e4e0-4376-859b-8ef8e9d749dd"]
+        )
+
+        test_fetcher = DataFetcher.from_config(
+            Config(config_str=config_str), "my_strat"
+        )
+
+        valid_ids = test_fetcher._get_valid_data_ids(self.s)
+
+        self.assertTrue(
+            len(validation_set.intersection(set(valid_ids))) == len(validation_set)
+            and len(validation_set) == len(valid_ids)
+        )
+
+    def test_participant_id_match(self):
+        # only the pairwise experiments should meet all criteria for this config
+        # so even though the provided participant ids are associated with other tests
+        # they should only meet this subset of the pairwise experiments.
+
+        validation_set = set([6, 8, 16, 17])
+        config_str = self.default_config(model_name="PairwiseProbitModel", num_stim=2)
+
+        setup_message = {
+            "type": "setup",
+            "version": "0.01",
+            "message": {"config_str": config_str},
+        }
+
+        self.s.handle_request(setup_message)
+
+        config_str += self.pre_seed_config("seed_conds", par_ids=["16", "4", "3"])
+
+        test_fetcher = DataFetcher.from_config(
+            Config(config_str=config_str), "my_strat"
+        )
+
+        valid_ids = test_fetcher._get_valid_data_ids(self.s)
+
+        self.assertTrue(
+            len(validation_set.intersection(set(valid_ids))) == len(validation_set)
+            and len(validation_set) == len(valid_ids)
+        )
+
+    def test_ex_metadata_match(self):
+        validation_set = {7, 15, 47, 50, 53, 57}
+
+        config_str = self.default_config() + self.pre_seed_config(
+            "seed_conds", ex_data={"modality": "vision"}
+        )
+
+        test_fetcher = DataFetcher.from_config(
+            Config(config_str=config_str), "my_strat"
+        )
+
+        valid_ids = test_fetcher._get_valid_data_ids(self.s)
+
+        self.assertTrue(
+            len(validation_set.intersection(set(valid_ids))) == len(validation_set)
+            and len(validation_set) == len(valid_ids)
+        )
+
+        validation_set |= {9, 18, 33, 44, 62}
+
+        config_str = self.default_config() + self.pre_seed_config(
+            "seed_conds", ex_data={"modality": ["vision", "haptics"]}
+        )
+
+        test_fetcher = DataFetcher.from_config(
+            Config(config_str=config_str), "my_strat"
+        )
+
+        valid_ids = test_fetcher._get_valid_data_ids(self.s)
+
+        self.assertTrue(
+            len(validation_set.intersection(set(valid_ids))) == len(validation_set)
+            and len(validation_set) == len(valid_ids)
+        )
+
+    def test_warm_start(self):
+        config_str = self.default_config() + self.pre_seed_config(
+            "seed_conds", exp_names=["multi_param_gen", "negative_param_gen"]
+        )
+
+        setup_message = {
+            "type": "setup",
+            "version": "0.01",
+            "message": {"config_str": config_str},
+        }
+
+        self.s.handle_request(setup_message)
+
+        for strat in self.s.strat.strat_list:
+            if self.s.config.has_option(strat.name, "seed_data_conditions"):
+                self.assertFalse(strat._model_is_fresh)
+                self.assertTrue(strat.n == 0)
+                self.assertTrue(strat._count == 0)
+
+    def test_undefined_parameter_filter(self):
+        config_str = self.default_config(
+            par_data={
+                "par1": ["continuous", 0, 1, True],
+                "par2": ["continuous", 0, 1, True],
+            },
+            outcome_types=["ordinal"],
+            model_name="OrdinalGPModel",
+        ) + self.pre_seed_config(
+            "seed_conds", exp_names=["multi_param_gen", "negative_param_exp"]
+        )
+
+        setup_message = {
+            "type": "setup",
+            "version": "0.01",
+            "message": {"config_str": config_str},
+        }
+
+        self.s.handle_request(setup_message)
+
+        for strat in self.s.strat.strat_list:
+            if self.s.config.has_option(strat.name, "seed_data_conditions"):
+                self.assertFalse(strat._model_is_fresh)
+                self.assertFalse(strat.x is not None and strat.x.le(-1).any())
+                self.assertTrue(strat.n == 0)
+                self.assertTrue(strat._count == 0)
+
+    def test_validate_data_query_constants(self):
+        config_str = self.default_config() + self.pre_seed_config(
+            "seed_conds", exp_ids=["multi_param_gen"]
+        )
+
+        test_fetcher = DataFetcher.from_config(
+            Config(config_str=config_str), "my_strat"
+        )
+
+        validation_record = self.s.db.get_raw_for(1)[0]
+        query_res = self.s.db.execute_sql_query(
+            test_fetcher._construct_data_query([1]), None
+        )[0]
+
+        self.assertTrue(
+            query_res[ITERATION_ID] == validation_record.children_param[0].iteration_id
+        )
+
+        self.assertTrue(
+            query_res[PARAM_NAME_ID] == validation_record.children_param[0].param_name
+        )
+
+        self.assertTrue(
+            query_res[PARAM_VAL_ID] == validation_record.children_param[0].param_value
+        )
+
+        self.assertTrue(
+            query_res[OUTCOME_ID] == validation_record.children_outcome[0].outcome_value
+        )
+
+    ######################################################
+    # this test was initially implemented using a custom profiler module.
+    # As this module was removed so were all references to its code.
+    # If you're interested in reviving this test you'll need to implement profiling
+    # using one of the languages built in profilers.
+    ######################################################
+    # def test_filter_2000(self):
+    #     config_str = self.default_config() + self.pre_seed_config("seed_conds",
+    #                 exp_ids=["f18d43aa-e4e0-4376-859b-8ef8e9d749dd", "b4e77159-cfd2-45f8-9215-d22c355039e2"])
+
+    #     setup_message = {
+    #         "type": "setup",
+    #         "version": "0.01",
+    #         "message": {"config_str": config_str}
+    #     }
+
+    #     self.s.handle_request(setup_message)


### PR DESCRIPTION
Summary:
There is a desire to warm start a strategy with data filtered on master table values recorded from previous experiments.

Data can be filtered on any data other than master.unique_id. This means that the below are all valid filter criteria:
- experiment_name
- experiment_description
- experiment_id
- participant_id
- anything stored in extra_metadata

Criteria will follow AND logic between fields, but inclusive OR logic within the same field.

Data will be further filtered out if it does not meet these criteria:
- Each parameter matches on name and type
- Each outcome matches on name and type
- Stimuli per trial are the same

Differential Revision: D66731597
