### PR TITLE
Revert initialize acqf method to not add bounds to calls

### DIFF
--- a/aepsych/transforms/ops/fixed.py
+++ b/aepsych/transforms/ops/fixed.py
@@ -126,6 +126,9 @@ class Fixed(Transform, StringParameterMixin, torch.nn.Module):
         if "values" not in options:
             value = config[name].get("value")
 
+            if value is None:
+                raise ValueError(f"Value option not found in {name} section.")
+
             try:
                 options["values"] = [float(value)]
             except ValueError:

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -84,7 +84,7 @@ def dim_grid(
         if i in slice_dims.keys():
             mesh_vals.append(slice(slice_dims[i] - 1e-10, slice_dims[i] + 1e-10, 1))
         else:
-            mesh_vals.append(slice(lower[i].item(), upper[i].item(), gridsize * 1j))
+            mesh_vals.append(slice(lower[i].item(), upper[i].item(), gridsize * 1j))  # type: ignore
 
     return torch.Tensor(np.mgrid[mesh_vals].reshape(dim, -1).T)
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ DEV_REQUIRES = BENCHMARK_REQUIRES + [
     "flake8",
     "black",
     "sqlalchemy-stubs",  # for mypy stubs
-    "mypy",
+    "mypy==1.14.0",
     "parameterized",
     "scikit-learn",  # used in unit tests
 ]

--- a/tests/models/test_semi_p.py
+++ b/tests/models/test_semi_p.py
@@ -141,6 +141,8 @@ class SemiPSmokeTests(unittest.TestCase):
                 "target": 0.75,
                 "query_set_size": 100,
                 "Xq": make_scaled_sobol(self.lb, self.ub, 100),
+                "lb": self.lb,
+                "ub": self.ub,
             },
             max_gen_time=0.2,
             lb=self.lb,

--- a/tests_gpu/generators/test_optimize_acqf_generator.py
+++ b/tests_gpu/generators/test_optimize_acqf_generator.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
+from inspect import signature
 
 import torch
 from aepsych.acquisition import (
@@ -51,8 +52,13 @@ class TestOptimizeAcqfGenerator(unittest.TestCase):
     def test_gpu_smoketest(self, acqf, acqf_kwargs):
         lb = torch.tensor([0.0])
         ub = torch.tensor([1.0])
-        bounds = torch.stack([lb, ub])
         inducing_size = 10
+
+        acqf_args_expected = list(signature(acqf).parameters.keys())
+        if "lb" in acqf_args_expected:
+            acqf_kwargs = acqf_kwargs.copy()
+            acqf_kwargs["lb"] = lb
+            acqf_kwargs["ub"] = ub
 
         model = GPClassificationModel(
             dim=1,


### PR DESCRIPTION
Summary: Acqf_kwargs already gets bounds from config if it needs it so now we work with those instead of the generator's bounds.

Differential Revision: D67532416


