### PR TITLE
Fix latest mypy errors and pin mypy version

### DIFF
--- a/aepsych/transforms/ops/fixed.py
+++ b/aepsych/transforms/ops/fixed.py
@@ -126,6 +126,9 @@ class Fixed(Transform, StringParameterMixin, torch.nn.Module):
         if "values" not in options:
             value = config[name].get("value")
 
+            if value is None:
+                raise ValueError(f"Value option not found in {name} section.")
+
             try:
                 options["values"] = [float(value)]
             except ValueError:

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -84,7 +84,7 @@ def dim_grid(
         if i in slice_dims.keys():
             mesh_vals.append(slice(slice_dims[i] - 1e-10, slice_dims[i] + 1e-10, 1))
         else:
-            mesh_vals.append(slice(lower[i].item(), upper[i].item(), gridsize * 1j))
+            mesh_vals.append(slice(lower[i].item(), upper[i].item(), gridsize * 1j))  # type: ignore
 
     return torch.Tensor(np.mgrid[mesh_vals].reshape(dim, -1).T)
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ DEV_REQUIRES = BENCHMARK_REQUIRES + [
     "flake8",
     "black",
     "sqlalchemy-stubs",  # for mypy stubs
-    "mypy",
+    "mypy==1.14.0",
     "parameterized",
     "scikit-learn",  # used in unit tests
 ]


### PR DESCRIPTION
Summary:
New mypy errors due to mypy update. We update to latest mypy version and now pin so we don't get more surprises.

Note that the ignore in dim_grid is necessary as that is a perfectly valid use of slice (with imaginary numbers for the step value) but  mypy seems to not understand that usage in numpy.

Differential Revision: D67537899


