### PR TITLE
Remove german double s from example config

### DIFF
--- a/configs/pairwise_al_example.ini
+++ b/configs/pairwise_al_example.ini
@@ -50,7 +50,7 @@ generator = OptimizeAcqfGenerator # The generator class used to generate new par
 acqf = PairwiseMCPosteriorVariance
 
 # The model, which must conform to the stimuli_per_trial and outcome_types settings above.
-# Use GPClassificationModel or GPRegressionModel for single or PairwiseProbitModel for pairwise.ß
+# Use GPClassificationModel or GPRegressionModel for single or PairwiseProbitModel for pairwise.
 model = PairwiseProbitModel
 
 ## Below this section are configurations of all the classes defined in the section above,


### PR DESCRIPTION
Summary: German double s "ß" was breaking some clients, it shouldn't be there anyways.

Differential Revision: D67770935


