### PR TITLE
Pin scipy version to fix botorch fitting failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ REQUIRES = [
     "numpy<2.0, >=1.20",
     "matplotlib",
     "torch",
-    "scipy",
+    "scipy==1.14.1",
     "SQLAlchemy==1.4.46",
     "dill",
     "pandas",


### PR DESCRIPTION
Summary:
Model fits are intermittently failing after scipy updated to 1.15.0 in pip. We're pinning to last stable version we know of 1.14.1.

Reported to Botorch, will remove this bandaid when that is fixed.

Reviewed By: crasanders

Differential Revision: D67802964


