### PR TITLE
Make server remember multiple _db_master_records

### DIFF
--- a/aepsych/database/db.py
+++ b/aepsych/database/db.py
@@ -337,7 +337,7 @@ class Database:
         name: str = None,
         extra_metadata: Optional[str] = None,
         exp_id: Optional[str] = None,
-        request: Dict[str, Any] = None,
+        request: Optional[Dict[str, Any]] = None,
         par_id: Optional[int] = None,
     ) -> str:
         """Record the setup of an experiment.
@@ -371,7 +371,7 @@ class Database:
         record.message_type = "setup"
         record.message_contents = request
 
-        if "extra_info" in request:
+        if request is not None and "extra_info" in request:
             record.extra_info = request["extra_info"]
 
         record.timestamp = datetime.datetime.now()

--- a/aepsych/server/message_handlers/handle_setup.py
+++ b/aepsych/server/message_handlers/handle_setup.py
@@ -38,6 +38,14 @@ def _configure(server, config):
         fetcher = DataFetcher.from_config(config, strat.name)
         fetcher.warm_start_strat(server, strat)
 
+    try:
+        # Check we have a record to get
+        _ = server._db_master_record
+    except (
+        IndexError
+    ):  # We probably don't have a record for this new ID, so we make a dummy
+        server._db_master_record = server.db.record_setup()
+
     return server.strat_id
 
 

--- a/aepsych/server/replay.py
+++ b/aepsych/server/replay.py
@@ -37,6 +37,9 @@ def replay(server, uuid_to_replay, skip_computations=False):
 
     master_record = server.db.get_master_record(uuid_to_replay)
 
+    # We're going to assume that a config message will be sent in this replay such that the server.strat_id matches this record
+    server._db_master_record = master_record
+
     if master_record is None:
         raise RuntimeError(
             f"The unique ID {uuid_to_replay} isn't in the database. Unable to perform replay."

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -59,7 +59,6 @@ class AEPsychServer(object):
         self.db = None
         self.is_performing_replay = False
         self.exit_server_loop = False
-        self._db_master_record = None
         self._db_raw_record = None
         self.db: db.Database = db.Database(database_path)
         self.skip_computations = False
@@ -71,6 +70,7 @@ class AEPsychServer(object):
         self._strats = []
         self._parnames = []
         self._configs = []
+        self._master_records = []
         self.strat_id = -1
         self._pregen_asks = []
         self.enable_pregen = False
@@ -269,6 +269,17 @@ class AEPsychServer(object):
         self._parnames.append(s)
 
     @property
+    def _db_master_record(self):
+        if self.strat_id == -1:
+            return None
+        else:
+            return self._master_records[self.strat_id]
+
+    @_db_master_record.setter
+    def _db_master_record(self, s):
+        self._master_records.append(s)
+
+    @property
     def n_strats(self):
         return len(self._strats)
 
@@ -385,7 +396,6 @@ def startServerAndRun(
         if socket is not None:
             if id_of_replay is not None:
                 server.replay(id_of_replay, skip_computations=True)
-                server._db_master_record = server.db.get_master_record(id_of_replay)
             server.serve()
         else:
             if config_path is not None:


### PR DESCRIPTION
Summary:
The attribute `server._db_master_record` used to only ever be a single master record and when not replaying from CLI, it will never be updated from the initial state of `None`. This means that it's possible to send messages to the server and it will not be recorded be linked to a master table row.

Similarly, the `resume` message swaps the `server.strat_id` but because only the last set `_db_master_record` is remembered by the server, all messages sent after a resume will still be linked to the master table row set by the last setup message.

This is now changed to allow `self._db_master_record` to act like other indexable properties in the `server` class where `server.strat_id` indexes which _db_master_record is produced when the property is accessed.

Reviewed By: crasanders

Differential Revision: D66734631


