### PR TITLE
Cleanup raw table get methods to always give back all rows from master_id

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -175,65 +175,6 @@ class AEPsychServer(object):
             raise RuntimeError("Trying to load strat in unknown format!")
         return strat
 
-    def generate_experiment_table(
-        self,
-        experiment_id: str,
-        table_name: str = "experiment_table",
-        return_df: bool = False,
-    ) -> Optional[pd.DataFrame]:
-        """Generate a table of a given experiment with all the raw data.
-
-        This table is generated from the database, and is added to the
-        experiment's database.
-
-        Args:
-            experiment_id (str): The experiment ID to generate the table for.
-            table_name (str): The name of the table. Defaults to
-                "experiment_table".
-            return_df (bool): If True, also return the dataframe.
-
-        Returns:
-            pd.DataFrame: The dataframe of the experiment table, if
-                return_df is True.
-        """
-        param_space = self.db.get_param_for(experiment_id, 1)
-        outcome_space = self.db.get_outcome_for(experiment_id, 1)
-
-        columns = []
-        columns.append("iteration_id")
-        for param in param_space:
-            columns.append(param.param_name)
-        for outcome in outcome_space:
-            columns.append(outcome.outcome_name)
-
-        columns.append("timestamp")
-
-        # Create dataframe
-        df = pd.DataFrame(columns=columns)
-
-        # Fill dataframe
-        for raw in self.db.get_raw_for(experiment_id):
-            row = {}
-            row["iteration_id"] = raw.unique_id
-            for param in raw.children_param:
-                row[param.param_name] = param.param_value
-            for outcome in raw.children_outcome:
-                row[outcome.outcome_name] = outcome.outcome_value
-            row["timestamp"] = raw.timestamp
-            # concat to dataframe
-            df = pd.concat([df, pd.DataFrame([row])], ignore_index=True)
-
-        # Make iteration_id the index
-        df.set_index("iteration_id", inplace=True)
-
-        # Save to .db file
-        df.to_sql(table_name, self.db.get_engine(), if_exists="replace")
-
-        if return_df:
-            return df
-        else:
-            return None
-
     ### Properties that are set on a per-strat basis
     @property
     def strat(self):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -207,9 +207,9 @@ class DBTestCase(unittest.TestCase):
         )
         outcome_dict = {x: {} for x in range(1, 8)}
         for outcome in outcome_data:
-            outcome_dict[outcome.iteration_id][outcome.outcome_name] = (
-                outcome.outcome_value
-            )
+            outcome_dict[outcome.iteration_id][
+                outcome.outcome_name
+            ] = outcome.outcome_value
 
         self.assertEqual(outcome_dict, outcome_dict_expected)
 
@@ -327,10 +327,10 @@ class DBTestCase(unittest.TestCase):
         # Record a param data entry
         self._database.record_param(raw_table, param_name, param_value)
         iteration_id = raw_table.unique_id
-        param_data = self._database.get_param_for(iteration_id)
+        param_data = self._database.get_params_for(iteration_id)
         self.assertEqual(len(param_data), 1)
-        self.assertEqual(param_data[0].param_name, param_name)
-        self.assertEqual(float(param_data[0].param_value), param_value)
+        self.assertEqual(param_data[0][0].param_name, param_name)
+        self.assertEqual(float(param_data[0][0].param_value), param_value)
 
     def test_outcome_table(self):
         outcome_value = 1.123
@@ -344,10 +344,10 @@ class DBTestCase(unittest.TestCase):
         # Record an outcome data entry
         self._database.record_outcome(raw_table, outcome_name, outcome_value)
         iteration_id = raw_table.unique_id
-        outcome_data = self._database.get_outcome_for(iteration_id)
+        outcome_data = self._database.get_outcomes_for(iteration_id)
         self.assertEqual(len(outcome_data), 1)
-        self.assertEqual(outcome_data[0].outcome_name, outcome_name)
-        self.assertEqual(outcome_data[0].outcome_value, outcome_value)
+        self.assertEqual(outcome_data[0][0].outcome_name, outcome_name)
+        self.assertEqual(outcome_data[0][0].outcome_value, outcome_value)
 
     # Test some metadata flow stuff and see if it is working.
     def test_metadata(self):


### PR DESCRIPTION
Summary:
Assuming every single experiment run has a unique ID (as it should), we clean up the database methods that grab the param table and outcome table rows.

Now, all you need is the master_id and either function will simply return all of the rows given that ID. Essentially, we collapsed the `all` variants of these methods into a single method which should be easier to just index.

We also delete the method that will no longer work because of these changes (and we're replacing them anyways).

Reviewed By: JasonKChow

Differential Revision: D67306206


