### PR TITLE
Remove warning about inducing since >= 100 in gpclassification

### DIFF
--- a/aepsych/database/db.py
+++ b/aepsych/database/db.py
@@ -14,13 +14,12 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm.session import close_all_sessions
-
 import aepsych.database.tables as tables
 from aepsych.config import Config
 from aepsych.strategy import Strategy
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.session import close_all_sessions
 
 logger = logging.getLogger()
 

--- a/aepsych/models/gp_classification.py
+++ b/aepsych/models/gp_classification.py
@@ -82,15 +82,6 @@ class GPClassificationModel(AEPsychModelDeviceMixin, ApproximateGP):
             {"options": optimizer_options} if optimizer_options else {"options": {}}
         )
 
-        if self.inducing_size >= 100:
-            logger.warning(
-                (
-                    "inducing_size in GPClassificationModel is >=100, more inducing points "
-                    "can lead to better fits but slower performance in general. Performance "
-                    "at >=100 inducing points is especially slow."
-                )
-            )
-
         if likelihood is None:
             likelihood = BernoulliLikelihood()
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -207,9 +207,9 @@ class DBTestCase(unittest.TestCase):
         )
         outcome_dict = {x: {} for x in range(1, 8)}
         for outcome in outcome_data:
-            outcome_dict[outcome.iteration_id][
-                outcome.outcome_name
-            ] = outcome.outcome_value
+            outcome_dict[outcome.iteration_id][outcome.outcome_name] = (
+                outcome.outcome_value
+            )
 
         self.assertEqual(outcome_dict, outcome_dict_expected)
 


### PR DESCRIPTION
Summary: New default inducing point algo is very unlikely to hit the magic number so warning about 100 inducing point no longer needed.

Differential Revision: D67864969


