### PR TITLE
Manually include transforms and inducing points into api docs

### DIFF
--- a/aepsych/database/data_fetcher.py
+++ b/aepsych/database/data_fetcher.py
@@ -9,7 +9,6 @@ import json
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import torch
-
 from aepsych.config import Config, ConfigurableMixin
 from aepsych.database.tables import DBMasterTable
 from aepsych.strategy import Strategy

--- a/aepsych/database/db.py
+++ b/aepsych/database/db.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import aepsych.database.tables as tables
-
 import pandas as pd
 from aepsych.config import Config
 from aepsych.strategy import Strategy

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -16,7 +16,6 @@ import warnings
 
 import aepsych.database.db as db
 import aepsych.utils_logging as utils_logging
-
 import dill
 import numpy as np
 import torch

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -24,6 +24,7 @@ AEPsych API Reference
    likelihoods
    plotting
    strategy
+   transforms
    utils_logging
    utils
 

--- a/sphinx/source/models.rst
+++ b/sphinx/source/models.rst
@@ -36,6 +36,14 @@ aepsych.models.monotonic\_rejection\_gp module
    :undoc-members:
    :show-inheritance:
 
+aepsych.models.inducing\_points module
+------------------------------------
+
+.. automodule:: aepsych.models.inducing_points
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 
@@ -43,3 +51,4 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
+

--- a/sphinx/source/transforms.rst
+++ b/sphinx/source/transforms.rst
@@ -1,0 +1,22 @@
+aepsych.transforms 
+==========================
+
+Submodules
+----------
+
+aepsych.transforms.parameters module
+------------------------------
+
+.. automodule:: aepsych.transforms.parameters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+aepsych.transforms.ops module
+-------------------------------------------
+
+.. automodule:: aepsych.transforms.ops
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/tests/server/test_cli.py
+++ b/tests/server/test_cli.py
@@ -9,6 +9,7 @@ import os
 import unittest
 from pathlib import Path
 
+
 class CLITestCase(unittest.TestCase):
     def test_summarize_cli(self):
         current_path = Path(os.path.abspath(__file__)).parent

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -17,7 +17,6 @@ from pathlib import Path
 import aepsych.config as configuration
 import aepsych.database.db as db
 import aepsych.database.tables as tables
-
 import pandas as pd
 import sqlalchemy
 
@@ -209,9 +208,9 @@ class DBTestCase(unittest.TestCase):
         )
         outcome_dict = {x: {} for x in range(1, 8)}
         for outcome in outcome_data:
-            outcome_dict[outcome.iteration_id][
-                outcome.outcome_name
-            ] = outcome.outcome_value
+            outcome_dict[outcome.iteration_id][outcome.outcome_name] = (
+                outcome.outcome_value
+            )
 
         self.assertEqual(outcome_dict, outcome_dict_expected)
 


### PR DESCRIPTION
Summary:
API docs seem to be manually composed, we add the transforms and inducing points submodule so that the docs will show up on the site.

Future work may automate this.

Differential Revision: D67884927
