### PR TITLE
Update release workflow to automatically update main version

### DIFF
--- a/.github/workflows/build-to-release.yml
+++ b/.github/workflows/build-to-release.yml
@@ -102,3 +102,39 @@ jobs:
           path: dist/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  update-main-version:
+    name: Update main version number
+    needs:
+        - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "release"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install repo and get version
+        run: |
+          python3 -m pip install .
+          echo "version=$(python -c "import aepsych; print(aepsych.version.__version__)")" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: "main"
+
+      - name: Edit main version with dev appended
+        run: |
+          sed -i "s/^__version__ .*/__version__ = \""$version"+dev\"/" aepsych/version.py
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: Update main version to ${{ env.version }}+dev
+          title: Automated main version bump to ${{ env.version }}+dev
+          body: Update main version to ${{ env.version }}+dev due to release.


### PR DESCRIPTION
Summary: The external Github actions workflow has been updated to get the version from the release branch and then update the main branch's version, appending +dev to the end. A pull request will be made, which should then go through the internal review loop.

Differential Revision: D67955010


