### PR TITLE
Implement Fixed Parameter Asks

### DIFF
--- a/aepsych/generators/acqf_thompson_sampler_generator.py
+++ b/aepsych/generators/acqf_thompson_sampler_generator.py
@@ -67,6 +67,7 @@ class AcqfThompsonSamplerGenerator(AEPsychGenerator):
         self.stimuli_per_trial = stimuli_per_trial
         self.lb = lb
         self.ub = ub
+        self.dim = len(lb)
 
     def _instantiate_acquisition_fn(self, model: ModelProtocol) -> AcquisitionFunction:
         """Instantiate the acquisition function with the model and any extra arguments.

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -44,6 +44,7 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
 
     acqf: AcquisitionFunction
     acqf_kwargs: Dict[str, Any]
+    dim: int
 
     def __init__(
         self,

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -52,7 +52,13 @@ class AEPsychGenerator(abc.ABC, Generic[AEPsychModelType]):
         pass
 
     @abc.abstractmethod
-    def gen(self, num_points: int, model: AEPsychModelType) -> torch.Tensor:
+    def gen(
+        self,
+        num_points: int,
+        model: AEPsychModelType,
+        fixed_features: Optional[Dict[int, float]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
         pass
 
     @classmethod

--- a/aepsych/generators/epsilon_greedy_generator.py
+++ b/aepsych/generators/epsilon_greedy_generator.py
@@ -34,6 +34,7 @@ class EpsilonGreedyGenerator(AEPsychGenerator):
         self.epsilon = epsilon
         self.lb = lb
         self.ub = ub
+        self.dim = len(lb)
 
     @classmethod
     def from_config(cls, config: Config) -> "EpsilonGreedyGenerator":

--- a/aepsych/generators/epsilon_greedy_generator.py
+++ b/aepsych/generators/epsilon_greedy_generator.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Dict, Optional
+
 import numpy as np
 import torch
 from aepsych.config import Config
@@ -56,17 +58,33 @@ class EpsilonGreedyGenerator(AEPsychGenerator):
         epsilon = config.getfloat(classname, "epsilon", fallback=0.1)
         return cls(lb=lb, ub=ub, subgenerator=subgen, epsilon=epsilon)
 
-    def gen(self, num_points: int, model: ModelProtocol) -> torch.Tensor:
+    def gen(
+        self,
+        num_points: int,
+        model: ModelProtocol,
+        fixed_features: Optional[Dict[int, float]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
         """Query next point(s) to run by sampling from the subgenerator with probability 1-epsilon, and randomly otherwise.
 
         Args:
             num_points (int): Number of points to query.
             model (ModelProtocol): Model to use for generating points.
+            fixed_features: (Dict[int, float], optional): Parameters that are fixed to specific values.
+            **kwargs: Passed to subgenerator if not exploring
         """
         if num_points > 1:
             raise NotImplementedError("Epsilon-greedy batched gen is not implemented!")
         if np.random.uniform() < self.epsilon:
-            sample = np.random.uniform(low=self.lb, high=self.ub)
-            return torch.tensor(sample).reshape(1, -1)
+            sample_ = np.random.uniform(low=self.lb, high=self.ub)
+            sample = torch.tensor(sample_).reshape(1, -1)
+
+            if fixed_features is not None:
+                for key, value in fixed_features.items():
+                    sample[:, key] = value
+
+            return sample
         else:
-            return self.subgenerator.gen(num_points, model)
+            return self.subgenerator.gen(
+                num_points, model, fixed_features=fixed_features, **kwargs
+            )

--- a/aepsych/generators/manual_generator.py
+++ b/aepsych/generators/manual_generator.py
@@ -54,11 +54,16 @@ class ManualGenerator(AEPsychGenerator):
         self,
         num_points: int = 1,
         model: Optional[AEPsychMixin] = None,  # included for API compatibility
+        fixed_features: Optional[Dict[int, float]] = None,
+        **kwargs,  # Ignored
     ) -> torch.Tensor:
         """Query next point(s) to run by quasi-randomly sampling the parameter space.
         Args:
             num_points (int): Number of points to query. Defaults to 1.
             model (AEPsychMixin, optional): Model to use for generating points. Not used in this generator. Defaults to None.
+            fixed_features (Dict[int, float], optional): Ignored, kept for consistent
+                API.
+            **kwargs: Ignored, API compatibility
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
         """
@@ -67,6 +72,12 @@ class ManualGenerator(AEPsychGenerator):
                 "Asked for more points than are left in the generator! Giving everthing it has!",
                 RuntimeWarning,
             )
+
+        if fixed_features is not None:
+            warnings.warn(
+                f"Cannot fix features when generating from {self.__class__.__name__}"
+            )
+
         points = self.points[self._idx : self._idx + num_points]
         self._idx += num_points
         return points

--- a/aepsych/generators/monotonic_rejection_generator.py
+++ b/aepsych/generators/monotonic_rejection_generator.py
@@ -68,7 +68,7 @@ class MonotonicRejectionGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         self.acqf_kwargs = acqf_kwargs
         self.model_gen_options = model_gen_options
         self.explore_features = explore_features
-        self.lb, self.ub, _ = _process_bounds(lb, ub, None)
+        self.lb, self.ub, self.dim = _process_bounds(lb, ub, None)
         self.bounds = torch.stack((self.lb, self.ub))
 
     def _instantiate_acquisition_fn(

--- a/aepsych/generators/monotonic_thompson_sampler_generator.py
+++ b/aepsych/generators/monotonic_thompson_sampler_generator.py
@@ -30,6 +30,7 @@ class MonotonicThompsonSamplerGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         num_ts_points: int,
         target_value: float,
         objective: MCAcquisitionObjective,
+        dim: int,
         explore_features: Optional[List[Type[int]]] = None,
     ) -> None:
         """Initialize MonotonicMCAcquisition
@@ -41,6 +42,7 @@ class MonotonicThompsonSamplerGenerator(AEPsychGenerator[MonotonicRejectionGP]):
             target_value (float): target value that is being looked for
             objective (MCAcquisitionObjective): Objective transform of the GP output
                 before evaluating the acquisition. Defaults to identity transform.
+            dim (int): Dimensionality of the model.
             explore_features (List[Type[int]], optional): List of features that will be selected randomly and then
                 fixed for acquisition fn optimization. Defaults to None.
         """
@@ -50,6 +52,7 @@ class MonotonicThompsonSamplerGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         self.target_value = target_value
         self.objective = objective()
         self.explore_features = explore_features
+        self.dim = dim
 
     def gen(
         self,

--- a/aepsych/generators/monotonic_thompson_sampler_generator.py
+++ b/aepsych/generators/monotonic_thompson_sampler_generator.py
@@ -5,7 +5,8 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional, Type
+import warnings
+from typing import Dict, List, Optional, Type
 
 import torch
 from aepsych.acquisition.objective import ProbitObjective
@@ -58,15 +59,22 @@ class MonotonicThompsonSamplerGenerator(AEPsychGenerator[MonotonicRejectionGP]):
         self,
         num_points: int,  # Current implementation only generates 1 point at a time
         model: MonotonicRejectionGP,
+        fixed_features: Optional[Dict[int, float]] = None,
+        **kwargs,
     ) -> torch.Tensor:
         """Query next point(s) to run by optimizing the acquisition function.
         Args:
             num_points (int): Number of points to query. current implementation only generates 1 point at a time.
             model (MonotonicRejectionGP): Fitted model of the data.
+            fixed_features (Dict[int, float], optional): Not implemented for this generator.
+            **kwargs: Ignored, API compatibility
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
         """
-
+        if fixed_features is not None:
+            warnings.warn(
+                "Cannot fix features when generating from MonotonicRejectionGenerator"
+            )
         # Generate the points at which to sample
         X = draw_sobol_samples(bounds=model.bounds_, n=self.num_ts_points, q=1).squeeze(
             1

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -71,6 +71,7 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
         self.stimuli_per_trial = stimuli_per_trial
         self.lb = lb
         self.ub = ub
+        self.dim = len(lb)
 
     def _instantiate_acquisition_fn(self, model: ModelProtocol) -> AcquisitionFunction:
         """

--- a/aepsych/generators/random_generator.py
+++ b/aepsych/generators/random_generator.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 from aepsych.config import Config
@@ -39,17 +39,27 @@ class RandomGenerator(AEPsychGenerator):
         self,
         num_points: int = 1,
         model: Optional[AEPsychMixin] = None,  # included for API compatibility.
+        fixed_features: Optional[Dict[int, float]] = None,
+        **kwargs,
     ) -> torch.Tensor:
         """Query next point(s) to run by randomly sampling the parameter space.
         Args:
             num_points (int): Number of points to query. Currently, only 1 point can be queried at a time.
             model (AEPsychMixin, optional): Model to use for generating points. Not used in this generator.
+            fixed_features: (Dict[int, float], optional): Parameters that are fixed to specific values.
+            **kwargs: Ignored, API compatibility
+
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
         """
         X = self.bounds_[0] + torch.rand((num_points, self.bounds_.shape[1])) * (
             self.bounds_[1] - self.bounds_[0]
         )
+
+        if fixed_features is not None:
+            for key, value in fixed_features.items():
+                X[:, key] = value
+
         return X
 
     @classmethod

--- a/aepsych/generators/semi_p.py
+++ b/aepsych/generators/semi_p.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Type
+from typing import Dict, Optional, Type
 
 import torch
 from aepsych.acquisition.objective.semi_p import SemiPThresholdObjective
@@ -34,6 +34,8 @@ class IntensityAwareSemiPGenerator(OptimizeAcqfGenerator):
         num_points: int,
         model: SemiParametricGPModel,  # type: ignore[override]
         context_objective: Type = SemiPThresholdObjective,
+        fixed_features: Optional[Dict[int, float]] = None,
+        **kwargs,
     ) -> torch.Tensor:
         """Query next point(s) to run by optimizing the acquisition function for both context and intensity.
 
@@ -41,14 +43,18 @@ class IntensityAwareSemiPGenerator(OptimizeAcqfGenerator):
             num_points (int): Number of points to query.
             model (SemiParametricGPModel): Fitted semi-parametric model of the data.
             context_objective (Type): The objective function used for context. Defaults to SemiPThresholdObjective.
+            fixed_features (Dict[int, float], optional): Not implemented for this generator.
+            **kwargs: Passed to generator
 
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
         """
+        if fixed_features is not None:
+            raise ValueError("Fixed features not supported for semi_p generators")
 
-        fixed_features = {model.stim_dim: 0}
+        fixed_features_ = {model.stim_dim: 0.0}
         next_x = super().gen(
-            num_points=num_points, model=model, fixed_features=fixed_features
+            num_points=num_points, model=model, fixed_features=fixed_features_, **kwargs
         )
         # to compute intensity, we need the point where f is at the
         # threshold as a function of context. self.acqf_kwargs should contain

--- a/aepsych/generators/sobol_generator.py
+++ b/aepsych/generators/sobol_generator.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 from aepsych.config import Config
@@ -50,16 +50,25 @@ class SobolGenerator(AEPsychGenerator):
         self,
         num_points: int = 1,
         model: Optional[AEPsychMixin] = None,  # included for API compatibility
+        fixed_features: Optional[Dict[int, float]] = None,
+        **kwargs,
     ) -> torch.Tensor:
         """Query next point(s) to run by quasi-randomly sampling the parameter space.
         Args:
             num_points (int): Number of points to query. Defaults to 1.
             moodel (AEPsychMixin, optional): Model to use for generating points. Not used in this generator. Defaults to None.
+            fixed_features: (Dict[int, float], optional): Parameters that are fixed to specific values.
+            **kwargs: Ignored, API compatibility
         Returns:
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim] or [num_points x dim x stimuli_per_trial] if stimuli_per_trial != 1.
         """
         grid = self.engine.draw(num_points)
         grid = self.lb + (self.ub - self.lb) * grid
+
+        if fixed_features is not None:
+            for key, value in fixed_features.items():
+                grid[:, key] = value
+
         if self.stimuli_per_trial == 1:
             return grid
 

--- a/aepsych/server/message_handlers/handle_ask.py
+++ b/aepsych/server/message_handlers/handle_ask.py
@@ -37,7 +37,7 @@ def handle_ask(server, request):
     return new_config
 
 
-def ask(server, num_points=1):
+def ask(server, num_points=1, **kwargs):
     """get the next point to query from the model
     Returns:
         dict -- new config dict (keys are strings, values are floats)
@@ -49,7 +49,14 @@ def ask(server, num_points=1):
             server.strat._make_next_strat()
         return None
 
+    # The fixed_pars kwargs name is purposefully differend to the fixed_features
+    # expected by botorch's optimize acqf to avoid doubling up ever while allowing other
+    # kwargs to pass through
+    if "fixed_pars" in kwargs:
+        fixed_pars = kwargs.pop("fixed_pars")
+        kwargs["fixed_features"] = server._fixed_to_idx(fixed_pars)
+
     # index by [0] is temporary HACK while serverside
     # doesn't handle batched ask
-    next_x = server.strat.gen()[0]
+    next_x = server.strat.gen(num_points=num_points, **kwargs)[0]
     return server._tensor_to_config(next_x)

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -13,6 +13,7 @@ import sys
 import threading
 import traceback
 import warnings
+from typing import Dict, Union
 
 import aepsych.database.db as db
 import aepsych.utils_logging as utils_logging
@@ -269,6 +270,23 @@ class AEPsychServer(object):
         x = self.strat.transforms.str_to_indices(x)[0]
 
         return x
+
+    def _fixed_to_idx(self, fixed: Dict[str, Union[float, str]]):
+        # Given a dictionary of fixed parameters, turn the parameters names into indices
+        dummy = np.zeros(len(self.parnames)).astype("O")
+        for key, value in fixed.items():
+            idx = self.parnames.index(key)
+            dummy[idx] = value
+        dummy = np.expand_dims(dummy, 0)
+        dummy = self.strat.transforms.str_to_indices(dummy)[0]
+
+        # Turn the dummy back into a dict
+        fixed_features = {}
+        for key in fixed.keys():
+            idx = self.parnames.index(key)
+            fixed_features[idx] = dummy[idx].item()
+
+        return fixed_features
 
     def __getstate__(self):
         # nuke the socket since it's not pickleble

--- a/aepsych/transforms/ops/base.py
+++ b/aepsych/transforms/ops/base.py
@@ -114,6 +114,9 @@ class StringParameterMixin:
 
         if self.string_map is not None:
             for idx, cats in self.string_map.items():
-                obj_arr[:, idx] = [cats.index(cat) for cat in obj_arr[:, idx]]
+                obj_arr[:, idx] = [
+                    cats.index(cat) if isinstance(cat, str) else cat
+                    for cat in obj_arr[:, idx]
+                ]
 
         return obj_arr

--- a/tests/generators/test_epsilon_greedy_generator.py
+++ b/tests/generators/test_epsilon_greedy_generator.py
@@ -44,6 +44,24 @@ class TestEpsilonGreedyGenerator(unittest.TestCase):
                 < 0.01
             )
 
+    def test_epsilon_greedy_fixed(self):
+        extra_acqf_args = {"target": 0.75, "beta": 1.96}
+        lb = torch.tensor([0.0])
+        ub = torch.tensor([1.0])
+
+        gen = EpsilonGreedyGenerator(
+            subgenerator=MonotonicRejectionGenerator(
+                acqf=MonotonicMCLSE, acqf_kwargs=extra_acqf_args, lb=lb, ub=ub
+            ),
+            epsilon=1,
+            lb=lb,
+            ub=ub,
+        )
+        model = MagicMock()
+        gen.subgenerator.gen = MagicMock()
+        result = gen.gen(1, model, fixed_features={0: 0.5})
+        self.assertTrue(result == 0.5)
+
     def test_greedyepsilon_config(self):
         config_str = """
             [common]

--- a/tests/generators/test_manual_generator.py
+++ b/tests/generators/test_manual_generator.py
@@ -67,6 +67,28 @@ class TestManualGenerator(unittest.TestCase):
         self.assertEqual(gen.seed, 123)
         self.assertTrue(gen.finished)
 
+    def test_manual_generator_fixed(self):
+        points = [[10, 10], [10, 11], [11, 10], [11, 11]]
+        config_str = f"""
+                [common]
+                lb = [10, 10]
+                ub = [11, 11]
+                parnames = [par1, par2]
+
+                [init_strat]
+                generator = ManualGenerator
+
+                [ManualGenerator]
+                points = {points}
+                seed = 123
+                """
+        config = Config()
+        config.update(config_str=config_str)
+        gen = ParameterTransformedGenerator.from_config(config, "init_strat")
+
+        with self.assertWarnsRegex(Warning, "Cannot fix features"):
+            gen.gen(fixed_features={0: 10.5})
+
 
 class TestSampleAroundPointsGenerator(unittest.TestCase):
     def test_sample_around_points_generator(self):

--- a/tests/generators/test_random_generator.py
+++ b/tests/generators/test_random_generator.py
@@ -60,6 +60,12 @@ class TestRandomGenerator(unittest.TestCase):
         npt.assert_equal(gen.ub.numpy(), np.array(ub))
         self.assertEqual(gen.dim, len(lb))
 
+    def test_randomgen_fixed(self):
+        gen = RandomGenerator(lb=[1, 2, 3], ub=[2, 3, 4], dim=3)
+        point = gen.gen(fixed_features={0: 1.5, 1: 2})[0]
+        self.assertTrue(point[0] == 1.5)
+        self.assertTrue(point[1] == 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/server/message_handlers/test_ask_handlers.py
+++ b/tests/server/message_handlers/test_ask_handlers.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from ..test_server import BaseServerTestCase
+
+
+class AskHandlerTestCase(BaseServerTestCase):
+    def test_fixed_ask(self):
+        config_str = """
+        [common]
+        parnames = [par1, par2]
+        stimuli_per_trial = 1
+        outcome_types = [binary]
+        strategy_names = [init_strat, opt_strat]
+
+        [par1]
+        par_type = continuous
+        lower_bound = 1
+        upper_bound = 100
+
+        [par2]
+        par_type = continuous
+        lower_bound = 0
+        upper_bound = 1
+
+        [init_strat]
+        generator = SobolGenerator
+        min_total_tells = 1
+
+        [opt_strat]
+        generator = OptimizeAcqfGenerator
+        acqf = MCLevelSetEstimation
+        model = GPClassificationModel
+        min_total_tells = 2
+        """
+        setup_request = {
+            "type": "setup",
+            "message": {"config_str": config_str},
+        }
+        self.s.handle_request(setup_request)
+
+        fixed1 = 75.0
+        fixed2 = 0.75
+
+        # SobolGenerator
+        # One fixed
+        resp = self.s.handle_request(
+            {"type": "ask", "message": {"fixed_pars": {"par1": fixed1}}}
+        )
+        self.assertTrue(resp["config"]["par1"][0] == fixed1)
+
+        self.s.handle_request(
+            {"type": "tell", "message": {"config": resp["config"], "outcome": 1}}
+        )
+
+        # Both fixed
+        resp = self.s.handle_request(
+            {"type": "ask", "message": {"fixed_pars": {"par1": fixed1, "par2": fixed2}}}
+        )
+        self.assertTrue(resp["config"]["par1"][0] == fixed1)
+        self.assertTrue(resp["config"]["par2"][0] == fixed2)
+
+        self.s.handle_request(
+            {"type": "tell", "message": {"config": resp["config"], "outcome": 0}}
+        )
+
+        # OptimizeAcqfGenerator
+        # One fixed
+        resp = self.s.handle_request(
+            {"type": "ask", "message": {"fixed_pars": {"par1": fixed1}}}
+        )
+        self.assertTrue(resp["config"]["par1"][0] == fixed1)
+
+        self.s.handle_request(
+            {"type": "tell", "message": {"config": resp["config"], "outcome": 1}}
+        )
+
+        # All fixed
+        resp = self.s.handle_request(
+            {
+                "type": "ask",
+                "message": {"fixed_pars": {"par1": fixed1, "par2": fixed2}},
+            }
+        )
+
+        self.assertTrue(resp["config"]["par1"][0] == fixed1)
+        self.assertTrue(resp["config"]["par2"][0] == fixed2)


### PR DESCRIPTION
Summary:
Allow asks to provide some some parameter values to fix when generating points. When set only the unset parameters will be automatically generated.

This more or less only works for OptimizeAcqfGenerator. Other generators will simply throw a warning and ignore the directive.

To conform API, every generator's gen method now includes the **kwargs but most of them will simply ignore it.

Differential Revision: D67956510


