### PR TITLE
More robust config saving to master record

### DIFF
--- a/aepsych/server/message_handlers/handle_setup.py
+++ b/aepsych/server/message_handlers/handle_setup.py
@@ -79,8 +79,9 @@ def configure(server, config=None, **config_args):
                 f"Config version {version} is less than AEPsych version {__version__}, but couldn't automatically update the config! Trying to configure the server anyway..."
             )
 
+    strat_id = _configure(server, usedconfig)
     server.db.record_config(master_table=server._db_master_record, config=usedconfig)
-    return _configure(server, usedconfig)
+    return strat_id
 
 
 def handle_setup(server, request):


### PR DESCRIPTION
Summary: Change the order of operation slightly to ensure that even if somehow you got to the handle_setup message without having a master record, it will still be able to save the config to the master record since the configuration message will create a master record and save it.

Differential Revision: D68190097


