### PR TITLE
Add batched ask support for MCLSE.

### DIFF
--- a/aepsych/acquisition/lse.py
+++ b/aepsych/acquisition/lse.py
@@ -84,7 +84,12 @@ class MCLevelSetEstimation(MCAcquisitionFunction):
 
         post = self.model.posterior(X)
         samples = self.sampler(post)  # num_samples x batch_shape x q x d_out
-        return self.acquisition(self.objective(samples, X)).squeeze(-1)
+        acq_vals = self.acquisition(self.objective(samples, X))
+
+        # Reduce q (which is a max on q)
+        acq_vals = torch.amax(acq_vals, dim=-1)
+
+        return acq_vals
 
 
 @acqf_input_constructor(MCLevelSetEstimation)

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -134,9 +134,7 @@ class OptimizeAcqfGenerator(AEPsychGenerator):
 
         acqf = self._instantiate_acquisition_fn(model)
 
-        if isinstance(acqf, MCLevelSetEstimation) or isinstance(
-            acqf, LookaheadAcquisitionFunction
-        ):
+        if isinstance(acqf, LookaheadAcquisitionFunction) and num_points > 1:
             warnings.warn(
                 f"{num_points} points were requested, but `{acqf.__class__.__name__}` can only generate one point at a time, returning only 1."
             )

--- a/aepsych/server/message_handlers/handle_ask.py
+++ b/aepsych/server/message_handlers/handle_ask.py
@@ -29,7 +29,16 @@ def handle_ask(server, request):
         else:
             params = ask(server)
 
-    new_config = {"config": params, "is_finished": server.strat.finished}
+    if params is None:  # For replay
+        lengths = [0]
+    else:
+        lengths = {len(val) for val in params.values()}
+
+    new_config = {
+        "config": params,
+        "is_finished": server.strat.finished,
+        "num_points": lengths.pop(),
+    }
     if not server.is_performing_replay:
         server.db.record_message(
             master_table=server._db_master_record, type="ask", request=request
@@ -43,8 +52,8 @@ def ask(server, num_points=1, **kwargs):
         dict -- new config dict (keys are strings, values are floats)
     """
     if server.skip_computations:
-        # HACK to makke sure strategies finish correctly
-        server.strat._strat._count += 1
+        # Fakes points being generated and tracked by strategy to end strategies
+        server.strat._strat._count += num_points
         if server.strat._strat.finished:
             server.strat._make_next_strat()
         return None
@@ -56,7 +65,5 @@ def ask(server, num_points=1, **kwargs):
         fixed_pars = kwargs.pop("fixed_pars")
         kwargs["fixed_features"] = server._fixed_to_idx(fixed_pars)
 
-    # index by [0] is temporary HACK while serverside
-    # doesn't handle batched ask
-    next_x = server.strat.gen(num_points=num_points, **kwargs)[0]
+    next_x = server.strat.gen(num_points=num_points, **kwargs)
     return server._tensor_to_config(next_x)

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -245,9 +245,10 @@ class AEPsychServer(object):
             # We always need a batch dimension for transformations
             next_x = next_x.unsqueeze(0)
 
-        next_x = self.strat.transforms.indices_to_str(next_x)[0]
+        next_x = self.strat.transforms.indices_to_str(next_x)
         config = {}
-        for name, val in zip(self.parnames, next_x):
+        for i, name in enumerate(self.parnames):
+            val = next_x[:, i]
             if isinstance(val, str):
                 config[name] = [val]
             elif isinstance(val, (int, float)):
@@ -255,16 +256,18 @@ class AEPsychServer(object):
             elif isinstance(val[0], str):
                 config[name] = val
             else:
-                config[name] = np.array(val, dtype="float64")
+                config[name] = list(np.array(val, dtype="float64"))
         return config
 
     def _config_to_tensor(self, config):
         # Converts a parameter config dictionary to a tensor
         # Check if the values of config are not array, if so make them so
         config_copy = {
-            key: value.squeeze()
-            if isinstance(value, np.ndarray)
-            else np.array(value).squeeze()
+            key: (
+                value.squeeze()
+                if isinstance(value, np.ndarray)
+                else np.array(value).squeeze()
+            )
             for key, value in config.items()
         }
 

--- a/tests/generators/test_optimize_acqf_generator.py
+++ b/tests/generators/test_optimize_acqf_generator.py
@@ -132,6 +132,15 @@ class TestOptimizeAcqfGenerator(unittest.TestCase):
         cands = generator.gen(2, model)
         self.assertEqual(len(cands), 2)
 
+        generator = OptimizeAcqfGenerator(
+            acqf=MCLevelSetEstimation,
+            acqf_kwargs={"objective": ProbitObjective()},
+            lb=lb,
+            ub=ub,
+        )
+        cands = generator.gen(2, model)
+        self.assertEqual(len(cands), 2)
+
     def test_batch_generation_only_one(self):
         seed = 1
         torch.manual_seed(seed)

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -605,7 +605,7 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
         for _i in range(n_init + n_opt):
             next_config = ask(server)
             next_pair = torch.stack(
-                (torch.tensor(next_config["x"]), torch.tensor(next_config["y"])), dim=0
+                (torch.tensor(next_config["x"]), torch.tensor(next_config["y"])), dim=1
             )
             next_y = bernoulli.rvs(f_pairwise(f_2d, next_pair, noise_scale=0.1))
             tell(server, config=next_config, outcome=next_y)

--- a/tests/server/message_handlers/test_ask_handlers.py
+++ b/tests/server/message_handlers/test_ask_handlers.py
@@ -1,15 +1,111 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
 
+import unittest
+
 from ..test_server import BaseServerTestCase
+
+dummy_config = """
+[common]
+lb = [0]
+ub = [1]
+parnames = [x]
+stimuli_per_trial = 1
+outcome_types = [binary]
+strategy_names = [init_strat, opt_strat]
+
+[metadata]
+experiment_name = test experiment
+experiment_description = dummy experiment to test the server
+experiment_id = e1
+participant_id = 101
+extra = data that is arbitrary
+array = [100, 1000]
+date = Nov 26, 2024
+
+[init_strat]
+min_asks = 2
+generator = SobolGenerator
+min_total_outcome_occurrences = 0
+
+[opt_strat]
+min_asks = 2
+generator = OptimizeAcqfGenerator
+acqf = MCPosteriorVariance
+model = GPClassificationModel
+min_total_outcome_occurrences = 0
+
+[GPClassificationModel]
+inducing_size = 10
+mean_covar_factory = default_mean_covar_factory
+
+[SobolGenerator]
+n_points = 2
+"""
+
+points = [[10, 10], [10, 11], [11, 10], [11, 11]]
+manual_dummy_config = f"""
+[common]
+lb = [10, 10]
+ub = [11, 11]
+parnames = [par1, par2]
+outcome_types = [binary]
+stimuli_per_trial = 1
+strategy_names = [init_strat]
+
+[init_strat]
+generator = ManualGenerator
+
+[ManualGenerator]
+points = {points}
+seed = 123
+"""
 
 
 class AskHandlerTestCase(BaseServerTestCase):
+    def test_handle_ask(self):
+        setup_request = {
+            "type": "setup",
+            "version": "0.01",
+            "message": {"config_str": dummy_config},
+        }
+        ask_request = {"type": "ask", "message": ""}
+
+        self.s.handle_request(setup_request)
+
+        resp = self.s.handle_request(ask_request)
+        self.assertEqual(len(resp["config"]["x"]), 1)
+        self.assertEqual(resp["num_points"], 1)
+
+        ask_request["message"] = {"num_points": 1}
+        resp = self.s.handle_request(ask_request)
+        self.assertEqual(len(resp["config"]["x"]), 1)
+        self.assertEqual(resp["num_points"], 1)
+
+        ask_request["message"] = {"num_points": 2}
+        resp = self.s.handle_request(ask_request)
+        self.assertEqual(len(resp["config"]["x"]), 2)
+        self.assertEqual(resp["num_points"], 2)
+
+    def test_handle_ask_with_manual_generator(self):
+        setup_request = {
+            "type": "setup",
+            "version": "0.01",
+            "message": {"config_str": manual_dummy_config},
+        }
+        ask_request = {"type": "ask", "message": {"num_points": 10}}
+
+        self.s.handle_request(setup_request)
+
+        resp = self.s.handle_request(ask_request)
+        self.assertEqual(len(resp["config"]["par1"]), 4)
+        self.assertEqual(resp["num_points"], 4)
+
     def test_fixed_ask(self):
         config_str = """
         [common]
@@ -90,3 +186,7 @@ class AskHandlerTestCase(BaseServerTestCase):
 
         self.assertTrue(resp["config"]["par1"][0] == fixed1)
         self.assertTrue(resp["config"]["par2"][0] == fixed2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -56,6 +56,24 @@ mean_covar_factory = default_mean_covar_factory
 n_points = 2
 """
 
+points = [[10, 10], [10, 11], [11, 10], [11, 11]]
+manual_dummy_config = f"""
+[common]
+lb = [10, 10]
+ub = [11, 11]
+parnames = [par1, par2]
+outcome_types = [binary]
+stimuli_per_trial = 1
+strategy_names = [init_strat]
+
+[init_strat]
+generator = ManualGenerator
+
+[ManualGenerator]
+points = {points}
+seed = 123
+"""
+
 
 class BaseServerTestCase(unittest.TestCase):
     # so that this can be overridden for tests that require specific databases.


### PR DESCRIPTION
Summary:
MCLSE's calculation wasn't handling the q dimension properly, before assuming it would always be one and squeezing it out. We do the right thing now by specifically applying a max there to reduce it following BoTorch's default handling of the q dimension.

Lookahead Function continues to fail, will need further work to ensure it is working properly.

Differential Revision: D67921333


