### PR TITLE
remove unused imports in tests_gpu

### DIFF
--- a/tests/test_points_allocators.py
+++ b/tests/test_points_allocators.py
@@ -8,7 +8,6 @@
 import unittest
 
 import gpytorch
-import numpy as np
 import torch
 from aepsych.config import Config
 from aepsych.kernels import RBFKernelPartialObsGrad

--- a/tests_gpu/test_config.py
+++ b/tests_gpu/test_config.py
@@ -10,7 +10,6 @@ import unittest
 import torch
 from aepsych.config import Config
 from aepsych.strategy import SequentialStrategy
-from aepsych.version import __version__
 
 
 class ConfigTestCase(unittest.TestCase):

--- a/tests_gpu/test_strategy.py
+++ b/tests_gpu/test_strategy.py
@@ -7,7 +7,6 @@
 
 import unittest
 
-import torch
 from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
 from aepsych.generators import OptimizeAcqfGenerator, SobolGenerator
 from aepsych.models.gp_classification import GPClassificationModel


### PR DESCRIPTION

Summary: remove unused imports in tests_gpu

Test Plan: tests should pass
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookresearch/aepsych/pull/544).
* #553
* #552
* #551
* #550
* #549
* #548
* #547
* #546
* #545
* __->__ #544
* #543