### PR TITLE
remove unused imports from config stub

### DIFF
--- a/aepsych/config.pyi
+++ b/aepsych/config.pyi
@@ -21,10 +21,6 @@ from typing import (
 
 import numpy as np
 import torch
-from botorch.models.transforms.input import (
-    ChainedInputTransform,
-    ReversibleInputTransform,
-)
 
 _T = TypeVar("_T")
 _ET = TypeVar("_ET")

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -20,10 +20,9 @@ from aepsych.acquisition import (
 )
 from aepsych.acquisition.monotonic_rejection import MonotonicMCAcquisition
 from aepsych.config import Config
-from aepsych.generators import OptimizeAcqfGenerator
 from aepsych.generators.base import AEPsychGenerator
 from aepsych.models.base import AEPsychMixin
-from aepsych.models.utils import get_extremum, get_jnd, get_max, get_min, inv_query
+from aepsych.models.utils import get_jnd, get_max, get_min, inv_query
 from aepsych.transforms import (
     ParameterTransformedGenerator,
     ParameterTransformedModel,

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -13,7 +13,6 @@ import numpy as np
 import torch
 from aepsych.config import Config
 from botorch.models.gpytorch import GPyTorchModel
-from scipy.stats import norm
 from torch.quasirandom import SobolEngine
 
 

--- a/tests/test_points_allocators.py
+++ b/tests/test_points_allocators.py
@@ -8,7 +8,6 @@
 import unittest
 
 import gpytorch
-import numpy as np
 import torch
 from aepsych.config import Config
 from aepsych.kernels import RBFKernelPartialObsGrad

--- a/tests_gpu/test_config.py
+++ b/tests_gpu/test_config.py
@@ -10,7 +10,6 @@ import unittest
 import torch
 from aepsych.config import Config
 from aepsych.strategy import SequentialStrategy
-from aepsych.version import __version__
 
 
 class ConfigTestCase(unittest.TestCase):

--- a/tests_gpu/test_strategy.py
+++ b/tests_gpu/test_strategy.py
@@ -7,7 +7,6 @@
 
 import unittest
 
-import torch
 from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
 from aepsych.generators import OptimizeAcqfGenerator, SobolGenerator
 from aepsych.models.gp_classification import GPClassificationModel


### PR DESCRIPTION

Summary: remove unused imports from config stub

Test Plan: mypy should still pass
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookresearch/aepsych/pull/547).
* #553
* #552
* #551
* #550
* #549
* #548
* __->__ #547
* #546
* #545
* #544
* #543