### PR TITLE
remove unused imports from generators

### DIFF
--- a/aepsych/config.pyi
+++ b/aepsych/config.pyi
@@ -21,10 +21,6 @@ from typing import (
 
 import numpy as np
 import torch
-from botorch.models.transforms.input import (
-    ChainedInputTransform,
-    ReversibleInputTransform,
-)
 
 _T = TypeVar("_T")
 _ET = TypeVar("_ET")

--- a/aepsych/generators/monotonic_thompson_sampler_generator.py
+++ b/aepsych/generators/monotonic_thompson_sampler_generator.py
@@ -12,7 +12,6 @@ import torch
 from aepsych.acquisition.objective import ProbitObjective
 from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator
-from aepsych.models.base import AEPsychMixin
 from aepsych.models.monotonic_rejection_gp import MonotonicRejectionGP
 from botorch.acquisition.objective import MCAcquisitionObjective
 from botorch.utils.sampling import draw_sobol_samples

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
-import inspect
 import time
 from typing import Any, Dict, Optional
 

--- a/aepsych/kernels/pairwisekernel.py
+++ b/aepsych/kernels/pairwisekernel.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Optional, Union
+from typing import Optional, Union
 
 import torch
 from gpytorch.kernels import Kernel

--- a/aepsych/likelihoods/semi_p.py
+++ b/aepsych/likelihoods/semi_p.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable, Optional
+from typing import Optional
 
 import torch
 from aepsych.acquisition.objective import AEPsychObjective, FloorProbitObjective

--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Iterable
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Mapping, Optional, Protocol, Tuple
 

--- a/aepsych/models/monotonic_rejection_gp.py
+++ b/aepsych/models/monotonic_rejection_gp.py
@@ -18,7 +18,7 @@ from aepsych.factory.monotonic import monotonic_mean_covar_factory
 from aepsych.kernels.rbf_partial_grad import RBFKernelPartialObsGrad
 from aepsych.means.constant_partial_grad import ConstantMeanPartialObsGrad
 from aepsych.models.base import AEPsychMixin
-from aepsych.models.inducing_points import GreedyVarianceReduction, SobolAllocator
+from aepsych.models.inducing_points import GreedyVarianceReduction
 from aepsych.models.inducing_points.base import InducingPointAllocator
 from aepsych.utils import _process_bounds, get_dims, get_optimizer_options, promote_0d
 from botorch.fit import fit_gpytorch_mll

--- a/aepsych/models/semi_p.py
+++ b/aepsych/models/semi_p.py
@@ -7,12 +7,10 @@
 
 from __future__ import annotations
 
-import warnings
 from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple
 
 import gpytorch
-import numpy as np
 import torch
 from aepsych.acquisition.objective import FloorLogitObjective
 from aepsych.acquisition.objective.semi_p import SemiPThresholdObjective

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import List, Mapping, Optional, Tuple, Union
+from typing import Mapping, Optional, Tuple, Union
 
 import numpy as np
 import torch

--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -20,10 +20,9 @@ from aepsych.acquisition import (
 )
 from aepsych.acquisition.monotonic_rejection import MonotonicMCAcquisition
 from aepsych.config import Config
-from aepsych.generators import OptimizeAcqfGenerator
 from aepsych.generators.base import AEPsychGenerator
 from aepsych.models.base import AEPsychMixin
-from aepsych.models.utils import get_extremum, get_jnd, get_max, get_min, inv_query
+from aepsych.models.utils import get_jnd, get_max, get_min, inv_query
 from aepsych.transforms import (
     ParameterTransformedGenerator,
     ParameterTransformedModel,

--- a/aepsych/transforms/ops/base.py
+++ b/aepsych/transforms/ops/base.py
@@ -7,7 +7,7 @@
 
 from abc import ABC
 from copy import deepcopy
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional
 
 import numpy as np
 import torch

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -9,18 +9,7 @@ import ast
 import warnings
 from abc import ABC
 from copy import deepcopy
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Mapping,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Callable, Dict, Literal, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -13,7 +13,6 @@ import numpy as np
 import torch
 from aepsych.config import Config
 from botorch.models.gpytorch import GPyTorchModel
-from scipy.stats import norm
 from torch.quasirandom import SobolEngine
 
 

--- a/tests/test_points_allocators.py
+++ b/tests/test_points_allocators.py
@@ -8,7 +8,6 @@
 import unittest
 
 import gpytorch
-import numpy as np
 import torch
 from aepsych.config import Config
 from aepsych.kernels import RBFKernelPartialObsGrad

--- a/tests_gpu/test_config.py
+++ b/tests_gpu/test_config.py
@@ -10,7 +10,6 @@ import unittest
 import torch
 from aepsych.config import Config
 from aepsych.strategy import SequentialStrategy
-from aepsych.version import __version__
 
 
 class ConfigTestCase(unittest.TestCase):

--- a/tests_gpu/test_strategy.py
+++ b/tests_gpu/test_strategy.py
@@ -7,7 +7,6 @@
 
 import unittest
 
-import torch
 from aepsych.acquisition.monotonic_rejection import MonotonicMCLSE
 from aepsych.generators import OptimizeAcqfGenerator, SobolGenerator
 from aepsych.models.gp_classification import GPClassificationModel


### PR DESCRIPTION

Summary: remove unused imports from generators

Test Plan: tests should pass
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookresearch/aepsych/pull/552).
* #553
* __->__ #552
* #551
* #550
* #549
* #548
* #547
* #546
* #545
* #544
* #543