### PR TITLE
Ensure acqf bounds in transform wrapped generators are transformed

### DIFF
--- a/aepsych/strategy.py
+++ b/aepsych/strategy.py
@@ -667,6 +667,7 @@ class Strategy(object):
             model = None
             use_gpu_modeling = False
 
+        # Handles if acqf is not in the generator but strategy block, otherwise, above handles it
         acqf_cls = config.getobj(name, "acqf", fallback=None)
         if acqf_cls is not None and hasattr(generator, "acqf"):
             if generator.acqf is None:

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -410,7 +410,20 @@ class ParameterTransformedGenerator(ParameterTransformWrapper, ConfigurableMixin
         return self.transforms.untransform(x)
 
     def _get_acqf_options(self, acqf: AcquisitionFunction, config: Config):
-        return self._base_obj._get_acqf_options(acqf, config)
+        kwargs = self._base_obj._get_acqf_options(acqf, config)
+
+        # Bandaid to ensure bounds are transformed for acqf
+        if "lb" in kwargs:
+            if not isinstance(kwargs["lb"], torch.Tensor):
+                kwargs["lb"] = torch.tensor(kwargs["lb"])
+            kwargs["lb"] = self.transforms.transform(kwargs["lb"])
+
+        if "ub" in kwargs:
+            if not isinstance(kwargs["ub"], torch.Tensor):
+                kwargs["ub"] = torch.tensor(kwargs["ub"])
+            kwargs["ub"] = self.transforms.transform(kwargs["ub"])
+
+        return kwargs
 
     @property
     def acqf(self) -> AcquisitionFunction | None:

--- a/tests/generators/test_optimize_acqf_generator.py
+++ b/tests/generators/test_optimize_acqf_generator.py
@@ -15,7 +15,7 @@ from aepsych.acquisition.objective import ProbitObjective
 from aepsych.config import Config
 from aepsych.generators import OptimizeAcqfGenerator
 from aepsych.models import GPClassificationModel, PairwiseProbitModel
-from aepsych.strategy import Strategy
+from aepsych.strategy import SequentialStrategy, Strategy
 from botorch.acquisition import qLogNoisyExpectedImprovement
 from botorch.acquisition.preference import AnalyticExpectedUtilityOfBestOption
 from sklearn.datasets import make_classification

--- a/tests/generators/test_optimize_acqf_generator.py
+++ b/tests/generators/test_optimize_acqf_generator.py
@@ -15,6 +15,7 @@ from aepsych.acquisition.objective import ProbitObjective
 from aepsych.config import Config
 from aepsych.generators import OptimizeAcqfGenerator
 from aepsych.models import GPClassificationModel, PairwiseProbitModel
+from aepsych.strategy import Strategy
 from botorch.acquisition import qLogNoisyExpectedImprovement
 from botorch.acquisition.preference import AnalyticExpectedUtilityOfBestOption
 from sklearn.datasets import make_classification


### PR DESCRIPTION
Summary:
Acqf generators sometimes needs bounds, which are reacquired from config. It is not guaranteed currently that the bounds will be in the right space.

We add an extra check to the wrappers to ensure these bounds are correctly transformed.

Differential Revision: D68473751


