### PR TITLE
update pairwise factory to use zero mean by default

### DIFF
--- a/aepsych/factory/pairwise.py
+++ b/aepsych/factory/pairwise.py
@@ -55,13 +55,17 @@ def pairwise_mean_covar_factory(
         raise NotImplementedError(
             "Only default_mean_covar_factory is supported for the base factor of pairwise_mean_covar_factory right now!"
         )
+    
+    zero_mean = config.getboolean(
+            "pairwise_mean_covar_factory", "zero_mean", fallback=True
+        )
 
     if len(shared_dims) > 0:
         active_dims = [i for i in range(config_dim) if i not in shared_dims]
         assert (
             len(active_dims) % 2 == 0
         ), "dimensionality of non-shared dims must be even!"
-        mean = _get_default_mean_function(config)
+        mean = _get_default_mean_function(config, zero_mean)
         cov1 = _get_default_cov_function(
             config, len(active_dims) // 2, stimuli_per_trial=1
         )
@@ -74,7 +78,7 @@ def pairwise_mean_covar_factory(
 
     else:
         assert config_dim % 2 == 0, "dimensionality must be even!"
-        mean = _get_default_mean_function(config)
+        mean = _get_default_mean_function(config, zero_mean)
         cov = _get_default_cov_function(config, config_dim // 2, stimuli_per_trial=1)
         covar = PairwiseKernel(cov)
 

--- a/tests/test_mean_covar_factories.py
+++ b/tests/test_mean_covar_factories.py
@@ -296,7 +296,7 @@ class TestFactories(unittest.TestCase):
         config = Config(config_dict=conf)
         meanfun, covarfun = pairwise_mean_covar_factory(config)
         self.assertTrue(covarfun.latent_kernel.ard_num_dims == 1)
-        self.assertIsInstance(meanfun, gpytorch.means.ConstantMean)
+        self.assertIsInstance(meanfun, gpytorch.means.ZeroMean)
         self.assertIsInstance(covarfun, PairwiseKernel)
         self.assertIsInstance(covarfun.latent_kernel, gpytorch.kernels.RBFKernel)
 
@@ -309,7 +309,7 @@ class TestFactories(unittest.TestCase):
     def test_pairwise_factory_shared(self):
         conf = {
             "common": {"lb": [0, 0, 0], "ub": [1, 1, 1]},
-            "pairwise_mean_covar_factory": {"shared_dims": [0]},
+            "pairwise_mean_covar_factory": {"shared_dims": [0], "zero_mean": False},
         }
         config = Config(config_dict=conf)
         meanfun, covarfun = pairwise_mean_covar_factory(config)


### PR DESCRIPTION
Summary: Generally in pairwise experiments, if you're just guessing you should have a 50/50 shot of picking either stimulus, but the default mean learns a bias. This makes the bias 0 unless it is explicitly overridden.

Differential Revision: D68521854


