### PR TITLE
always update dbs when they’re loaded

### DIFF
--- a/aepsych/database/db.py
+++ b/aepsych/database/db.py
@@ -26,11 +26,12 @@ logger = logging.getLogger()
 
 
 class Database:
-    def __init__(self, db_path: Optional[str] = None) -> None:
+    def __init__(self, db_path: Optional[str] = None, update: bool = True) -> None:
         """Initialize the database object.
 
         Args:
             db_path (str, optional): The path to the database. Defaults to None.
+            update (bool): Update the db to the latest schema. Defaults to True.
         """
         if db_path is None:
             db_path = "./databases/default.db"
@@ -45,6 +46,9 @@ class Database:
             logger.info(f"No DB found at {db_path}, creating a new DB!")
 
         self._engine = self.get_engine()
+
+        if update and self.is_update_required():
+            self.perform_updates()
 
     def get_engine(self) -> sessionmaker:
         """Get the engine for the database.

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -102,7 +102,7 @@ class DBTestCase(unittest.TestCase):
         time.sleep(0.1)
 
         # open the new db
-        test_database = db.Database(db_path=dst_db_path.as_posix())
+        test_database = db.Database(db_path=dst_db_path.as_posix(), update=False)
 
         self.assertFalse(tables.DbReplayTable._has_extra_info(test_database._engine))
         self.assertTrue(test_database.is_update_required())
@@ -146,7 +146,7 @@ class DBTestCase(unittest.TestCase):
         time.sleep(0.1)
 
         # open the new db
-        test_database = db.Database(db_path=dst_db_path.as_posix())
+        test_database = db.Database(db_path=dst_db_path.as_posix(), update=False)
 
         # Make sure that update is required
         self.assertTrue(test_database.is_update_required())


### PR DESCRIPTION
Summary: DBs are now always updated when they’re loaded. This ensures the databases are updated even when not loading from server.

Differential Revision: D68530038


