### PR TITLE
remove old strategy methods

### DIFF
--- a/aepsych/benchmark/problem.py
+++ b/aepsych/benchmark/problem.py
@@ -330,7 +330,9 @@ class LSEProblemWithEdgeLogging(LSEProblem):
         # add number of edge samples to the log
 
         # get the trials selected by the final strat only
-        n_opt_trials = strat.strat_list[-1].n_trials
+        n_opt_trials = (
+            len(strat.strat_list[-1].x) if strat.strat_list[-1].x is not None else 0
+        )
 
         lb, ub = strat.lb, strat.ub
         r = ub - lb

--- a/aepsych/strategy/strategy.py
+++ b/aepsych/strategy/strategy.py
@@ -15,7 +15,7 @@ import torch
 from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator
 from aepsych.models.base import AEPsychMixin
-from aepsych.models.utils import get_jnd, get_max, get_min, inv_query
+from aepsych.models.utils import get_max, get_min, inv_query
 from aepsych.strategy.utils import ensure_model_is_fresh
 from aepsych.transforms import (
     ParameterTransformedGenerator,
@@ -386,23 +386,6 @@ class Strategy(object):
         return self.model.predict(x=x, probability_space=probability_space)
 
     @ensure_model_is_fresh
-    def get_jnd(
-        self, *args, **kwargs
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
-        """Get the just-noticeable difference (JND) for the given input(s).
-
-        Returns:
-            Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]: The JND value(s).
-        """
-        assert (
-            self.model is not None
-        ), "model is None! Cannot get the get jnd without a model!"
-        self.model.to(self.model_device)
-        return get_jnd(  # type: ignore
-            model=self.model, lb=self.lb, ub=self.ub, dim=self.dim, *args, **kwargs
-        )
-
-    @ensure_model_is_fresh
     def sample(
         self, x: torch.Tensor, num_samples: Optional[int] = None
     ) -> torch.Tensor:
@@ -481,19 +464,6 @@ class Strategy(object):
             bool: True if the strategy can be fitted, False otherwise.
         """
         return self.has_model and self.x is not None and self.y is not None
-
-    @property
-    def n_trials(self) -> int:
-        """Get the number of trials.
-
-        Returns:
-            int: The number of trials.
-        """
-        warnings.warn(
-            "'n_trials' is deprecated and will be removed in a future release. Specify 'min_asks' instead.",
-            DeprecationWarning,
-        )
-        return self.min_asks
 
     def pre_warm_model(self, x: torch.Tensor, y: torch.Tensor) -> None:
         """

--- a/tests/models/test_gp_classification.py
+++ b/tests/models/test_gp_classification.py
@@ -23,6 +23,7 @@ from aepsych.config import Config
 from aepsych.generators import OptimizeAcqfGenerator, SobolGenerator
 from aepsych.kernels import PairwiseKernel
 from aepsych.models import GPClassificationModel
+from aepsych.models.utils import get_jnd
 from aepsych.strategy import SequentialStrategy, Strategy
 from aepsych.transforms import ParameterTransformedModel, ParameterTransforms
 from aepsych.transforms.ops import NormalizeScale
@@ -701,12 +702,26 @@ class GPClassificationTest(unittest.TestCase):
         # we expect jnd close to the target to be close to the correct
         # jnd (1.5), and since this is linear model this should be true
         # for both definitions of JND
-        jnd_step = strat.get_jnd(grid=x[:, None], method="step")
+        jnd_step = get_jnd(
+            strat.model,
+            strat.lb,
+            strat.ub,
+            dim=strat.dim,
+            grid=x[:, None],
+            method="step",
+        )
         est_jnd_step = jnd_step[50]
         # looser test because step-jnd is hurt more by reverting to the mean
         self.assertTrue(np.abs(est_jnd_step - 1.5) < 0.5)
 
-        jnd_taylor = strat.get_jnd(grid=x[:, None], method="taylor")
+        jnd_taylor = get_jnd(
+            strat.model,
+            strat.lb,
+            strat.ub,
+            dim=strat.dim,
+            grid=x[:, None],
+            method="taylor",
+        )
         est_jnd_taylor = jnd_taylor[50]
         self.assertTrue(np.abs(est_jnd_taylor - 1.5) < 0.25)
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -225,24 +225,6 @@ class TestSequenceGenerators(unittest.TestCase):
         self.strat.finish()
         self.assertTrue(self.strat.finished)
 
-    def test_n_trials_deprecation(self):
-        seed = 1
-        torch.manual_seed(seed)
-        np.random.seed(seed)
-        lb = [-1, -1]
-        ub = [1, 1]
-
-        self.strat = Strategy(
-            generator=SobolGenerator(lb=lb, ub=ub),
-            min_asks=50,
-            lb=lb,
-            ub=ub,
-            stimuli_per_trial=1,
-            outcome_types=["binary"],
-        )
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(self.strat.n_trials, 50)
-
     def test_batchsobol_pairwise(self):
         lb = [1, 2, 3]
         ub = [2, 3, 4]


### PR DESCRIPTION
Summary: n_trials is deprecated and being removed. get_jnd relies on functions that assume monotonicity, and in general we don't assume monotonicity any more, so that shouldn't be a general-purpose method

Differential Revision: D68797959


