### PR TITLE
copyright header for extensions

### DIFF
--- a/aepsych/extensions.py
+++ b/aepsych/extensions.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
 import importlib.util
 import logging
 import sys


### PR DESCRIPTION
Summary: add missing copyright header for extensions.py

Reviewed By: crasanders

Differential Revision: D68800869


