### PR TITLE
remove support for very old configs

### DIFF
--- a/aepsych/server/message_handlers/handle_setup.py
+++ b/aepsych/server/message_handlers/handle_setup.py
@@ -61,28 +61,6 @@ def configure(server, config=None, **config_args):
         usedconfig = Config(**config_args)
     else:
         usedconfig = config
-    if "experiment" in usedconfig:
-        logger.warning(
-            'The "experiment" section is being deprecated from configs. Please put everything in the "experiment" section in the "common" section instead.'
-        )
-
-        for i in usedconfig["experiment"]:
-            usedconfig["common"][i] = usedconfig["experiment"][i]
-        del usedconfig["experiment"]
-
-    version = usedconfig.version
-    if version < __version__:
-        try:
-            usedconfig.convert_to_latest()
-
-            server.db.perform_updates()
-            logger.warning(
-                f"Config version {version} is less than AEPsych version {__version__}. The config was automatically modified to be compatible. Check the config table in the db to see the changes."
-            )
-        except RuntimeError:
-            logger.warning(
-                f"Config version {version} is less than AEPsych version {__version__}, but couldn't automatically update the config! Trying to configure the server anyway..."
-            )
 
     strat_id = _configure(server, usedconfig)
     server.db.record_config(master_table=server._db_master_record, config=usedconfig)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -170,10 +170,6 @@ class BenchmarkTestCase(unittest.TestCase):
                 "outcome_types": ["binary"],
                 "strategy_names": "[init_strat, opt_strat]",
             },
-            "experiment": {
-                "acqf": "MCLevelSetEstimation",
-                "model": "GPClassificationModel",
-            },
             "init_strat": {
                 "min_asks": [2, 4],
                 "generator": "SobolGenerator",
@@ -188,6 +184,7 @@ class BenchmarkTestCase(unittest.TestCase):
                         [("problem", "name")], lambda x: 2 + int(x == "test problem")
                     ),
                 ],
+                "model": "GPClassificationModel",
                 "generator": "OptimizeAcqfGenerator",
                 "min_total_outcome_occurrences": 0,
             },
@@ -205,6 +202,7 @@ class BenchmarkTestCase(unittest.TestCase):
                 "restarts": 1,
                 "samps": 20,
                 "max_gen_time": 0.1,
+                "acqf": "MCLevelSetEstimation",
             },
         }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -292,17 +292,6 @@ class ConfigTestCase(unittest.TestCase):
         self.assertTrue(isinstance(strat.strat_list[2].model, SemiParametricGPModel))
         self.assertTrue(strat.strat_list[2].generator.acqf is EAVC)
 
-    def test_experiment_deprecation(self):
-        config_str = """
-            [experiment]
-            acqf = PairwiseMCPosteriorVariance
-            model = PairwiseProbitModel
-            """
-        config = Config()
-        config.update(config_str=config_str)
-        self.assertTrue("acqf" in config["common"])
-        self.assertTrue("model" in config["common"])
-
     def test_to_string(self):
         in_str = """
             [common]


### PR DESCRIPTION
Summary: We had a versioning system to convert old configs, but users can just revert to old versions of AEPsych if they need to, and the functions weren't even being maintained

Differential Revision: D68795412


