### PR TITLE
fix mypy errors for latest pytorch

### DIFF
--- a/aepsych/acquisition/lookahead.py
+++ b/aepsych/acquisition/lookahead.py
@@ -449,7 +449,7 @@ class SMOCU(GlobalLookaheadAcquisitionFunction):
         target: Optional[float] = None,
         query_set_size: Optional[int] = 256,
         Xq: Optional[torch.Tensor] = None,
-        k: Optional[float] = 20.0,
+        k: float = 20.0,
     ) -> None:
         """
         model (GPyTorchModel): The gpytorch model to use.
@@ -459,7 +459,7 @@ class SMOCU(GlobalLookaheadAcquisitionFunction):
         target (float, optional): Threshold value to target in p-space. Default is None.
         query_set_size (int, optional): Number of points in the query set. Default is 256.
         Xq (torch.Tensor, optional): (m x d) global reference set. Default is None.
-        k (float, optional): Scaling factor for the softmax approximation, controlling the "softness" of the maximum operation. Default is 20.0.
+        k (float): Scaling factor for the softmax approximation, controlling the "softness" of the maximum operation. Default is 20.0.
         """
 
         super().__init__(

--- a/aepsych/transforms/ops/fixed.py
+++ b/aepsych/transforms/ops/fixed.py
@@ -53,7 +53,9 @@ class Fixed(Transform, StringParameterMixin, torch.nn.Module):
 
         super().__init__()
         self.register_buffer("indices", indices_)
+        self.indices: torch.Tensor
         self.register_buffer("values", values_)
+        self.values: torch.Tensor
         self.transform_on_train = transform_on_train
         self.transform_on_eval = transform_on_eval
         self.transform_on_fantasize = transform_on_fantasize

--- a/aepsych/transforms/ops/round.py
+++ b/aepsych/transforms/ops/round.py
@@ -39,6 +39,7 @@ class Round(Transform, torch.nn.Module):
         """
         super().__init__()
         self.register_buffer("indices", torch.tensor(indices, dtype=torch.long))
+        self.indices: torch.Tensor
         self.transform_on_train = transform_on_train
         self.transform_on_eval = transform_on_eval
         self.transform_on_fantasize = transform_on_fantasize


### PR DESCRIPTION
Summary:
Latest pytorch changed some type hints which causes mypy to be angry.

Critical change is now buffers are annotated as Tensor | Module, which we override in the cases where we know the registered object is a tensor.

Differential Revision: D68860945


