### PR TITLE
ConfigurableMixin default options

### DIFF
--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -12,7 +12,6 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Protocol, Tuple
 
 import gpytorch
 import torch
-
 from aepsych.config import Config, ConfigurableMixin
 from aepsych.factory.default import default_mean_covar_factory
 from aepsych.utils import get_dims, get_optimizer_options


### PR DESCRIPTION
Summary:
Configurable mixin's get_config_options is no longer abstract and will instead just look for options as defined by the class's init.

Currently not directly used anywhere (any instance of configurable mixin uses a completely overridden get_config_option).

Differential Revision: D68847119


