### PR TITLE
Allow objects to be defined with aliases in configs

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1332,6 +1332,71 @@ class ConfigTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             config.getobj("common", "generator")
 
+    def test_object_alias(self):
+        config_str = """
+            [common]
+            parnames = [par1]
+            outcome_types = [binary]
+            stimuli_per_trial = 1
+            strategy_names = [opt_strat]
+
+            [par1]
+            par_type = continuous
+            lower_bound = 1
+            upper_bound = 100
+
+            [opt_strat]
+            model = ModelAlias
+            generator = SobolGenerator
+
+            [ModelAlias]
+            class = GPClassificationModel
+            inducing_size = 50
+        """
+        config = Config(config_str=config_str)
+
+        strat = Strategy.from_config(config, "opt_strat")
+
+        self.assertIsInstance(strat.model, GPClassificationModel)
+        self.assertTrue(strat.model.inducing_size == 50)
+
+    def test_object_double_alias(self):
+        config_str = """
+            [common]
+            parnames = [par1]
+            outcome_types = [binary]
+            stimuli_per_trial = 1
+            strategy_names = [init_strat, opt_strat]
+
+            [par1]
+            par_type = continuous
+            lower_bound = 1
+            upper_bound = 100
+
+            [init_strat]
+            model = ModelAlias
+            generator = SobolGenerator
+
+            [opt_strat]
+            model = ModelAlias
+            generator = SobolGenerator
+
+            [ModelAlias]
+            class = GPClassificationModel
+            inducing_size = 50
+        """
+        config = Config(config_str=config_str)
+
+        strat = Strategy.from_config(config, "init_strat")
+
+        self.assertIsInstance(strat.model, GPClassificationModel)
+        self.assertTrue(strat.model.inducing_size == 50)
+
+        strat2 = Strategy.from_config(config, "opt_strat")
+
+        self.assertIsInstance(strat2.model, GPClassificationModel)
+        self.assertTrue(strat2.model.inducing_size == 50)
+
 
 class TestConfigurableMixing(unittest.TestCase):
     """Temporary test cases until ConfigurableMixin rolls out entirely."""


### PR DESCRIPTION
Summary:
On top of using the exact object name to refer to a model, we now allow arbitrary strings that essentially act as aliases to existing objects.

When a object is generated from config and the object name is not found in the registered names, it will use that name to find a config block. This config block should include the key “class”, which should be registered name and any options for that aliased class will be held in this alias block. 

The alias is handled by creating a new type with the base object but giving it the name of the alias. By modifying the name, it should also allow all from_configs to work with the aliased object because it should be looking for options in the block with the same name of the aliased object.

Differential Revision: D68810885


