### PR TITLE
make p_below_threshold a utility function rather than a method; remove old attributes from ModelProtocol

### DIFF
--- a/aepsych/benchmark/problem.py
+++ b/aepsych/benchmark/problem.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Union
 import aepsych
 import numpy as np
 import torch
+from aepsych.models.utils import p_below_threshold
 from aepsych.strategy import SequentialStrategy
 from aepsych.utils import make_scaled_sobol
 from scipy.stats import bernoulli
@@ -287,7 +288,7 @@ class LSEProblem(Problem):
         # define what "threshold" means in high-dim.
 
         # Brier score on level-set probabilities
-        p_l = model.p_below_threshold(self.eval_grid, self.f_threshold(model))
+        p_l = p_below_threshold(model, self.eval_grid, self.f_threshold(model))
         true_p_l = self.true_below_threshold
         assert (
             p_l.ndim == 2

--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -43,18 +43,6 @@ class ModelProtocol(Protocol):
         pass
 
     @property
-    def lb(self) -> torch.Tensor:
-        pass
-
-    @property
-    def ub(self) -> torch.Tensor:
-        pass
-
-    @property
-    def bounds(self) -> torch.Tensor:
-        pass
-
-    @property
     def dim(self) -> int:
         pass
 
@@ -82,28 +70,12 @@ class ModelProtocol(Protocol):
     def sample(self, x: torch.Tensor, num_samples: int) -> torch.Tensor:
         pass
 
-    def _get_extremum(
-        self,
-        extremum_type: str,
-        locked_dims: Optional[Mapping[int, List[float]]],
-        n_samples=1000,
-    ) -> Tuple[float, torch.Tensor]:
-        pass
-
-    def dim_grid(self, gridsize: int = 30) -> torch.Tensor:
-        pass
-
     def fit(self, train_x: torch.Tensor, train_y: torch.Tensor, **kwargs: Any) -> None:
         pass
 
     def update(
         self, train_x: torch.Tensor, train_y: torch.Tensor, **kwargs: Any
     ) -> None:
-        pass
-
-    def p_below_threshold(
-        self, x: torch.Tensor, f_thresh: torch.Tensor
-    ) -> torch.Tensor:
         pass
 
 
@@ -255,26 +227,6 @@ class AEPsychMixin(GPyTorchModel, ConfigurableMixin):
         )
 
         return options
-
-    def p_below_threshold(
-        self, x: torch.Tensor, f_thresh: torch.Tensor
-    ) -> torch.Tensor:
-        """Compute the probability that the latent function is below a threshold.
-
-        Args:
-            x (torch.Tensor): Points at which to evaluate the probability.
-            f_thresh (torch.Tensor): Threshold value.
-
-        Returns:
-            torch.Tensor: Probability that the latent function is below the threshold.
-        """
-        f, var = self.predict(x)
-        f_thresh = f_thresh.reshape(-1, 1)
-        f = f.reshape(1, -1)
-        var = var.reshape(1, -1)
-
-        z = (f_thresh - f) / var.sqrt()
-        return torch.distributions.Normal(0, 1).cdf(z)  # Use PyTorch's CDF equivalent
 
 
 class AEPsychModelDeviceMixin(AEPsychMixin):

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -388,6 +388,27 @@ def get_jnd(
     return median, lower, upper
 
 
+def p_below_threshold(
+    model: ModelProtocol, x: torch.Tensor, f_thresh: torch.Tensor
+) -> torch.Tensor:
+    """Compute the probability that the latent function is below a threshold.
+
+    Args:
+        x (torch.Tensor): Points at which to evaluate the probability.
+        f_thresh (torch.Tensor): Threshold value.
+
+    Returns:
+        torch.Tensor: Probability that the latent function is below the threshold.
+    """
+    f, var = model.predict(x)
+    f_thresh = f_thresh.reshape(-1, 1)
+    f = f.reshape(1, -1)
+    var = var.reshape(1, -1)
+
+    z = (f_thresh - f) / var.sqrt()
+    return torch.distributions.Normal(0, 1).cdf(z)  # Use PyTorch's CDF equivalent
+
+
 class TargetDistancePosteriorTransform(PosteriorTransform):
     def __init__(
         self,

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -693,21 +693,6 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
         train_x = self.transforms.transform(train_x)
         self._base_obj.update(train_x, train_y, **kwargs)
 
-    def p_below_threshold(
-        self, x: torch.Tensor, f_thresh: torch.Tensor
-    ) -> torch.Tensor:
-        """Compute the probability that the latent function is below a threshold.
-
-        Args:
-            x (torch.Tensor): Points at which to evaluate the probability.
-            f_thresh (torch.Tensor): Threshold value.
-
-        Returns:
-            torch.Tensor: Probability that the latent function is below the threshold.
-        """
-        x = self.transforms.transform(x)
-        return self._base_obj.p_below_threshold(x, f_thresh)
-
     @property
     def training(self) -> bool:
         # Check if model has it first

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -22,6 +22,7 @@ from aepsych.benchmark import (
 )
 from aepsych.models import GPClassificationModel
 from aepsych.models.inducing_points import GreedyVarianceReduction
+from aepsych.models.utils import p_below_threshold
 
 torch.set_num_threads(1)
 torch.set_num_interop_threads(1)
@@ -96,7 +97,7 @@ class MultipleLSETestCase(unittest.TestCase):
 
     def test_vectorized_score_calculation(self):
         f_thresholds = self.test_problem.f_threshold(self.model)
-        p_l = self.model.p_below_threshold(self.test_problem.eval_grid, f_thresholds)
+        p_l = p_below_threshold(self.model, self.test_problem.eval_grid, f_thresholds)
         true_p_l = self.test_problem.true_below_threshold
         # Now, perform the Brier score calculation and classification error in PyTorch
         brier_p_below_thresh = torch.mean(2 * torch.square(true_p_l - p_l), dim=1)


### PR DESCRIPTION
Summary: p_below_threshold only makes sense for certain models and shouldn't be a method on the base protocol, so moving it to be a utility function. Also removing some old attributes from the protocol that are no longer needed

Differential Revision: D68957314


