### PR TITLE
fix flakey acqf time limit test

### DIFF
--- a/tests/generators/test_optimize_acqf_generator.py
+++ b/tests/generators/test_optimize_acqf_generator.py
@@ -39,11 +39,9 @@ class TestOptimizeAcqfGenerator(unittest.TestCase):
         lb = -3 * torch.ones(8)
         ub = 3 * torch.ones(8)
         inducing_size = 10
-        bounds = torch.stack([lb, ub])
 
         model = GPClassificationModel(
             dim=8,
-            max_fit_time=0.5,
             inducing_size=inducing_size,
         )
 


### PR DESCRIPTION
Summary: time limit test seems to be flakey, try to make most of the comptuational effort go to the acqf given a better fit model.

Differential Revision: D69127714


