### PR TITLE
add additional logging to test failures to help catch flakey inducing point tests

### DIFF
--- a/tests/test_points_allocators.py
+++ b/tests/test_points_allocators.py
@@ -101,7 +101,9 @@ class TestInducingPointAllocators(unittest.TestCase):
 
         self.assertIs(model.inducing_point_method.last_allocator_used, KMeansAllocator)
         inducing_points = model.variational_strategy.inducing_points
-        self.assertTrue(inducing_points.shape == (9, 2))
+        self.assertTrue(
+            inducing_points.shape == (9, 2), f"shape is {inducing_points.shape}"
+        )
         # We made ints, so mod 1 should be 0s, so we know these were the original inputs
         self.assertTrue(torch.all(inducing_points % 1 == 0))
 


### PR DESCRIPTION
Summary: Can't replicate test failure even with the buck command, so just add some extra info to help catch failures in the future.

Differential Revision: D69138310


