### PR TITLE
speed up pairwise probit server test

### DIFF
--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -152,8 +152,10 @@ class PairwiseProbitModel(PairwiseGP, AEPsychMixin):
             # figure out how long evaluating a single samp
             starttime = time.time()
             _ = mll(self(datapoints), comparisons)
-            single_eval_time = time.time() - starttime
-            n_eval = int(max_fit_time / single_eval_time)
+            single_eval_time = (
+                time.time() - starttime + 1e-6
+            )  # add an epsilon to avoid divide by zero
+            n_eval = int(max_fit_time / (single_eval_time))
 
             optimizer_kwargs["options"]["maxfun"] = n_eval
             logger.info(f"fit maxfun is {n_eval}")

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -534,13 +534,13 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
 
             [PairwiseProbitModel]
             mean_covar_factory = default_mean_covar_factory
+            max_fit_time = 1
 
             [PairwiseMCPosteriorVariance]
             objective = ProbitObjective
 
             [OptimizeAcqfGenerator]
-            restarts = 10
-            samps = 1000
+            max_gen_time = 1
             """
 
         server = self.s


### PR DESCRIPTION
Summary: Pairwise probit server test sometimes times out in CI. Add time limits to speed up the test.

Differential Revision: D69148067


