### PR TITLE
nightly github CI tests

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: "0 12 * * *" # every day at 4AM west coast time
 
 jobs:
   lint:


### PR DESCRIPTION
Summary: We technically don’t run any tests in external CI if we aren’t writing diffs. This will run the tests nightly. Will help catch when our external dependencies change and breaks out code.

Differential Revision: D69150756


