### PR TITLE
Migrate GS usages to new module location

### DIFF
--- a/website/pages/api/_modules/aepsych/generators/base.html
+++ b/website/pages/api/_modules/aepsych/generators/base.html
@@ -23,7 +23,7 @@
 <span class="kn">from</span> <span class="nn">aepsych.config</span> <span class="kn">import</span> <span class="n">Config</span><span class="p">,</span> <span class="n">ConfigurableMixin</span>
 <span class="kn">from</span> <span class="nn">aepsych.models.base</span> <span class="kn">import</span> <span class="n">AEPsychMixin</span>
 <span class="kn">from</span> <span class="nn">ax.core.experiment</span> <span class="kn">import</span> <span class="n">Experiment</span>
-<span class="kn">from</span> <span class="nn">ax.modelbridge.generation_node</span> <span class="kn">import</span> <span class="n">GenerationStep</span>
+<span class="kn">from</span> <span class="nn">ax.generation_strategy.generation_node</span> <span class="kn">import</span> <span class="n">GenerationStep</span>
 <span class="kn">from</span> <span class="nn">botorch.acquisition</span> <span class="kn">import</span> <span class="p">(</span>
     <span class="n">AcquisitionFunction</span><span class="p">,</span>
     <span class="n">NoisyExpectedImprovement</span><span class="p">,</span>

--- a/website/pages/api/_modules/aepsych/strategy.html
+++ b/website/pages/api/_modules/aepsych/strategy.html
@@ -43,7 +43,7 @@
 <span class="p">)</span>
 <span class="kn">from</span> <span class="nn">aepsych.utils_logging</span> <span class="kn">import</span> <span class="n">getLogger</span>
 <span class="kn">from</span> <span class="nn">ax.core.base_trial</span> <span class="kn">import</span> <span class="n">TrialStatus</span>
-<span class="kn">from</span> <span class="nn">ax.modelbridge.generation_strategy</span> <span class="kn">import</span> <span class="n">GenerationStrategy</span>
+<span class="kn">from</span> <span class="nn">ax.generation_strategy.generation_strategy</span> <span class="kn">import</span> <span class="n">GenerationStrategy</span>
 <span class="kn">from</span> <span class="nn">ax.plot.contour</span> <span class="kn">import</span> <span class="n">interact_contour</span>
 <span class="kn">from</span> <span class="nn">ax.plot.slice</span> <span class="kn">import</span> <span class="n">plot_slice</span>
 <span class="kn">from</span> <span class="nn">ax.service.ax_client</span> <span class="kn">import</span> <span class="n">AxClient</span>


### PR DESCRIPTION
Summary:
Removing the following old files from `ax/modelbridge/` in favor of the new `ax/generation_strategy` directory.

```
best_model_selector.py
dispatch_utils.py
external_generation_node.py
generation_node_input_constructors.py
generation_node.py
generation_strategy.py
model_spec.py
transition_criterion.py
```

Differential Revision: D68645075
