### PR TITLE
Make db start new sessions for queries

### DIFF
--- a/aepsych/database/db.py
+++ b/aepsych/database/db.py
@@ -19,7 +19,7 @@ import pandas as pd
 from aepsych.config import Config
 from aepsych.strategy import Strategy
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.orm.session import close_all_sessions
 
 logger = logging.getLogger()
@@ -45,33 +45,22 @@ class Database:
         else:
             logger.info(f"No DB found at {db_path}, creating a new DB!")
 
-        self._engine = self.get_engine()
+        self._full_db_path = Path(self._db_dir)
+        self._full_db_path.mkdir(parents=True, exist_ok=True)
+        self._full_db_path = self._full_db_path.joinpath(self._db_name)
+
+        self._engine = create_engine(f"sqlite:///{self._full_db_path.as_posix()}")
+
+        # create the table metadata and tables
+        tables.Base.metadata.create_all(self._engine)
+
+        # Create a session to be start and closed on each use
+        self.session = scoped_session(
+            sessionmaker(bind=self._engine, expire_on_commit=False)
+        )
 
         if update and self.is_update_required():
             self.perform_updates()
-
-    def get_engine(self) -> sessionmaker:
-        """Get the engine for the database.
-
-        Returns:
-            sessionmaker: The sessionmaker object for the database.
-        """
-        if not hasattr(self, "_engine") or self._engine is None:
-            self._full_db_path = Path(self._db_dir)
-            self._full_db_path.mkdir(parents=True, exist_ok=True)
-            self._full_db_path = self._full_db_path.joinpath(self._db_name)
-
-            self._engine = create_engine(f"sqlite:///{self._full_db_path.as_posix()}")
-
-            # create the table metadata and tables
-            tables.Base.metadata.create_all(self._engine)
-
-            # create an ongoing session to be used. Provides a conduit
-            # to the db so the instantiated objects work properly.
-            Session = sessionmaker(bind=self.get_engine())
-            self._session = Session()
-
-        return self._engine
 
     def delete_db(self) -> None:
         """Delete the database."""
@@ -106,21 +95,6 @@ class Database:
         tables.DbParamTable.update(self._engine)
         tables.DbOutcomeTable.update(self._engine)
 
-    @contextmanager
-    def session_scope(self):
-        """Provide a transactional scope around a series of operations."""
-        Session = sessionmaker(bind=self.get_engine())
-        session = Session()
-        try:
-            yield session
-            session.commit()
-        except Exception as err:
-            logger.error(f"db session use failed: {err}")
-            session.rollback()
-            raise
-        finally:
-            session.close()
-
     # @retry(stop_max_attempt_number=8, wait_exponential_multiplier=1.8)
     def execute_sql_query(self, query: str, vals: Dict[str, str]) -> List[Any]:
         """Execute an arbitrary query written in sql.
@@ -132,7 +106,7 @@ class Database:
         Returns:
             List[Any]: The results of the query.
         """
-        with self.session_scope() as session:
+        with self.session() as session:
             return session.execute(query, vals).all()
 
     def get_master_records(self) -> List[tables.DBMasterTable]:
@@ -141,7 +115,8 @@ class Database:
         Returns:
             List[tables.DBMasterTable]: The list of master records.
         """
-        records = self._session.query(tables.DBMasterTable).all()
+        with self.session() as session:
+            records = session.query(tables.DBMasterTable).all()
         return records
 
     def get_master_record(self, master_id: int) -> Optional[tables.DBMasterTable]:
@@ -153,11 +128,12 @@ class Database:
         Returns:
             tables.DBMasterTable or None: The master record or None if it doesn't exist.
         """
-        records = (
-            self._session.query(tables.DBMasterTable)
-            .filter(tables.DBMasterTable.unique_id == master_id)
-            .all()
-        )
+        with self.session() as session:
+            records = (
+                session.query(tables.DBMasterTable)
+                .filter(tables.DBMasterTable.unique_id == master_id)
+                .all()
+            )
 
         if 0 < len(records):
             return records[0]
@@ -290,6 +266,13 @@ class Database:
 
         return []
 
+    @staticmethod
+    def _add_commit(session, obj):
+        # Helps guarantee duplicated objects across session can still be written
+        merged = session.merge(obj)
+        session.add(merged)
+        session.commit()
+
     def record_setup(
         self,
         description: str = None,
@@ -312,33 +295,35 @@ class Database:
         Returns:
             str: The experiment id.
         """
-        self.get_engine()
+        with self.session() as session:
 
-        master_table = tables.DBMasterTable()
-        master_table.experiment_description = description
-        master_table.experiment_name = name
-        master_table.experiment_id = exp_id if exp_id is not None else str(uuid.uuid4())
-        master_table.participant_id = (
-            par_id if par_id is not None else str(uuid.uuid4())
-        )
-        master_table.extra_metadata = extra_metadata
-        self._session.add(master_table)
+            master_table = tables.DBMasterTable()
+            master_table.experiment_description = description
+            master_table.experiment_name = name
+            master_table.experiment_id = (
+                exp_id if exp_id is not None else str(uuid.uuid4())
+            )
+            master_table.participant_id = (
+                par_id if par_id is not None else str(uuid.uuid4())
+            )
+            master_table.extra_metadata = extra_metadata
 
-        logger.debug(f"record_setup = [{master_table}]")
+            session.add(master_table)
 
-        record = tables.DbReplayTable()
-        record.message_type = "setup"
-        record.message_contents = request
+            logger.debug(f"record_setup = [{master_table}]")
 
-        if request is not None and "extra_info" in request:
-            record.extra_info = request["extra_info"]
+            record = tables.DbReplayTable()
+            record.message_type = "setup"
+            record.message_contents = request
 
-        record.timestamp = datetime.datetime.now()
-        record.parent = master_table
-        logger.debug(f"record_setup = [{record}]")
+            if request is not None and "extra_info" in request:
+                record.extra_info = request["extra_info"]
 
-        self._session.add(record)
-        self._session.commit()
+            record.timestamp = datetime.datetime.now()
+            record.parent = master_table
+            logger.debug(f"record_setup = [{record}]")
+
+            self._add_commit(session, record)
 
         # return the master table if it has a link to the list of child rows
         # tis needs to be passed into all future calls to link properly
@@ -354,19 +339,19 @@ class Database:
             type (str): The type of the message.
             request (Dict[str, Any]): The request.
         """
-        # create a linked setup table
-        record = tables.DbReplayTable()
-        record.message_type = type
-        record.message_contents = request
+        with self.session() as session:
+            # create a linked setup table
+            record = tables.DbReplayTable()
+            record.message_type = type
+            record.message_contents = request
 
-        if "extra_info" in request:
-            record.extra_info = request["extra_info"]
+            if "extra_info" in request:
+                record.extra_info = request["extra_info"]
 
-        record.timestamp = datetime.datetime.now()
-        record.parent = master_table
+            record.timestamp = datetime.datetime.now()
+            record.parent = master_table
 
-        self._session.add(record)
-        self._session.commit()
+            self._add_commit(session, record)
 
     def record_raw(
         self,
@@ -386,19 +371,19 @@ class Database:
         Returns:
             tables.DbRawTable: The raw entry.
         """
-        raw_entry = tables.DbRawTable()
-        raw_entry.model_data = model_data
+        with self.session() as session:
+            raw_entry = tables.DbRawTable()
+            raw_entry.model_data = model_data
 
-        if timestamp is None:
-            raw_entry.timestamp = datetime.datetime.now()
-        else:
-            raw_entry.timestamp = timestamp
-        raw_entry.parent = master_table
+            if timestamp is None:
+                raw_entry.timestamp = datetime.datetime.now()
+            else:
+                raw_entry.timestamp = timestamp
+            raw_entry.parent = master_table
 
-        raw_entry.extra_data = json.dumps(extra_data)
+            raw_entry.extra_data = json.dumps(extra_data)
 
-        self._session.add(raw_entry)
-        self._session.commit()
+            self._add_commit(session, raw_entry)
 
         return raw_entry
 
@@ -412,14 +397,14 @@ class Database:
             param_name (str): The parameter name.
             param_value (str): The parameter value.
         """
-        param_entry = tables.DbParamTable()
-        param_entry.param_name = param_name
-        param_entry.param_value = param_value
+        with self.session() as session:
+            param_entry = tables.DbParamTable()
+            param_entry.param_name = param_name
+            param_entry.param_value = param_value
 
-        param_entry.parent = raw_table
+            param_entry.parent = raw_table
 
-        self._session.add(param_entry)
-        self._session.commit()
+            self._add_commit(session, param_entry)
 
     def record_outcome(
         self, raw_table: tables.DbRawTable, outcome_name: str, outcome_value: float
@@ -431,14 +416,14 @@ class Database:
             outcome_name (str): The outcome name.
             outcome_value (float): The outcome value.
         """
-        outcome_entry = tables.DbOutcomeTable()
-        outcome_entry.outcome_name = outcome_name
-        outcome_entry.outcome_value = outcome_value
+        with self.session() as session:
+            outcome_entry = tables.DbOutcomeTable()
+            outcome_entry.outcome_name = outcome_name
+            outcome_entry.outcome_value = outcome_value
 
-        outcome_entry.parent = raw_table
+            outcome_entry.parent = raw_table
 
-        self._session.add(outcome_entry)
-        self._session.commit()
+            self._add_commit(session, outcome_entry)
 
     def record_strat(self, master_table: tables.DBMasterTable, strat: Strategy) -> None:
         """Record a strategy in the database.
@@ -447,13 +432,13 @@ class Database:
             master_table (tables.DBMasterTable): The master table.
             strat (Strategy): The strategy.
         """
-        strat_entry = tables.DbStratTable()
-        strat_entry.strat = strat
-        strat_entry.timestamp = datetime.datetime.now()
-        strat_entry.parent = master_table
+        with self.session() as session:
+            strat_entry = tables.DbStratTable()
+            strat_entry.strat = strat
+            strat_entry.timestamp = datetime.datetime.now()
+            strat_entry.parent = master_table
 
-        self._session.add(strat_entry)
-        self._session.commit()
+            self._add_commit(session, strat_entry)
 
     def record_config(self, master_table: tables.DBMasterTable, config: Config) -> None:
         """Record a config in the database.
@@ -462,13 +447,13 @@ class Database:
             master_table (tables.DBMasterTable): The master table.
             config (Config): The config.
         """
-        config_entry = tables.DbConfigTable()
-        config_entry.config = config
-        config_entry.timestamp = datetime.datetime.now()
-        config_entry.parent = master_table
+        with self.session() as session:
+            config_entry = tables.DbConfigTable()
+            config_entry.config = config
+            config_entry.timestamp = datetime.datetime.now()
+            config_entry.parent = master_table
 
-        self._session.add(config_entry)
-        self._session.commit()
+            self._add_commit(session, config_entry)
 
     def summarize_experiments(self) -> pd.DataFrame:
         """Provides a summary of the experiments contained in the database as a pandas dataframe.

--- a/aepsych/database/tables.py
+++ b/aepsych/database/tables.py
@@ -49,10 +49,16 @@ class DBMasterTable(Base):
 
     extra_metadata = Column(String(4096))  # JSON-formatted metadata
 
-    children_replay = relationship("DbReplayTable", back_populates="parent")
-    children_strat = relationship("DbStratTable", back_populates="parent")
-    children_config = relationship("DbConfigTable", back_populates="parent")
-    children_raw = relationship("DbRawTable", back_populates="parent")
+    children_replay = relationship(
+        "DbReplayTable", lazy="subquery", back_populates="parent"
+    )
+    children_strat = relationship(
+        "DbStratTable", lazy="subquery", back_populates="parent"
+    )
+    children_config = relationship(
+        "DbConfigTable", lazy="subquery", back_populates="parent"
+    )
+    children_raw = relationship("DbRawTable", lazy="subquery", back_populates="parent")
 
     @classmethod
     def from_sqlite(cls, row: Dict[str, Any]) -> "DBMasterTable":
@@ -185,7 +191,9 @@ class DbReplayTable(Base):
     extra_info = Column(PickleType(pickler=pickle))
 
     master_table_id = Column(Integer, ForeignKey("master.unique_id"))
-    parent = relationship("DBMasterTable", back_populates="children_replay")
+    parent = relationship(
+        "DBMasterTable", lazy="subquery", back_populates="children_replay"
+    )
 
     __mapper_args__ = {}
 
@@ -297,7 +305,9 @@ class DbStratTable(Base):
     strat = Column(PickleType(pickler=pickle))
 
     master_table_id = Column(Integer, ForeignKey("master.unique_id"))
-    parent = relationship("DBMasterTable", back_populates="children_strat")
+    parent = relationship(
+        "DBMasterTable", lazy="subquery", back_populates="children_strat"
+    )
 
     @classmethod
     def from_sqlite(cls, row: Dict[str, Any]) -> "DbStratTable":
@@ -356,7 +366,9 @@ class DbConfigTable(Base):
     config = Column(PickleType(pickler=pickle))
 
     master_table_id = Column(Integer, ForeignKey("master.unique_id"))
-    parent = relationship("DBMasterTable", back_populates="children_config")
+    parent = relationship(
+        "DBMasterTable", lazy="subquery", back_populates="children_config"
+    )
 
     @classmethod
     def from_sqlite(cls, row: Dict[str, Any]) -> "DbConfigTable":
@@ -420,9 +432,15 @@ class DbRawTable(Base):
     extra_data = Column(PickleType(pickler=pickle))
 
     master_table_id = Column(Integer, ForeignKey("master.unique_id"))
-    parent = relationship("DBMasterTable", back_populates="children_raw")
-    children_param = relationship("DbParamTable", back_populates="parent")
-    children_outcome = relationship("DbOutcomeTable", back_populates="parent")
+    parent = relationship(
+        "DBMasterTable", lazy="subquery", back_populates="children_raw"
+    )
+    children_param = relationship(
+        "DbParamTable", lazy="subquery", back_populates="parent"
+    )
+    children_outcome = relationship(
+        "DbOutcomeTable", lazy="subquery", back_populates="parent"
+    )
 
     @classmethod
     def from_sqlite(cls, row: Dict[str, Any]) -> "DbRawTable":
@@ -654,7 +672,9 @@ class DbParamTable(Base):
     param_value = Column(String(50))
 
     iteration_id = Column(Integer, ForeignKey("raw_data.unique_id"))
-    parent = relationship("DbRawTable", back_populates="children_param")
+    parent = relationship(
+        "DbRawTable", lazy="subquery", back_populates="children_param"
+    )
 
     @classmethod
     def from_sqlite(cls, row: Dict[str, Any]) -> "DbParamTable":
@@ -720,7 +740,9 @@ class DbOutcomeTable(Base):
     outcome_value = Column(Float)
 
     iteration_id = Column(Integer, ForeignKey("raw_data.unique_id"))
-    parent = relationship("DbRawTable", back_populates="children_outcome")
+    parent = relationship(
+        "DbRawTable", lazy="subquery", back_populates="children_outcome"
+    )
 
     @classmethod
     def from_sqlite(cls, row: Dict[str, Any]) -> "DbOutcomeTable":

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -1,41 +1,35 @@
 #!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 # All rights reserved.
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-
-import argparse
-import io
+import asyncio
+import json
+from typing import Dict, Union, Optional
 import logging
-import os
-import sys
-import threading
+import concurrent
 import traceback
+import io
+import os
+import argparse
 import warnings
-from typing import Dict, Union
 
-import aepsych.database.db as db
-import aepsych.utils_logging as utils_logging
-import dill
-import numpy as np
-import torch
-from aepsych import version
+from aepsych.database import db
 from aepsych.server.message_handlers import MESSAGE_MAP
-from aepsych.server.message_handlers.handle_ask import ask
 from aepsych.server.message_handlers.handle_setup import configure
+from aepsych import utils_logging, version
+import numpy as np
+import dill
+import torch
 from aepsych.server.replay import (
     get_dataframe_from_replay,
     get_strat_from_replay,
     get_strats_from_replay,
     replay,
 )
-from aepsych.server.sockets import BAD_REQUEST, DummySocket, PySocket
-from aepsych.utils import promote_0d
 
 logger = utils_logging.getLogger(logging.INFO)
-DEFAULT_DESC = "default description"
-DEFAULT_NAME = "default name"
 
 
 def get_next_filename(folder, fname, ext):
@@ -44,139 +38,35 @@ def get_next_filename(folder, fname, ext):
     return f"{folder}/{fname}_{n + 1}.{ext}"
 
 
-class AEPsychServer(object):
-    def __init__(self, socket=None, database_path=None):
-        """Server for doing black box optimization using gaussian processes.
-        Keyword Arguments:
-            socket -- socket object that implements `send` and `receive` for json
-            messages (default: DummySocket()).
-            TODO actually make an abstract interface to subclass from here
-        """
-        if socket is None:
-            self.socket = DummySocket()
-        else:
-            self.socket = socket
-        self.db = None
+class AEPsychServer:
+    def __init__(
+        self,
+        host: str = "0.0.0.0",
+        port: int = 5555,
+        database_path: str = "./databases/default.db",
+        max_workers: Optional[int] = None,
+    ):
+        self.host = host
+        self.port = port
+        self.max_workers = max_workers
+        self.db: db.Database = db.Database(database_path)
         self.is_performing_replay = False
         self.exit_server_loop = False
         self._db_raw_record = None
-        self.db: db.Database = db.Database(database_path)
         self.skip_computations = False
         self.strat_names = None
         self.extensions = None
-
-        if self.db.is_update_required():
-            self.db.perform_updates()
-
         self._strats = []
         self._parnames = []
         self._configs = []
         self._master_records = []
         self.strat_id = -1
-        self._pregen_asks = []
-        self.enable_pregen = False
         self.outcome_names = []
 
-        self.debug = False
-        self.receive_thread = threading.Thread(
-            target=self._receive_send, args=(self.exit_server_loop,), daemon=True
-        )
+        if self.db.is_update_required():
+            self.db.perform_updates()
 
-        self.queue = []
-
-    def cleanup(self):
-        """Close the socket and terminate connection to the server.
-
-        Returns:
-            None
-        """
-        self.socket.close()
-
-    def _receive_send(self, is_exiting: bool) -> None:
-        """Receive messages from the client.
-
-        Args:
-            is_exiting (bool): True to terminate reception of new messages from the client, False otherwise.
-
-        Returns:
-            None
-        """
-        while True:
-            request = self.socket.receive(is_exiting)
-            if request != BAD_REQUEST:
-                self.queue.append(request)
-            if self.exit_server_loop:
-                break
-        logger.info("Terminated input thread")
-
-    def _handle_queue(self) -> None:
-        """Handles the queue of messages received by the server.
-
-        Returns:
-            None
-        """
-        if self.queue:
-            request = self.queue.pop(0)
-            try:
-                result = self.handle_request(request)
-            except Exception as e:
-                error_message = f"Request '{request}' raised error '{e}'!"
-                result = f"server_error, {error_message}"
-                logger.error(f"{error_message}! Full traceback follows:")
-                logger.error(traceback.format_exc())
-            self.socket.send(result)
-        else:
-            if self.can_pregen_ask and (len(self._pregen_asks) == 0):
-                self._pregen_asks.append(ask(self))
-
-    def serve(self) -> None:
-        """Run the server. Note that all configuration outside of socket type and port
-        happens via messages from the client. The server simply forwards messages from
-        the client to its `setup`, `ask` and `tell` methods, and responds with either
-        acknowledgment or other response as needed. To understand the server API, see
-        the docs on the methods in this class.
-
-        Returns:
-            None
-
-        Raises:
-            RuntimeError: if a request from a client has no request type
-            RuntimeError: if a request from a client has no known request type
-            TODO make things a little more robust to bad messages from client; this
-             requires resetting the req/rep queue status.
-
-        """
-        logger.info("Server up, waiting for connections!")
-        logger.info("Ctrl-C to quit!")
-        # yeah we're not sanitizing input at all
-
-        # Start the method to accept a client connection
-        self.socket.accept_client()
-        self.receive_thread.start()
-        while True:
-            self._handle_queue()
-            if self.exit_server_loop:
-                break
-        # Close the socket and terminate with code 0
-        self.cleanup()
-        sys.exit(0)
-
-    def _unpack_strat_buffer(self, strat_buffer):
-        if isinstance(strat_buffer, io.BytesIO):
-            strat = torch.load(strat_buffer, pickle_module=dill)
-            strat_buffer.seek(0)
-        elif isinstance(strat_buffer, bytes):
-            warnings.warn(
-                "Strat buffer is not in bytes format!"
-                + " This is a deprecated format, loading using dill.loads.",
-                DeprecationWarning,
-            )
-            strat = dill.loads(strat_buffer)
-        else:
-            raise RuntimeError("Trying to load strat in unknown format!")
-        return strat
-
-    ### Properties that are set on a per-strat basis
+    #### Properties ####
     @property
     def strat(self):
         if self.strat_id == -1:
@@ -225,10 +115,7 @@ class AEPsychServer(object):
     def n_strats(self):
         return len(self._strats)
 
-    @property
-    def can_pregen_ask(self):
-        return self.strat is not None and self.enable_pregen
-
+    #### Methods to handle parameter configs ####
     def _tensor_to_config(self, next_x):
         stim_per_trial = self.strat.stimuli_per_trial
         dim = self.strat.dim
@@ -297,13 +184,117 @@ class AEPsychServer(object):
 
         return fixed_features
 
-    def __getstate__(self):
-        # nuke the socket since it's not pickleble
-        state = self.__dict__.copy()
-        del state["socket"]
-        del state["db"]
-        return state
+    #### Methods to handle replay ####
+    def replay(self, uuid_to_replay, skip_computations=False):
+        return replay(self, uuid_to_replay, skip_computations)
 
+    def get_strats_from_replay(self, uuid_of_replay=None, force_replay=False):
+        return get_strats_from_replay(self, uuid_of_replay, force_replay)
+
+    def get_strat_from_replay(self, uuid_of_replay=None, strat_id=-1):
+        return get_strat_from_replay(self, uuid_of_replay, strat_id)
+
+    def get_dataframe_from_replay(self, uuid_of_replay=None, force_replay=False):
+        return get_dataframe_from_replay(self, uuid_of_replay, force_replay)
+
+    def _unpack_strat_buffer(self, strat_buffer):
+        if isinstance(strat_buffer, io.BytesIO):
+            strat = torch.load(strat_buffer, pickle_module=dill)
+            strat_buffer.seek(0)
+        elif isinstance(strat_buffer, bytes):
+            warnings.warn(
+                "Strat buffer is not in bytes format!"
+                + " This is a deprecated format, loading using dill.loads.",
+                DeprecationWarning,
+            )
+            strat = dill.loads(strat_buffer)
+        else:
+            raise RuntimeError("Trying to load strat in unknown format!")
+        return strat
+
+    #### Method to handle async server ####
+    def start_blocking(self):
+        """Starts the server in a blocking state in the main thread. Used by the
+        command line interface to start the server for a client in another
+        process or machine."""
+        asyncio.run(self.serve())
+
+    def start_background(self):
+        """Starts the server in a background thread. Used for scripts where the
+        client and server are in the same process."""
+        raise NotImplementedError
+
+    async def serve(self):
+        server = await asyncio.start_server(self.handle_client, self.host, self.port)
+        self.loop = asyncio.get_running_loop()
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=self.max_workers)
+        self.loop.set_default_executor(pool)
+
+        async with server:
+            logging.info(f"Serving on {self.host}:{self.port}")
+            try:
+                await server.serve_forever()
+            except KeyboardInterrupt:
+                exception_type = "CTRL+C"
+                dump_type = "dump"
+                server.write_strats(exception_type)
+                server.generate_debug_info(exception_type, dump_type)
+            except RuntimeError as e:
+                exception_type = "RuntimeError"
+                dump_type = "crashdump"
+                server.write_strats(exception_type)
+                server.generate_debug_info(exception_type, dump_type)
+                raise RuntimeError(e)
+
+    async def handle_client(self, reader, writer):
+        addr = writer.get_extra_info("peername")
+        logger.info(f"Connected to {addr}")
+
+        try:
+            while True:
+                rcv = await reader.read(1024 * 512)
+                message = json.loads(rcv)
+
+                future = self.loop.run_in_executor(None, self.handle_request, message)
+
+                try:
+                    result = await future
+                except Exception as e:
+                    logger.error(f"Error handling message: {message}")
+                    logger.error(traceback.format_exc())
+                    result = {"error": str(e)}
+
+                if isinstance(result, dict):
+                    return_msg = json.dumps(self._simplify_arrays(result)).encode()
+                    writer.write(return_msg)
+                else:
+                    writer.write(str(result).encode())
+
+                await writer.drain()
+        except asyncio.CancelledError:
+            pass
+        finally:
+            logger.info(f"Connection closed for {addr}")
+            writer.close()
+            await writer.wait_closed()
+
+    def handle_request(self, message):
+        type_ = message["type"]
+        result = MESSAGE_MAP[type_](self, message)
+        return result
+
+    def _simplify_arrays(self, message):
+        # Simplify arrays for encoding and sending a message to the client
+        return {
+            k: (
+                v.tolist()
+                if type(v) == np.ndarray
+                else self._simplify_arrays(v) if type(v) is dict else v
+            )
+            for k, v in message.items()
+        }
+
+    #### Methods to handle exiting ####
     def write_strats(self, termination_type):
         if self._db_master_record is not None and self.strat is not None:
             logger.info(f"Dumping strats to DB due to {termination_type}.")
@@ -318,72 +309,15 @@ class AEPsychServer(object):
         logger.exception(f"Got {exception_type}, exiting! Server dump in {fname}")
         dill.dump(self, open(fname, "wb"))
 
-    def handle_request(self, request):
-        if "type" not in request.keys():
-            raise RuntimeError(f"Request {request} contains no request type!")
-        else:
-            type = request["type"]
-            if type in MESSAGE_MAP.keys():
-                logger.info(f"Received msg [{type}]")
-                ret_val = MESSAGE_MAP[type](self, request)
-                return ret_val
-
-            else:
-                exception_message = (
-                    f"unknown type: {type}. Allowed types [{MESSAGE_MAP.keys()}]"
-                )
-
-                raise RuntimeError(exception_message)
-
-    def replay(self, uuid_to_replay, skip_computations=False):
-        return replay(self, uuid_to_replay, skip_computations)
-
-    def get_strats_from_replay(self, uuid_of_replay=None, force_replay=False):
-        return get_strats_from_replay(self, uuid_of_replay, force_replay)
-
-    def get_strat_from_replay(self, uuid_of_replay=None, strat_id=-1):
-        return get_strat_from_replay(self, uuid_of_replay, strat_id)
-
-    def get_dataframe_from_replay(self, uuid_of_replay=None, force_replay=False):
-        return get_dataframe_from_replay(self, uuid_of_replay, force_replay)
-
-
-#! THIS IS WHAT START THE SERVER
-def startServerAndRun(
-    server_class, socket=None, database_path=None, config_path=None, id_of_replay=None
-):
-    server = server_class(socket=socket, database_path=database_path)
-    try:
-        if config_path is not None:
-            with open(config_path) as f:
-                config_str = f.read()
-            configure(server, config_str=config_str)
-
-        if socket is not None:
-            if id_of_replay is not None:
-                server.replay(id_of_replay, skip_computations=True)
-            server.serve()
-        else:
-            if config_path is not None:
-                logger.info(
-                    "You have passed in a config path but this is a replay. If there's a config in the database it will be used instead of the passed in config path."
-                )
-            server.replay(id_of_replay)
-    except KeyboardInterrupt:
-        exception_type = "CTRL+C"
-        dump_type = "dump"
-        server.write_strats(exception_type)
-        server.generate_debug_info(exception_type, dump_type)
-    except RuntimeError as e:
-        exception_type = "RuntimeError"
-        dump_type = "crashdump"
-        server.write_strats(exception_type)
-        server.generate_debug_info(exception_type, dump_type)
-        raise RuntimeError(e)
+    def __getstate__(self):
+        # nuke the socket since it's not pickleble
+        state = self.__dict__.copy()
+        del state["db"]
+        return state
 
 
 def parse_argument():
-    parser = argparse.ArgumentParser(description="AEPsych Server!")
+    parser = argparse.ArgumentParser(description="AEPsych Server")
     parser.add_argument(
         "--port", metavar="N", type=int, default=5555, help="port to serve on"
     )
@@ -415,72 +349,53 @@ def parse_argument():
         "--db",
         type=str,
         help="The database to use if not the default (./databases/default.db).",
-        default=None,
+        default="./databases/default.db",
     )
 
     parser.add_argument(
-        "-r", "--replay", type=str, help="Unique id of the experiment to replay."
-    )
-
-    parser.add_argument(
-        "-m", "--resume", action="store_true", help="Resume server after replay."
+        "-r",
+        "--resume",
+        type=str,
+        help="Unique id of the experiment to replay and resume the server from.",
     )
 
     args = parser.parse_args()
     return args
 
 
-def start_server(server_class, args):
-    logger.info("Starting the AEPsychServer")
+def main():
+    logger.info("Starting AEPsychServer")
     logger.info(f"AEPsych Version: {version.__version__}")
-    try:
-        if "db" in args and args.db is not None:
-            database_path = args.db
-            if "replay" in args and args.replay is not None:
-                logger.info(f"Attempting to replay {args.replay}")
-                if args.resume is True:
-                    sock = PySocket(port=args.port)
-                    logger.info(f"Will resume {args.replay}")
-                else:
-                    sock = None
-                startServerAndRun(
-                    server_class,
-                    socket=sock,
-                    database_path=database_path,
-                    uuid_of_replay=args.replay,
-                    config_path=args.stratconfig,
-                )
-            else:
-                logger.info(f"Setting the database path {database_path}")
-                sock = PySocket(port=args.port)
-                startServerAndRun(
-                    server_class,
-                    database_path=database_path,
-                    socket=sock,
-                    config_path=args.stratconfig,
-                )
-        else:
-            sock = PySocket(port=args.port)
-            startServerAndRun(server_class, socket=sock, config_path=args.stratconfig)
 
-    except (KeyboardInterrupt, SystemExit):
-        logger.exception("Got Ctrl+C, exiting!")
-        sys.exit()
-    except RuntimeError as e:
-        fname = get_next_filename(".", "dump", "pkl")
-        logger.exception(f"CRASHING!! dump in {fname}")
-        raise RuntimeError(e)
-
-
-def main(server_class=AEPsychServer):
     args = parse_argument()
     if args.logs:
         # overide logger path
         log_path = args.logs
-        logger = utils_logging.getLogger(logging.DEBUG, log_path)
-    logger.info(f"Saving logs to path: {log_path}")
-    start_server(server_class, args)
+        logger = utils_logging.getLogger(log_path)
+        logger.info(f"Saving logs to path: {log_path}")
+
+    server = AEPsychServer(
+        host=args.ip,
+        port=args.port,
+        database_path=args.db,
+    )
+
+    if args.stratconfig is not None and args.resume is not None:
+        raise ValueError(
+            "Cannot configure the server with a config file and a resume from a replay at the same time."
+        )
+
+    elif args.stratconfig is not None:
+        configure(server, config_str=args.stratconfig)
+
+    elif args.resume is not None:
+        if args.db is None:
+            raise ValueError("Cannot resume from a replay if no database is given.")
+        server.replay(args.resume, skip_computations=True)
+
+    # Starts the server in a blocking state
+    server.start_blocking()
 
 
 if __name__ == "__main__":
-    main(AEPsychServer)
+    main()

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -34,8 +34,6 @@ class RemoteServerTestCase(unittest.TestCase):
         )
 
     def tearDown(self):
-        self.s.cleanup()
-
         # cleanup the db
         if self.s.db is not None:
             self.s.db.delete_db()

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -501,8 +501,6 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
         self.s = server.AEPsychServer(database_path=database_path)
 
     def tearDown(self):
-        self.s.cleanup()
-
         # cleanup the db
         if self.s.db is not None:
             self.s.db.delete_db()

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -13,6 +13,8 @@ import unittest
 import uuid
 from pathlib import Path
 from unittest.mock import MagicMock
+import asyncio
+from typing import Any, Dict
 
 import aepsych.server as server
 import aepsych.utils_logging as utils_logging
@@ -77,28 +79,39 @@ seed = 123
 """
 
 
-class BaseServerTestCase(unittest.TestCase):
-    # so that this can be overridden for tests that require specific databases.
+class AsyncServerTestBase(unittest.IsolatedAsyncioTestCase):
     @property
     def database_path(self):
         return "./{}_test_server.db".format(str(uuid.uuid4().hex))
 
-    def setUp(self):
+    async def asyncSetUp(self):
+        ip = "0.0.0.0"
+        port = 5555
+
         # setup logger
         server.logger = utils_logging.getLogger(logging.DEBUG, "logs")
-        # random port
-        socket = server.sockets.PySocket(port=0)
+
         # random datebase path name without dashes
         database_path = self.database_path
-        self.s = server.AEPsychServer(socket=socket, database_path=database_path)
+        self.s = server.AEPsychServer(database_path=database_path, host=ip, port=port)
         self.db_name = database_path.split("/")[1]
         self.db_path = database_path
 
-    def tearDown(self):
-        self.s.cleanup()
+        self.server_task = asyncio.create_task(self.s.serve())
+        await asyncio.sleep(0.1)
 
-        # sleep to ensure db is closed
-        time.sleep(0.2)
+        self.reader, self.writer = await asyncio.open_connection(ip, port)
+
+    async def asyncTearDown(self):
+        self.server_task.cancel()
+        try:
+            await self.server_task
+        except asyncio.CancelledError:
+            pass
+
+        self.writer.close()
+
+        await asyncio.sleep(0.2)
 
         # cleanup the db
         if self.s.db is not None:
@@ -107,15 +120,55 @@ class BaseServerTestCase(unittest.TestCase):
             except PermissionError as e:
                 print("Failed to deleted database: ", e)
 
-    def dummy_create_setup(self, server, request=None):
-        request = request or {"test": "test request"}
-        server._db_master_record = server.db.record_setup(
-            description="default description", name="default name", request=request
-        )
+    async def mock_client(self, request: Dict[str, Any]) -> Any:
+        self.writer.write(json.dumps(request).encode())
+        await self.writer.drain()
+
+        response = await self.reader.read(1024 * 512)
+        return response.decode()
 
 
-class ServerTestCase(BaseServerTestCase):
-    def test_final_strat_serialization(self):
+class AsyncServerTestCase(AsyncServerTestBase):
+    async def test_pandadf_dump_single(self):
+        setup_request = {
+            "type": "setup",
+            "version": "0.01",
+            "message": {"config_str": dummy_config},
+        }
+        ask_request = {"type": "ask", "message": ""}
+        tell_request = {
+            "type": "tell",
+            "message": {"config": {"x": [0.5]}, "outcome": 1},
+            "extra_info": {},
+        }
+
+        await self.mock_client(setup_request)
+
+        expected_x = [0, 1, 2, 3]
+        expected_z = list(reversed(expected_x))
+        expected_y = [x % 2 for x in expected_x]
+        i = 0
+        while not self.s.strat.finished:
+            await self.mock_client(ask_request)
+            tell_request["message"]["config"]["x"] = [expected_x[i]]
+            tell_request["message"]["config"]["z"] = [expected_z[i]]
+            tell_request["message"]["outcome"] = expected_y[i]
+            tell_request["extra_info"]["e1"] = 1
+            tell_request["extra_info"]["e2"] = 2
+            i = i + 1
+            await self.mock_client(tell_request)
+
+        unique_id = self.s.db.get_master_records()[-1].unique_id
+        out_df = self.s.get_dataframe_from_replay(unique_id)
+        self.assertTrue((out_df.x == expected_x).all())
+        self.assertTrue((out_df.z == expected_z).all())
+        self.assertTrue((out_df.response == expected_y).all())
+        self.assertTrue((out_df.e1 == [1] * 4).all())
+        self.assertTrue((out_df.e2 == [2] * 4).all())
+        self.assertTrue("post_mean" in out_df.columns)
+        self.assertTrue("post_var" in out_df.columns)
+
+    async def test_final_strat_serialization(self):
         setup_request = {
             "type": "setup",
             "version": "0.01",
@@ -126,10 +179,10 @@ class ServerTestCase(BaseServerTestCase):
             "type": "tell",
             "message": {"config": {"x": [0.5]}, "outcome": 1},
         }
-        self.s.handle_request(setup_request)
+        await self.mock_client(setup_request)
         while not self.s.strat.finished:
-            self.s.handle_request(ask_request)
-            self.s.handle_request(tell_request)
+            await self.mock_client(ask_request)
+            await self.mock_client(tell_request)
 
         unique_id = self.s.db.get_master_records()[-1].unique_id
         stored_strat = self.s.get_strat_from_replay(unique_id)
@@ -146,7 +199,7 @@ class ServerTestCase(BaseServerTestCase):
                 self.s.strat.model.covar_module.lengthscale,
             )
 
-    def test_pandadf_dump_single(self):
+    async def test_pandadf_dump_single(self):
         setup_request = {
             "type": "setup",
             "version": "0.01",
@@ -158,20 +211,20 @@ class ServerTestCase(BaseServerTestCase):
             "message": {"config": {"x": [0.5]}, "outcome": 1},
             "extra_info": {},
         }
-        self.s.handle_request(setup_request)
+        await self.mock_client(setup_request)
         expected_x = [0, 1, 2, 3]
         expected_z = list(reversed(expected_x))
         expected_y = [x % 2 for x in expected_x]
         i = 0
         while not self.s.strat.finished:
-            self.s.handle_request(ask_request)
+            await self.mock_client(ask_request)
             tell_request["message"]["config"]["x"] = [expected_x[i]]
             tell_request["message"]["config"]["z"] = [expected_z[i]]
             tell_request["message"]["outcome"] = expected_y[i]
             tell_request["extra_info"]["e1"] = 1
             tell_request["extra_info"]["e2"] = 2
             i = i + 1
-            self.s.handle_request(tell_request)
+            await self.mock_client(tell_request)
 
         unique_id = self.s.db.get_master_records()[-1].unique_id
         out_df = self.s.get_dataframe_from_replay(unique_id)
@@ -183,7 +236,7 @@ class ServerTestCase(BaseServerTestCase):
         self.assertTrue("post_mean" in out_df.columns)
         self.assertTrue("post_var" in out_df.columns)
 
-    def test_pandadf_dump_multistrat(self):
+    async def test_pandadf_dump_multistrat(self):
         setup_request = {
             "type": "setup",
             "version": "0.01",
@@ -199,16 +252,16 @@ class ServerTestCase(BaseServerTestCase):
         expected_z = list(reversed(expected_x))
         expected_y = [x % 2 for x in expected_x]
         i = 0
-        self.s.handle_request(setup_request)
+        await self.mock_client(setup_request)
         while not self.s.strat.finished:
-            self.s.handle_request(ask_request)
+            await self.mock_client(ask_request)
             tell_request["message"]["config"]["x"] = [expected_x[i]]
             tell_request["message"]["config"]["z"] = [expected_z[i]]
             tell_request["message"]["outcome"] = expected_y[i]
             tell_request["extra_info"]["e1"] = 1
             tell_request["extra_info"]["e2"] = 2
             i = i + 1
-            self.s.handle_request(tell_request)
+            await self.mock_client(tell_request)
 
         unique_id = self.s.db.get_master_records()[-1].unique_id
         out_df = self.s.get_dataframe_from_replay(unique_id)
@@ -221,7 +274,7 @@ class ServerTestCase(BaseServerTestCase):
         self.assertTrue("post_mean" in out_df.columns)
         self.assertTrue("post_var" in out_df.columns)
 
-    def test_pandadf_dump_flat(self):
+    async def test_pandadf_dump_flat(self):
         """
         This test handles the case where the config values are flat
         scalars and not lists
@@ -237,20 +290,20 @@ class ServerTestCase(BaseServerTestCase):
             "message": {"config": {"x": [0.5]}, "outcome": 1},
             "extra_info": {},
         }
-        self.s.handle_request(setup_request)
+        await self.mock_client(setup_request)
         expected_x = [0, 1, 2, 3]
         expected_z = list(reversed(expected_x))
         expected_y = [x % 2 for x in expected_x]
         i = 0
         while not self.s.strat.finished:
-            self.s.handle_request(ask_request)
+            await self.mock_client(ask_request)
             tell_request["message"]["config"]["x"] = expected_x[i]
             tell_request["message"]["config"]["z"] = expected_z[i]
             tell_request["message"]["outcome"] = expected_y[i]
             tell_request["extra_info"]["e1"] = 1
             tell_request["extra_info"]["e2"] = 2
             i = i + 1
-            self.s.handle_request(tell_request)
+            await self.mock_client(tell_request)
 
         unique_id = self.s.db.get_master_records()[-1].unique_id
         out_df = self.s.get_dataframe_from_replay(unique_id)
@@ -262,52 +315,7 @@ class ServerTestCase(BaseServerTestCase):
         self.assertTrue("post_mean" in out_df.columns)
         self.assertTrue("post_var" in out_df.columns)
 
-    def test_receive(self):
-        """test_receive - verifies the receive is working when server receives unexpected messages"""
-
-        message1 = b"\x16\x03\x01\x00\xaf\x01\x00\x00\xab\x03\x03\xa9\x80\xcc"  # invalid message
-        message2 = b"\xec\xec\x14M\xfb\xbd\xac\xe7jF\xbe\xf9\x9bM\x92\x15b\xb5"  # invalid message
-        message3 = {"message": {"target": "test request"}}  # valid message
-        message_list = [message1, message2, json.dumps(message3)]
-
-        self.s.socket.conn = MagicMock()
-
-        for i, message in enumerate(message_list):
-            select.select = MagicMock(return_value=[[self.s.socket.conn], [], []])
-            self.s.socket.conn.recv = MagicMock(return_value=message)
-            if i != 2:
-                self.assertEqual(self.s.socket.receive(False), BAD_REQUEST)
-            else:
-                self.assertEqual(self.s.socket.receive(False), message3)
-
-    def test_error_handling(self):
-        # double brace escapes, single brace to substitute, so we end up with 3 braces
-        request = f"{{{BAD_REQUEST}}}"
-
-        expected_error = f"server_error, Request '{request}' raised error ''str' object has no attribute 'keys''!"
-
-        self.s.socket.accept_client = MagicMock()
-
-        self.s.socket.receive = MagicMock(return_value=request)
-        self.s.socket.send = MagicMock()
-        self.s.exit_server_loop = True
-        with self.assertRaises(SystemExit):
-            self.s.serve()
-        self.s.socket.send.assert_called_once_with(expected_error)
-
-    def test_queue(self):
-        """Test to see that the queue is being handled correctly"""
-
-        self.s.socket.accept_client = MagicMock()
-        ask_request = {"type": "ask", "message": ""}
-        self.s.socket.receive = MagicMock(return_value=ask_request)
-        self.s.socket.send = MagicMock()
-        self.s.exit_server_loop = True
-        with self.assertRaises(SystemExit):
-            self.s.serve()
-        assert len(self.s.queue) == 0
-
-    def test_replay(self):
+    async def test_replay(self):
         exp_config = """
             [common]
             lb = [0]
@@ -341,15 +349,14 @@ class ServerTestCase(BaseServerTestCase):
         }
         exit_request = {"message": "", "type": "exit"}
 
-        self.s.handle_request(setup_request)
+        await self.mock_client(setup_request)
         while not self.s.strat.finished:
-            self.s.handle_request(ask_request)
-            self.s.handle_request(tell_request)
+            await self.mock_client(ask_request)
+            await self.mock_client(tell_request)
 
-        self.s.handle_request(exit_request)
+        await self.mock_client(exit_request)
 
-        socket = server.sockets.PySocket(port=0)
-        serv = server.AEPsychServer(socket=socket, database_path=self.db_path)
+        serv = server.AEPsychServer(database_path=self.db_path)
         exp_ids = [rec.unique_id for rec in serv.db.get_master_records()]
 
         serv.replay(exp_ids[-1], skip_computations=True)
@@ -359,7 +366,7 @@ class ServerTestCase(BaseServerTestCase):
         self.assertTrue(strat.finished)
         self.assertTrue(strat.x.shape[0] == 4)
 
-    def test_string_parameter(self):
+    async def test_string_parameter(self):
         string_config = """
             [common]
             parnames = [x, y, z]
@@ -405,16 +412,17 @@ class ServerTestCase(BaseServerTestCase):
             "type": "tell",
             "message": {"config": {"x": [0.5], "y": ["blue"], "z": [50]}, "outcome": 1},
         }
-        self.s.handle_request(setup_request)
+        await self.mock_client(setup_request)
         while not self.s.strat.finished:
-            response = self.s.handle_request(ask_request)
+            response = await self.mock_client(ask_request)
+            response = json.loads(response)
             self.assertTrue(response["config"]["y"][0] == "blue")
-            self.s.handle_request(tell_request)
+            await self.mock_client(tell_request)
 
         self.assertTrue(len(self.s.strat.lb) == 2)
         self.assertTrue(len(self.s.strat.ub) == 2)
 
-    def test_metadata(self):
+    async def test_metadata(self):
         setup_request = {
             "type": "setup",
             "version": "0.01",
@@ -425,10 +433,10 @@ class ServerTestCase(BaseServerTestCase):
             "type": "tell",
             "message": {"config": {"x": [0.5]}, "outcome": 1},
         }
-        self.s.handle_request(setup_request)
+        await self.mock_client(setup_request)
         while not self.s.strat.finished:
-            self.s.handle_request(ask_request)
-            self.s.handle_request(tell_request)
+            await self.mock_client(ask_request)
+            await self.mock_client(tell_request)
 
         master_record = self.s.db.get_master_records()[-1]
         extra_metadata = json.loads(master_record.extra_metadata)
@@ -443,7 +451,7 @@ class ServerTestCase(BaseServerTestCase):
         self.assertTrue(extra_metadata["extra"] == "data that is arbitrary")
         self.assertTrue("experiment_id" not in extra_metadata)
 
-    def test_extension_server(self):
+    async def test_extension_server(self):
         extension_path = Path(__file__).parent.parent.parent
         extension_path = extension_path / "extensions_example" / "new_objects.py"
 
@@ -470,8 +478,8 @@ class ServerTestCase(BaseServerTestCase):
             "message": {"config_str": config_str},
         }
 
-        with self.assertLogs(level=logging.INFO) as logs:
-            self.s.handle_request(setup_request)
+        with self.assertLogs() as logs:
+            await self.mock_client(setup_request)
             outputs = ";".join(logs.output)
             self.assertTrue(str(extension_path) in outputs)
 
@@ -480,6 +488,88 @@ class ServerTestCase(BaseServerTestCase):
 
         self.assertTrue(one == 1)
         self.assertTrue(strat.generator._base_obj.__class__.__name__ == "OnesGenerator")
+
+
+class BaseServerTestCase(unittest.TestCase):
+    # so that this can be overridden for tests that require specific databases.
+    @property
+    def database_path(self):
+        return "./{}_test_server.db".format(str(uuid.uuid4().hex))
+
+    def setUp(self):
+        # setup logger
+        server.logger = utils_logging.getLogger("logs")
+
+        # random datebase path name without dashes
+        database_path = self.database_path
+        self.s = server.AEPsychServer(database_path=database_path)
+        self.db_name = database_path.split("/")[1]
+        self.db_path = database_path
+
+    def tearDown(self):
+        # sleep to ensure db is closed
+        time.sleep(0.2)
+
+        # cleanup the db
+        if self.s.db is not None:
+            try:
+                self.s.db.delete_db()
+            except PermissionError as e:
+                print("Failed to deleted database: ", e)
+
+    def dummy_create_setup(self, server, request=None):
+        request = request or {"test": "test request"}
+        server._db_master_record = server.db.record_setup(
+            description="default description", name="default name", request=request
+        )
+
+
+class ServerTestCase(BaseServerTestCase):
+
+    def test_receive(self):
+        """test_receive - verifies the receive is working when server receives unexpected messages"""
+
+        message1 = b"\x16\x03\x01\x00\xaf\x01\x00\x00\xab\x03\x03\xa9\x80\xcc"  # invalid message
+        message2 = b"\xec\xec\x14M\xfb\xbd\xac\xe7jF\xbe\xf9\x9bM\x92\x15b\xb5"  # invalid message
+        message3 = {"message": {"target": "test request"}}  # valid message
+        message_list = [message1, message2, json.dumps(message3)]
+
+        self.s.socket.conn = MagicMock()
+
+        for i, message in enumerate(message_list):
+            select.select = MagicMock(return_value=[[self.s.socket.conn], [], []])
+            self.s.socket.conn.recv = MagicMock(return_value=message)
+            if i != 2:
+                self.assertEqual(self.s.socket.receive(False), BAD_REQUEST)
+            else:
+                self.assertEqual(self.s.socket.receive(False), message3)
+
+    def test_error_handling(self):
+        # double brace escapes, single brace to substitute, so we end up with 3 braces
+        request = f"{{{BAD_REQUEST}}}"
+
+        expected_error = f"server_error, Request '{request}' raised error ''str' object has no attribute 'keys''!"
+
+        self.s.socket.accept_client = MagicMock()
+
+        self.s.socket.receive = MagicMock(return_value=request)
+        self.s.socket.send = MagicMock()
+        self.s.exit_server_loop = True
+        with self.assertRaises(SystemExit):
+            self.s.serve()
+        self.s.socket.send.assert_called_once_with(expected_error)
+
+    def test_queue(self):
+        """Test to see that the queue is being handled correctly"""
+
+        self.s.socket.accept_client = MagicMock()
+        ask_request = {"type": "ask", "message": ""}
+        self.s.socket.receive = MagicMock(return_value=ask_request)
+        self.s.socket.send = MagicMock()
+        self.s.exit_server_loop = True
+        with self.assertRaises(SystemExit):
+            self.s.serve()
+        assert len(self.s.queue) == 0
 
 
 if __name__ == "__main__":

--- a/tests/test_datafetcher.py
+++ b/tests/test_datafetcher.py
@@ -98,9 +98,6 @@ class DataFetcherTestCase(unittest.TestCase):
         # setup logger
         server.logger = utils_logging.getLogger(logging.DEBUG, "logs")
 
-        # random port
-        socket = server.sockets.PySocket(port=0)
-
         database_path = Path(__file__).parent / "test_databases" / "1000_outcome.db"
 
         dst_db_path = Path("./{}.db".format(str(uuid.uuid4().hex)))
@@ -109,7 +106,7 @@ class DataFetcherTestCase(unittest.TestCase):
         time.sleep(0.1)
         self.assertTrue(dst_db_path.is_file())
 
-        self.s = server.AEPsychServer(socket=socket, database_path=dst_db_path)
+        self.s = server.AEPsychServer(database_path=dst_db_path)
 
         setup_message = {
             "type": "setup",
@@ -125,8 +122,6 @@ class DataFetcherTestCase(unittest.TestCase):
 
     def tearDown(self):
         time.sleep(0.1)
-
-        self.s.cleanup()
         self.s.db.delete_db()
 
     def test_create_from_config(self):


### PR DESCRIPTION

Summary: To allow db to be accessible across threads, sessions need to be scoped carefully.

Test Plan:
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebookresearch/aepsych/pull/637).
* #640
* #639
* #638
* __->__ #637
* #636