### PR TITLE
Fix array handling from server to support multi stim returns

### DIFF
--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -249,14 +249,7 @@ class AEPsychServer(object):
         config = {}
         for i, name in enumerate(self.parnames):
             val = next_x[:, i]
-            if isinstance(val, str):
-                config[name] = [val]
-            elif isinstance(val, (int, float)):
-                config[name] = [float(val)]
-            elif isinstance(val[0], str):
-                config[name] = val
-            else:
-                config[name] = list(np.array(val, dtype="float64"))
+            config[name] = val.tolist()
         return config
 
     def _config_to_tensor(self, config):


### PR DESCRIPTION
Summary: Multistimuli experiments weren’t able to return to the client because the _tensor_to_config method didn’t handle nested object numpy arrays correctly. This fixes it.

Differential Revision: D69474480


