### PR TITLE
implement AffinePosteriorTransform

### DIFF
--- a/aepsych/acquisition/objective/__init__.py
+++ b/aepsych/acquisition/objective/__init__.py
@@ -8,6 +8,7 @@
 import sys
 
 from ...config import Config
+from .multi_outcome import AffinePosteriorTransform
 from .objective import (
     AEPsychObjective,
     FloorGumbelObjective,
@@ -25,6 +26,7 @@ __all__ = [
     "ProbitObjective",
     "SemiPProbabilityObjective",
     "SemiPThresholdObjective",
+    "AffinePosteriorTransform",
 ]
 
 Config.register_module(sys.modules[__name__])

--- a/aepsych/acquisition/objective/multi_outcome.py
+++ b/aepsych/acquisition/objective/multi_outcome.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from typing import Any, Dict, Optional
+
+import torch
+from aepsych.config import Config, ConfigurableMixin
+from botorch.acquisition.objective import ScalarizedPosteriorTransform
+
+
+class AffinePosteriorTransform(ScalarizedPosteriorTransform, ConfigurableMixin):
+    @classmethod
+    def get_config_options(
+        cls,
+        config: Config,
+        name: Optional[str] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Return a dictionary of the relevant options to initialize this class from the
+        config, even if it is outside of the named section. By default, this will look
+        for options in name based on the __init__'s arguments/defaults.
+
+        Args:
+            config (Config): Config to look for options in.
+            name (str, optional): Primary section to look for options for this class and
+                the name to infer options from other sections in the config.
+            options (Dict[str, Any], optional): Options to override from the config,
+                defaults to None.
+
+
+        Return:
+            Dict[str, Any]: A dictionary of options to initialize this class.
+        """
+        name = name or cls.__name__
+        options = super().get_config_options(config, name, options)
+
+        if "weights" not in options:
+            outcomes = config.getlist("common", "outcome_types", element_type=str)
+            options["weights"] = torch.ones(len(outcomes)) / len(outcomes)
+
+        return options

--- a/aepsych/models/model_protocol.py
+++ b/aepsych/models/model_protocol.py
@@ -50,8 +50,7 @@ class ModelProtocol(Protocol):
     def predict_transform(
         self,
         x: torch.Tensor,
-        transformed_posterior_cls: Optional[type[TransformedPosterior]] = None,
-        **transform_kwargs,
+        **kwargs,
     ):
         pass
 


### PR DESCRIPTION
Summary: This is a thin wrapper around Botorch's ScalarizedPosteriorTransform that allows one to combine multiple outcomes into a single weighted outcome for optimization.

Differential Revision: D69137323


