### PR TITLE
Ensure that parameter transformed wrapped objects can be fully pickled

### DIFF
--- a/aepsych/server/replay.py
+++ b/aepsych/server/replay.py
@@ -82,8 +82,7 @@ def get_strats_from_replay(server, uuid_of_replay=None, force_replay=False):
                 strat.model.fit(strat.x, strat.y)
         return server._strats
     else:
-        strat_buffers = server.db.get_strats_for(uuid_of_replay)
-        return [server._unpack_strat_buffer(sb) for sb in strat_buffers]
+        return server.db.get_strats_for(uuid_of_replay)
 
 
 def get_strat_from_replay(server, uuid_of_replay=None, strat_id=-1):
@@ -98,9 +97,9 @@ def get_strat_from_replay(server, uuid_of_replay=None, strat_id=-1):
         else:
             raise RuntimeError("Server has no experiment records!")
 
-    strat_buffer = server.db.get_strat_for(uuid_of_replay, strat_id)
-    if strat_buffer is not None:
-        return server._unpack_strat_buffer(strat_buffer)
+    strats = server.db.get_strat_for(uuid_of_replay, strat_id)
+    if strats is not None:
+        return strats
     else:
         warnings.warn(
             "No final strat found (likely due to old DB,"

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -161,21 +161,6 @@ class AEPsychServer(object):
         self.cleanup()
         sys.exit(0)
 
-    def _unpack_strat_buffer(self, strat_buffer):
-        if isinstance(strat_buffer, io.BytesIO):
-            strat = torch.load(strat_buffer, pickle_module=dill)
-            strat_buffer.seek(0)
-        elif isinstance(strat_buffer, bytes):
-            warnings.warn(
-                "Strat buffer is not in bytes format!"
-                + " This is a deprecated format, loading using dill.loads.",
-                DeprecationWarning,
-            )
-            strat = dill.loads(strat_buffer)
-        else:
-            raise RuntimeError("Trying to load strat in unknown format!")
-        return strat
-
     ### Properties that are set on a per-strat basis
     @property
     def strat(self):

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -477,6 +477,10 @@ class ParameterTransformedGenerator(ParameterTransformWrapper, ConfigurableMixin
                 f"{self._base_obj.__class__.__name__} has no attribute 'eval'"
             )
 
+    def __reduce__(self):
+        # Helps pickle work (not dill)
+        return (ParameterTransformedGenerator, (self._base_obj, self.transforms))
+
     @classmethod
     def get_config_options(
         cls,
@@ -724,6 +728,10 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
             warnings.warn(
                 f"{self._base_obj.__class__.__name__} has no attribute 'eval'"
             )
+
+    def __reduce__(self):
+        # Helps pickle work (not dill)
+        return (ParameterTransformedModel, (self._base_obj, self.transforms))
 
     @classmethod
     def get_config_options(


### PR DESCRIPTION
Summary: Give them the __reduce__ special method to provide instructions on how to recreate the classes.

Differential Revision: D70126921


