### PR TITLE
Update ordinal gp to follow the rest of the model API

### DIFF
--- a/aepsych/factory/__init__.py
+++ b/aepsych/factory/__init__.py
@@ -9,6 +9,7 @@ import sys
 
 from ..config import Config
 from .default import default_mean_covar_factory
+from .ordinal import ordinal_mean_covar_factory
 from .pairwise import pairwise_mean_covar_factory
 from .song import song_mean_covar_factory
 
@@ -23,6 +24,7 @@ TODO write a modular AEPsych tutorial.
 
 __all__ = [
     "default_mean_covar_factory",
+    "ordinal_mean_covar_factory",
     "song_mean_covar_factory",
     "pairwise_mean_covar_factory",
 ]

--- a/aepsych/factory/ordinal.py
+++ b/aepsych/factory/ordinal.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from configparser import NoOptionError
+from typing import Tuple
+
+import gpytorch
+from aepsych.config import Config
+
+from .default import default_mean_covar_factory
+
+
+def ordinal_mean_covar_factory(
+    config: Config,
+) -> Tuple[gpytorch.means.ConstantMean, gpytorch.kernels.ScaleKernel]:
+    """Create a mean and covariance function for ordinal GPs.
+
+    Args:
+        config (Config): Config object containing bounds.
+
+    Returns:
+        Tuple[gpytorch.means.ConstantMean, gpytorch.kernels.ScaleKernel]: A tuple containing
+        the mean function (ConstantMean) and the covariance function (ScaleKernel).
+    """
+
+    try:
+        base_factory = config.getobj("ordinal_mean_covar_factory", "base_factory")
+    except NoOptionError:
+        base_factory = default_mean_covar_factory
+
+    _, base_covar = base_factory(config)
+
+    mean = gpytorch.means.ZeroMean()  # wlog since ordinal is shift-invariant
+
+    if isinstance(base_covar, gpytorch.kernels.ScaleKernel):
+        covar = base_covar.base_kernel
+    else:
+        covar = base_covar
+
+    return mean, covar

--- a/aepsych/likelihoods/ordinal.py
+++ b/aepsych/likelihoods/ordinal.py
@@ -45,7 +45,9 @@ class OrdinalLikelihood(Likelihood, ConfigurableMixin):
             self.raw_cutpoint_deltas
         )
         # for identification, the first cutpoint is 0
-        return torch.cat((torch.tensor([0]), torch.cumsum(cutpoint_deltas, 0)))
+        return torch.cat(
+            (torch.tensor([0]).to(cutpoint_deltas), torch.cumsum(cutpoint_deltas, 0))
+        )
 
     def forward(self, function_samples: torch.Tensor, *params, **kwargs) -> Categorical:
         """Forward pass for Ordinal
@@ -58,7 +60,9 @@ class OrdinalLikelihood(Likelihood, ConfigurableMixin):
         """
 
         # this whole thing can probably be some clever batched thing, meh
-        probs = torch.zeros(*function_samples.size(), self.n_levels)
+        probs = torch.zeros(*function_samples.size(), self.n_levels).to(
+            function_samples
+        )
 
         probs[..., 0] = self.link(self.cutpoints[0] - function_samples)
 

--- a/aepsych/models/__init__.py
+++ b/aepsych/models/__init__.py
@@ -11,6 +11,7 @@ from ..config import Config
 from .gp_classification import GPClassificationModel
 from .gp_regression import GPRegressionModel
 from .monotonic_projection_gp import MonotonicProjectionGP
+from .ordinal_gp import OrdinalGPModel
 from .pairwise_probit import PairwiseProbitModel
 from .semi_p import (
     HadamardSemiPModel,
@@ -22,6 +23,7 @@ from .variationalgp import VariationalGPModel
 __all__ = [
     "GPClassificationModel",
     "GPRegressionModel",
+    "OrdinalGPModel",
     "MonotonicProjectionGP",
     "HadamardSemiPModel",
     "SemiParametricGPModel",

--- a/aepsych/models/ordinal_gp.py
+++ b/aepsych/models/ordinal_gp.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import gpytorch
+import torch
+from aepsych.likelihoods import OrdinalLikelihood
+from aepsych.models import GPClassificationModel
+
+
+class OrdinalGPModel(GPClassificationModel):
+    """
+    Convenience wrapper for GPClassificationModel that hardcodes
+    an ordinal likelihood, better priors for this setting, and
+    adds a convenience method for computing outcome probabilities.
+
+    TODO: at some point we should refactor posteriors so that things like
+    OrdinalPosterior and MonotonicPosterior don't have to have their own
+    model classes.
+    """
+
+    outcome_type = "ordinal"
+
+    def __init__(self, likelihood=None, *args, **kwargs):
+        """Initialize the OrdinalGPModel
+
+        Args:
+            likelihood (Likelihood): The likelihood function to use. If None defaults to
+                Ordinal likelihood.
+        """
+        covar_module = kwargs.pop("covar_module", None)
+        dim = kwargs.get("dim")
+        if covar_module is None:
+            ls_prior = gpytorch.priors.GammaPrior(concentration=1.5, rate=3.0)
+            ls_prior_mode = (ls_prior.concentration - 1) / ls_prior.rate
+            ls_constraint = gpytorch.constraints.Positive(
+                transform=None, initial_value=ls_prior_mode
+            )
+
+            # no outputscale due to shift identifiability in d.
+            covar_module = gpytorch.kernels.RBFKernel(
+                lengthscale_prior=ls_prior,
+                lengthscale_constraint=ls_constraint,
+                ard_num_dims=dim,
+            )
+
+        if likelihood is None:
+            likelihood = OrdinalLikelihood(n_levels=5)
+        super().__init__(
+            *args,
+            covar_module=covar_module,
+            likelihood=likelihood,
+            **kwargs,
+        )
+
+    def predict_probs(self, xgrid: torch.Tensor) -> torch.Tensor:
+        """Predict probabilities of each ordinal level at xgrid
+
+        Args:
+            xgrid (torch.Tensor): Tensor of input points to predict at
+
+        Returns:
+            torch.Tensor: Tensor of probabilities of each ordinal level at xgrid
+        """
+        fmean, fvar = self.predict(xgrid)
+        return self.calculate_probs(fmean, fvar)
+
+    def calculate_probs(self, fmean: torch.Tensor, fvar: torch.Tensor) -> torch.Tensor:
+        """Calculate probabilities of each ordinal level given a mean and variance
+
+        Args:
+            fmean (torch.Tensor): Mean of the latent function
+            fvar (torch.Tensor): Variance of the latent function
+
+        Returns:
+            torch.Tensor: Tensor of probabilities of each ordinal level
+        """
+        fsd = torch.sqrt(1 + fvar)
+        probs = torch.zeros(*fmean.size(), self.likelihood.n_levels)
+
+        probs[..., 0] = self.likelihood.link(
+            (self.likelihood.cutpoints[0] - fmean) / fsd
+        )
+
+        for i in range(1, self.likelihood.n_levels - 1):
+            probs[..., i] = self.likelihood.link(
+                (self.likelihood.cutpoints[i] - fmean) / fsd
+            ) - self.likelihood.link((self.likelihood.cutpoints[i - 1] - fmean) / fsd)
+        probs[..., -1] = 1 - self.likelihood.link(
+            (self.likelihood.cutpoints[-1] - fmean) / fsd
+        )
+        return probs

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -129,6 +129,9 @@ def get_extremum(
             tmp[key] = tensor[key].item()
         locked_dims = tmp
 
+        # Transform bounds
+        bounds = model.transforms.transform(bounds)
+
     if model.num_outputs > 1 and posterior_transform is None:
         if weights is None:
             weights = torch.Tensor([1] * model.num_outputs)

--- a/aepsych/strategy/strategy.py
+++ b/aepsych/strategy/strategy.py
@@ -162,9 +162,6 @@ class Strategy(ConfigurableMixin):
         self.keep_most_recent = keep_most_recent
 
         self.transforms = transforms
-        if self.transforms is not None:
-            self.lb = self.transforms.transform(self.lb.unsqueeze(0))[0]
-            self.ub = self.transforms.transform(self.ub.unsqueeze(0))[0]
 
         self.min_post_range = min_post_range
         if self.min_post_range is not None:
@@ -172,11 +169,6 @@ class Strategy(ConfigurableMixin):
             self.eval_grid = make_scaled_sobol(
                 lb=self.lb, ub=self.ub, size=self._n_eval_points
             )
-
-            # this grid needs to be in untransformed space because it goes through a
-            # transform wrapped model
-            if self.transforms is not None:
-                self.eval_grid = self.transforms.untransform(self.eval_grid)
 
         # similar to ub/lb/grid, x is in raw parameter space
         self.x: Optional[torch.Tensor] = None

--- a/configs/ordinal_exploration_example.ini
+++ b/configs/ordinal_exploration_example.ini
@@ -1,0 +1,48 @@
+### Example config for ordinal (likert) data
+# Assuming you are learning a latent value from k-point scores,  the
+# only things that need to be changed for a
+# typical experiment are:
+# 1. parnames, lb and ub under [common], and optionally target.
+# 2. min_asks under init_strat
+# 3. n_levels under OrdinalLikelihood
+
+## The common section includes global server parameters and parameters
+## reused in multiple other classes
+[common]
+parnames = [par1, par2] # names of the parameters
+stimuli_per_trial = 1 # the number of stimuli shown in each trial; 1 for single, or 2 for pairwise experiments
+outcome_types = [ordinal]
+strategy_names = [init_strat] # The strategies that will be used, corresponding to the named sections below
+
+[par1]
+par_type = continuous
+lower_bound = -1
+upper_bound = 1
+
+[par2]
+par_type = continuous
+lower_bound = -1
+upper_bound = 1
+
+# Configuration for the initialization strategy, which we use to gather initial points
+# before we start doing model-based acquisition
+[init_strat]
+min_asks = 50 # number of sobol trials to run
+generator = SobolGenerator # The generator class used to generate new parameter values
+model = OrdinalGPModel
+refit_every = 50
+
+## Below this section are configurations of all the classes defined in the section above,
+## matching the API in the code.
+
+## OrdinalGPModel model settings.
+[OrdinalGPModel]
+# Number of inducing points for approximate inference. 100 is fine for 2d and overkill for 1d;
+# for larger dimensions, scale this up.
+inducing_size = 100
+# ordinal_mean_covar_factory has better defaults for the ordinal setting than the default factory,
+mean_covar_factory = ordinal_mean_covar_factory
+likelihood = OrdinalLikelihood
+
+[OrdinalLikelihood]
+n_levels = 5

--- a/tests/models/test_ordinal_gp.py
+++ b/tests/models/test_ordinal_gp.py
@@ -1,0 +1,115 @@
+import unittest
+
+import numpy as np
+import torch
+from aepsych.generators import OptimizeAcqfGenerator, SobolGenerator
+from aepsych.likelihoods import OrdinalLikelihood
+from aepsych.models import OrdinalGPModel
+from aepsych.strategy import SequentialStrategy, Strategy
+from aepsych.transforms import (
+    ParameterTransformedGenerator,
+    ParameterTransformedModel,
+    ParameterTransforms,
+)
+from aepsych.transforms.ops import NormalizeScale
+from botorch.acquisition import qLogNoisyExpectedImprovement
+from sklearn.datasets import make_regression
+
+
+class OrdinalGPTest(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(1)
+        torch.manual_seed(1)
+        X, y, coeff = make_regression(
+            n_samples=100,
+            n_features=2,
+            n_informative=2,
+            random_state=1,
+            coef=True,
+        )
+
+        self.X, self.y, self.coeff = (
+            torch.Tensor(X),
+            torch.Tensor(y),
+            torch.Tensor(coeff),
+        )
+
+        # Remap y to an ordinal response via binning
+        self.n_bins = 7
+        _, self.edges = torch.histogram(self.y, bins=self.n_bins - 1)
+        self.y = torch.bucketize(self.y, self.edges, right=True) - 1
+
+        # Reused transform
+        self.lb = torch.tensor([-3.0, -3.0])
+        self.ub = torch.tensor([3.0, 3.0])
+        self.transform = ParameterTransforms(
+            normalize=NormalizeScale(d=2, bounds=torch.stack([self.lb, self.ub]))
+        )
+
+    def simulate_response(self, x, std=0.5):
+        # Simulate noisy ordinal response
+        x = x + torch.normal(torch.zeros_like(x), torch.ones_like(x) * std)
+        y = torch.sum(x * self.coeff, dim=1)
+        return torch.clamp(
+            torch.bucketize(y, self.edges) - 1, min=0, max=self.n_bins - 1
+        )
+
+    def test_ordinal_strategy(self):
+        n_init = 30
+        n_opt = 2
+
+        # Create strategy
+        sobol_gen = ParameterTransformedGenerator(
+            SobolGenerator,
+            transforms=self.transform,
+            lb=self.lb,
+            ub=self.ub,
+        )
+        acqf_gen = ParameterTransformedGenerator(
+            OptimizeAcqfGenerator,
+            transforms=self.transform,
+            lb=self.lb,
+            ub=self.ub,
+            acqf=qLogNoisyExpectedImprovement,
+        )
+        model = ParameterTransformedModel(
+            OrdinalGPModel,
+            transforms=self.transform,
+            dim=2,
+            likelihood=OrdinalLikelihood(n_levels=self.n_bins),
+        )
+
+        strat_list = [
+            Strategy(
+                lb=self.lb,
+                ub=self.ub,
+                min_asks=n_init,
+                generator=sobol_gen,
+                stimuli_per_trial=1,
+                outcome_types=["ordinal"],
+                transforms=self.transform,
+            ),
+            Strategy(
+                lb=self.lb,
+                ub=self.ub,
+                model=model,
+                generator=acqf_gen,
+                min_asks=n_opt,
+                stimuli_per_trial=1,
+                outcome_types=["ordinal"],
+                transforms=self.transform,
+            ),
+        ]
+        strat = SequentialStrategy(strat_list)
+
+        while not strat.finished:
+            x = strat.gen(1)
+            y = self.simulate_response(x)
+            strat.add_data(x, y)
+
+        # Test learned model
+        min_, max_ = torch.argmax(
+            strat.model.predict_probs(torch.stack([self.lb, self.ub])), axis=1
+        )
+        self.assertTrue(min_ == 0)
+        self.assertTrue(max_ == 6)

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 import aepsych.server as server
 import aepsych.utils_logging as utils_logging
+import torch
 from aepsych.server.sockets import BAD_REQUEST
 
 dummy_config = """
@@ -411,8 +412,8 @@ class ServerTestCase(BaseServerTestCase):
             self.assertTrue(response["config"]["y"][0] == "blue")
             self.s.handle_request(tell_request)
 
-        self.assertTrue(len(self.s.strat.lb) == 2)
-        self.assertTrue(len(self.s.strat.ub) == 2)
+        self.assertTrue(torch.all(torch.tensor([0, 0, 0]) == self.s.strat.lb))
+        self.assertTrue(torch.all(torch.tensor([1, 1, 100]) == self.s.strat.ub))
 
     def test_metadata(self):
         setup_request = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1089,8 +1089,8 @@ class ConfigTestCase(unittest.TestCase):
         strat = SequentialStrategy.from_config(config)
         opt_strat = strat.strat_list[1]
 
-        self.assertTrue(torch.all(opt_strat.lb == torch.Tensor([0, -5])))
-        self.assertTrue(torch.all(opt_strat.ub == torch.Tensor([1, 1])))
+        self.assertTrue(torch.all(opt_strat.lb == torch.Tensor([1, -5])))
+        self.assertTrue(torch.all(opt_strat.ub == torch.Tensor([100, 1])))
 
     def test_common_fallback_bounds(self):
         config_str = """

--- a/tests/test_datafetcher.py
+++ b/tests/test_datafetcher.py
@@ -378,8 +378,8 @@ class DataFetcherTestCase(unittest.TestCase):
                 "par1": ["continuous", 0, 1, True],
                 "par2": ["continuous", 0, 1, True],
             },
-            outcome_types=["continuous"],
-            model_name="GPRegressionModel",
+            outcome_types=["ordinal"],
+            model_name="OrdinalGPModel",
         ) + self.pre_seed_config(
             "seed_conds", exp_names=["multi_param_gen", "negative_param_exp"]
         )

--- a/tests_gpu/models/test_ordinal_gp.py
+++ b/tests_gpu/models/test_ordinal_gp.py
@@ -1,0 +1,122 @@
+import unittest
+
+import numpy as np
+import torch
+from aepsych.generators import OptimizeAcqfGenerator, SobolGenerator
+from aepsych.likelihoods import OrdinalLikelihood
+from aepsych.models import OrdinalGPModel
+from aepsych.strategy import SequentialStrategy, Strategy
+from aepsych.transforms import (
+    ParameterTransformedGenerator,
+    ParameterTransformedModel,
+    ParameterTransforms,
+)
+from aepsych.transforms.ops import NormalizeScale
+from botorch.acquisition import qLogNoisyExpectedImprovement
+from sklearn.datasets import make_regression
+
+
+class OrdinalGPTest(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(1)
+        torch.manual_seed(1)
+        X, y, coeff = make_regression(
+            n_samples=100,
+            n_features=2,
+            n_informative=2,
+            random_state=1,
+            coef=True,
+        )
+
+        self.X, self.y, self.coeff = (
+            torch.Tensor(X),
+            torch.Tensor(y),
+            torch.Tensor(coeff),
+        )
+
+        # Remap y to an ordinal response via binning
+        self.n_bins = 7
+        _, self.edges = torch.histogram(self.y, bins=self.n_bins - 1)
+        self.y = torch.bucketize(self.y, self.edges, right=True) - 1
+
+        # Reused transform
+        self.lb = torch.tensor([-3.0, -3.0])
+        self.ub = torch.tensor([3.0, 3.0])
+        self.transform = ParameterTransforms(
+            normalize=NormalizeScale(d=2, bounds=torch.stack([self.lb, self.ub]))
+        )
+
+    def simulate_response(self, x, std=0.5):
+        # Simulate noisy ordinal response
+        x = x + torch.normal(torch.zeros_like(x), torch.ones_like(x) * std)
+        y = torch.sum(x * self.coeff, dim=1)
+        return torch.clamp(
+            torch.bucketize(y, self.edges) - 1, min=0, max=self.n_bins - 1
+        )
+
+    def test_ordinal_strategy(self):
+        n_init = 30
+        n_opt = 2
+
+        # Create strategy
+        sobol_gen = ParameterTransformedGenerator(
+            SobolGenerator,
+            transforms=self.transform,
+            lb=self.lb,
+            ub=self.ub,
+        )
+        acqf_gen = ParameterTransformedGenerator(
+            OptimizeAcqfGenerator,
+            transforms=self.transform,
+            lb=self.lb,
+            ub=self.ub,
+            acqf=qLogNoisyExpectedImprovement,
+        )
+        model = ParameterTransformedModel(
+            OrdinalGPModel,
+            transforms=self.transform,
+            dim=2,
+            likelihood=OrdinalLikelihood(n_levels=self.n_bins),
+        )
+
+        strat_list = [
+            Strategy(
+                lb=self.lb,
+                ub=self.ub,
+                min_asks=n_init,
+                generator=sobol_gen,
+                stimuli_per_trial=1,
+                outcome_types=["ordinal"],
+                transforms=self.transform,
+            ),
+            Strategy(
+                lb=self.lb,
+                ub=self.ub,
+                model=model,
+                generator=acqf_gen,
+                min_asks=n_opt,
+                stimuli_per_trial=1,
+                outcome_types=["ordinal"],
+                transforms=self.transform,
+                use_gpu_generating=True,
+                use_gpu_modeling=True,
+            ),
+        ]
+        strat = SequentialStrategy(strat_list)
+
+        while not strat.finished:
+            x = strat.gen(1)
+            x = x.cpu()
+            y = self.simulate_response(x)
+            strat.add_data(x, y)
+
+        model.cuda()
+        # Test learned model
+        min_, max_ = torch.argmax(
+            strat.model.predict_probs(torch.stack([self.lb, self.ub])), axis=1
+        )
+        self.assertTrue(min_ == 0)
+        self.assertTrue(max_ == 6)
+
+        # Check model is on gpu
+        self.assertEqual(strat.model.device.type, "cuda")


### PR DESCRIPTION
Summary:
Uses variation gp as base now.

OrdinalGPModel specific test.

GPU support tested with a new test.

Theoretically, predict_probs needs to change to new predict_transformed but out of scope.

Differential Revision: D70129028


