### PR TITLE
Unify tell handling to the expected shapes

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -14,52 +14,82 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
+      
       - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip
           pip install ".[dev]"
-      - name: Lint with flake8
-        id: flake8
+          cd clients/python
+          pip install .
+      
+      - name: Lint aepsych with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Type check with mypy
-        id: mypy
+      
+      - name: Type check aepsych with mypy
+        if: always()
+        run: mypy --config-file mypy.ini
+      
+      - name: Lint sepsych_client with flake8  
         if: always()
         run: |
-          mypy --config-file mypy.ini
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        working-directory: clients/python
+      
+      - name: Type check aepsych_client with mypy
+        if: always()
+        run: mypy --config-file mypy.ini
+        working-directory: clients/python
+      
       - uses: omnilib/ufmt@action-v1
         if: always()
         with:
-          path: aepsych tests tests_gpu
+          path: aepsych tests tests_gpu clients/python
           requirements: requirements-fmt.txt
           python-version: "3.10"
 
-  build-test:
 
+  build-test:
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
         os: [macos-latest, windows-latest, macos-13]
+    
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
+    
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install ".[dev]"
-    - name: Test with unittest
-      run: |
-        cd tests
-        python -m unittest
+        cd  clients/python
+        pip install .
+    
+    - name: Test aepsych with unittest
+      run: python -m unittest
+      working-directory: tests
+    
+    - name: Test aepsych python client with unittest
+      if: always()
+      run: python -m unittest
+      working-directory: clients/python/tests
+      

--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -254,6 +254,8 @@ class PairwiseProbitModel(PairwiseGP, AEPsychModelMixin):
                 f"Unknown rereference type {rereference}! Options: x_min, x_max, f_min, f_max."
             )
 
+        if len(x.shape) == 3:
+            x = x.squeeze(2)
         x_stack = torch.vstack([x, x_ref])
         samps = self.posterior(x_stack).rsample(torch.Size([num_samples]))
         samps, samps_ref = torch.split(samps, [samps.shape[1] - 1, 1], dim=1)

--- a/aepsych/server/message_handlers/handle_query.py
+++ b/aepsych/server/message_handlers/handle_query.py
@@ -56,7 +56,7 @@ def query(
             raise RuntimeError("Cannot query model at location = None!")
 
         mean, _var = server.strat.predict(
-            server._config_to_tensor(x).unsqueeze(axis=0),
+            server._config_to_tensor(x),
             probability_space=probability_space,
         )
         response["x"] = x

--- a/clients/python/mypy.ini
+++ b/clients/python/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+files = aepsych_client
+show_error_codes = True
+pretty = True
+ignore_missing_imports = True

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.usort]
+first_party_detection = false
+
+[tool.black]
+target-version = ["py310"]
+
+[tool.ufmt]
+formatter = "ruff-api"
+sorter = "usort"

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -783,7 +783,7 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
 
         conf = ask(server)
 
-        self.assertTrue(server._config_to_tensor(conf).shape == (1, 2))
+        self.assertTrue(server._config_to_tensor(conf).shape == (1, 1, 2))
 
         config_str = """
             [common]
@@ -819,7 +819,7 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
 
         conf = ask(server)
 
-        self.assertTrue(server._config_to_tensor(conf).shape == (2, 2))
+        self.assertTrue(server._config_to_tensor(conf).shape == (1, 2, 2))
 
         config_str = """
             [common]
@@ -856,14 +856,14 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
         conf = ask(server)
 
         tensor = server._config_to_tensor(conf)
-        self.assertTrue(tensor.shape == (3, 2))
+        self.assertTrue(tensor.shape == (1, 3, 2))
 
         # Check if reshapes were correct
-        self.assertTrue(torch.all(tensor[0, :] <= -1e-6))
+        self.assertTrue(torch.all(tensor[0, 0, :] <= -1e-6))
         self.assertTrue(
-            torch.all(torch.logical_and(tensor[1, :] >= 1e-6, tensor[1, :] <= 1))
+            torch.all(torch.logical_and(tensor[0, 1, :] >= 1e-6, tensor[0, 1, :] <= 1))
         )
-        self.assertTrue(torch.all(tensor[2, :] >= 10))
+        self.assertTrue(torch.all(tensor[0, 2, :] >= 10))
 
 
 if __name__ == "__main__":

--- a/tests/server/message_handlers/test_can_model.py
+++ b/tests/server/message_handlers/test_can_model.py
@@ -20,9 +20,7 @@ class StratCanModelTestCase(BaseServerTestCase):
         ask_request = {"type": "ask", "message": ""}
         tell_request = {
             "type": "tell",
-            "message": [
-                {"config": {"x": [0.5]}, "outcome": 1},
-            ],
+            "message": {"config": {"x": [0.5]}, "outcome": 1},
         }
         can_model_request = {
             "type": "can_model",

--- a/tests/server/message_handlers/test_query_handlers.py
+++ b/tests/server/message_handlers/test_query_handlers.py
@@ -61,28 +61,14 @@ class QueryHandlerTestCase(BaseServerTestCase):
         ask_request = {"type": "ask", "message": ""}
         tell_request = {
             "type": "tell",
-            "message": [
-                {
-                    "config": {
-                        "par1": [0.5, 0.5],
-                        "par2": [-0.5, -0.5],
-                        "par3": [40, 50],
-                    },
-                    "outcome": 1,
+            "message": {
+                "config": {
+                    "par1": [[0.5, 0.5], [0.0, 0.75], [1, -1]],
+                    "par2": [[-0.5, -0.5], [0.0, -1], [0, 0.0]],
+                    "par3": [[40, 50], [11, 99], [40, 12]],
                 },
-                {
-                    "config": {
-                        "par1": [0.0, 0.75],
-                        "par2": [0.0, -1],
-                        "par3": [11, 99],
-                    },
-                    "outcome": 0,
-                },
-                {
-                    "config": {"par1": [1, -1], "par2": [0, 0.0], "par3": [40, 12]},
-                    "outcome": 0,
-                },
-            ],
+                "outcome": [1, 0, 0],
+            },
         }
 
         self.s.handle_request(setup_request)
@@ -192,11 +178,13 @@ class QueryHandlerTestCase(BaseServerTestCase):
         ask_request = {"type": "ask", "message": ""}
         tell_request = {
             "type": "tell",
-            "message": [
-                {"config": {"x": [0.5, 0.5], "y": [0.25, 0.75]}, "outcome": 1},
-                {"config": {"x": [0.25, 0.75], "y": [0.5, 0.5]}, "outcome": 0},
-                {"config": {"x": [0.2, 0.6], "y": [0.3, 0.9]}, "outcome": 0},
-            ],
+            "message": {
+                "config": {
+                    "x": [[0.5, 0.5], [0.25, 0.75], [0.2, 0.6]],
+                    "y": [[0.25, 0.75], [0.5, 0.5], [0.3, 0.9]],
+                },
+                "outcome": [1, 0, 0],
+            },
         }
 
         self.s.handle_request(setup_request)

--- a/tests/server/message_handlers/test_tell_handlers.py
+++ b/tests/server/message_handlers/test_tell_handlers.py
@@ -36,6 +36,33 @@ class MessageHandlerTellTests(BaseServerTestCase):
         self.assertEqual(self.s.db.record_message.call_count, 2)
         self.assertEqual(len(self.s.strat.x), 1)
 
+    def test_batch_tell(self):
+        setup_request = {
+            "type": "setup",
+            "message": {"config_str": dummy_config},
+        }
+
+        batch_tell_request = {
+            "type": "tell",
+            "message": {"config": {"x": [[0.5], [1.0], [0.0]]}, "outcome": [1, 0, 1]},
+        }
+
+        self.s.db.record_message = MagicMock()
+
+        self.s.handle_request(setup_request)
+        self.s.handle_request(batch_tell_request)
+        self.assertEqual(self.s.db.record_message.call_count, 1)
+        self.assertEqual(len(self.s.strat.x), 3)
+
+        self.s.handle_request(batch_tell_request)
+        self.assertEqual(self.s.db.record_message.call_count, 2)
+        self.assertEqual(len(self.s.strat.x), 6)
+
+        batch_tell_request["message"]["model_data"] = False
+        self.s.handle_request(batch_tell_request)
+        self.assertEqual(self.s.db.record_message.call_count, 3)
+        self.assertEqual(len(self.s.strat.x), 6)
+
     def test_tell_extra_data(self):
         setup_request = {
             "type": "setup",


### PR DESCRIPTION
Summary:
Tells could handle a lot of different shapes before, we simplify this handling by unifying the shapes to our expected forms.

Cases are as follows:
* Parameter configuration dictionaries should have keys that are each parameter and the values should be one of a few forms:
* * If it's multi stimuli or multi trial (batch) or both, then it must be 2D. The first dimension represents the batch dimension and the second dimension represents the stimuli dimension.
* * * If the model is not multi stimuli and only multi trial, we remove the stimuli dimension on converting this to the tensor, otherwise we return batch, dim, stim.
* * * If the model is multi stimuli but only has 1 stiim, we assume this is for a prediction and handle it like multi stimuli still with batch, dim stim. 
* * If it is a single value, it is assumed to be a single trial single stimuli case

Batch tells no longer allow a list of configuration dictionaries and instead follow the above case.
The pairwise probit now has an additional check to help handle this.

Differential Revision: D70285840


