### PR TITLE
fix client query handling of kwargs

### DIFF
--- a/clients/python/aepsych_client/client.py
+++ b/clients/python/aepsych_client/client.py
@@ -271,16 +271,16 @@ class AEPsychClient:
                 - "x": dictionary, the parameter configuration dictionary for the query.
                 - "y": list, the y from the query.
         """
-        request = {
-            "type": "query",
-            "message": {
-                "query_type": query_type,
-                "probability_space": probability_space,
-                "x": x,
-                "y": y,
-                "constraints": constraints,
-            }.update(**kwargs),
+        message = {
+            "query_type": query_type,
+            "probability_space": probability_space,
+            "x": x,
+            "y": y,
+            "constraints": constraints,
         }
+        message.update(**kwargs)
+
+        request = {"type": "query", "message": message}
 
         return self._send_recv(request)
 

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -94,6 +94,8 @@ class RemoteServerTestCase(unittest.TestCase):
         response = self.client.ask()
         self.assertTrue(response["is_finished"])
 
+        response = self.client.query("max")
+
         self.client.configure(config_str=config_str, config_name="second_config")
         self.assertEqual(self.s.strat._count, 0)
         self.assertEqual(self.s.strat_id, 1)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ REQUIRES = [
     "SQLAlchemy==1.4.46",
     "dill",
     "pandas",
-    "aepsych_client==0.3.0",
+    "aepsych_client",
     "statsmodels",
     "botorch==0.12.0",
 ]


### PR DESCRIPTION
Summary:
Query was broken because we were sending a None after updating the message with the kwargs. Fixed this.

Removed the aepsych client version pin

Differential Revision: D70911685


