### PR TITLE
Allow MLL class to be modified in variational GPs

### DIFF
--- a/aepsych/models/gp_classification.py
+++ b/aepsych/models/gp_classification.py
@@ -43,6 +43,7 @@ class GPClassificationModel(VariationalGPModel):
         mean_module: Optional[gpytorch.means.Mean] = None,
         covar_module: Optional[gpytorch.kernels.Kernel] = None,
         likelihood: Optional[Likelihood] = None,
+        mll_class: Optional[gpytorch.mlls.MarginalLogLikelihood] = None,
         inducing_point_method: Optional[InducingPointAllocator] = None,
         inducing_size: int = 100,
         max_fit_time: Optional[float] = None,
@@ -57,6 +58,8 @@ class GPClassificationModel(VariationalGPModel):
                 gamma prior.
             likelihood (gpytorch.likelihood.Likelihood, optional): The likelihood function to use. If None defaults to
                 Bernouli likelihood. This should not be modified unless you know what you're doing.
+            mll_class (gpytorch.mlls.MarginalLogLikelihood, optional): The approximate marginal log likelihood class to
+                use. If None defaults to VariationalELBO.
             inducing_point_method (InducingPointAllocator, optional): The method to use for selecting inducing points.
                 If not set, a GreedyVarianceReduction is made.
             inducing_size (int): Number of inducing points. Defaults to 100.
@@ -73,6 +76,7 @@ class GPClassificationModel(VariationalGPModel):
             mean_module=mean_module,
             covar_module=covar_module,
             likelihood=likelihood,
+            mll_class=mll_class,
             inducing_point_method=inducing_point_method,
             inducing_size=inducing_size,
             max_fit_time=max_fit_time,

--- a/aepsych/models/ordinal_gp.py
+++ b/aepsych/models/ordinal_gp.py
@@ -31,6 +31,7 @@ class OrdinalGPModel(VariationalGPModel):
         mean_module: Optional[gpytorch.means.Mean] = None,
         covar_module: Optional[gpytorch.kernels.Kernel] = None,
         likelihood: Optional[Likelihood] = None,
+        mll_class: Optional[gpytorch.mlls.MarginalLogLikelihood] = None,
         inducing_point_method: Optional[InducingPointAllocator] = None,
         inducing_size: int = 100,
         max_fit_time: Optional[float] = None,
@@ -45,6 +46,8 @@ class OrdinalGPModel(VariationalGPModel):
                 gamma prior.
             likelihood (gpytorch.likelihood.Likelihood, optional): The likelihood function to use. If None defaults to
                 Gaussian likelihood.
+            mll_class (gpytorch.mlls.MarginalLogLikelihood, optional): The approximate marginal log likelihood class to
+                use. If None defaults to VariationalELBO.
             inducing_point_method (InducingPointAllocator, optional): The method to use for selecting inducing points.
                 If not set, a GreedyVarianceReduction is made.
             inducing_size (int): Number of inducing points. Defaults to 100.
@@ -75,6 +78,7 @@ class OrdinalGPModel(VariationalGPModel):
             mean_module=mean_module,
             covar_module=covar_module,
             likelihood=likelihood,
+            mll_class=mll_class,
             inducing_point_method=inducing_point_method,
             inducing_size=inducing_size,
             max_fit_time=max_fit_time,

--- a/aepsych/models/semi_p.py
+++ b/aepsych/models/semi_p.py
@@ -255,6 +255,7 @@ class SemiParametricGPModel(VariationalGPModel):
         mean_module: Optional[gpytorch.means.Mean] = None,
         covar_module: Optional[gpytorch.kernels.Kernel] = None,
         likelihood: Optional[Any] = None,
+        mll_class: Optional[gpytorch.mlls.MarginalLogLikelihood] = None,
         slope_mean: float = 2.0,
         inducing_point_method: Optional[InducingPointAllocator] = None,
         inducing_size: int = 100,
@@ -271,6 +272,8 @@ class SemiParametricGPModel(VariationalGPModel):
                 gamma prior.
             likelihood (gpytorch.likelihood.Likelihood, optional): The likelihood function to use. If None defaults to
                 linear-Bernouli likelihood with probit link.
+            mll_class (gpytorch.mlls.MarginalLogLikelihood, optional): The approximate marginal log likelihood class to
+                use. If None defaults to VariationalELBO.
             slope_mean (float): The mean of the slope. Defaults to 2.
             inducing_point_method (InducingPointAllocator, optional): The method to use for selecting inducing points.
                 If not set, a GreedyVarianceReduction is made.
@@ -314,6 +317,7 @@ class SemiParametricGPModel(VariationalGPModel):
             mean_module=mean_module,
             covar_module=covar_module,
             likelihood=likelihood,
+            mll_class=mll_class,
             inducing_size=inducing_size,
             max_fit_time=max_fit_time,
             inducing_point_method=inducing_point_method,
@@ -459,6 +463,7 @@ class HadamardSemiPModel(VariationalGPModel):
         offset_mean_module: Optional[gpytorch.means.Mean] = None,
         offset_covar_module: Optional[gpytorch.kernels.Kernel] = None,
         likelihood: Optional[Likelihood] = None,
+        mll_class: Optional[gpytorch.mlls.MarginalLogLikelihood] = None,
         slope_mean: float = 2,
         inducing_point_method: Optional[InducingPointAllocator] = None,
         inducing_size: int = 100,
@@ -475,6 +480,8 @@ class HadamardSemiPModel(VariationalGPModel):
             offset_mean_module (gpytorch.means.Mean, optional): Mean module to use (default: constant mean) for offset.
             offset_covar_module (gpytorch.kernels.Kernel, optional): Covariance kernel to use (default: scaled RBF) for offset.
             likelihood (gpytorch.likelihood.Likelihood, optional)): defaults to bernoulli with logistic input and a floor of .5
+            mll_class (gpytorch.mlls.MarginalLogLikelihood, optional): The approximate marginal log likelihood class to
+                use. If None defaults to VariationalELBO.
             slope_mean (float): The mean of the slope. Defaults to 2.
             inducing_point_method (InducingPointAllocator, optional): The method to use for selecting inducing points.
                 If not set, a GreedyVarianceReduction is made.
@@ -487,6 +494,7 @@ class HadamardSemiPModel(VariationalGPModel):
         super().__init__(
             dim=dim,
             inducing_size=inducing_size,
+            mll_class=mll_class,
             max_fit_time=max_fit_time,
             inducing_point_method=inducing_point_method,
             optimizer_options=optimizer_options,


### PR DESCRIPTION
Summary: MLL class can now be modified in the init for variational GPs. If not set, they all default back to VariationalELBO.

Differential Revision: D71353139


