### PR TITLE
Rewrite dim_grid to just use simple torch functions

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,6 +46,27 @@ class UtilsTestCase(unittest.TestCase):
 
         self.assertTrue(np.all(grid.shape == (900, 3)))
 
+    def test_dim_grid_values(self):
+        """Test that the grid points are correctly spaced."""
+        lb = torch.tensor([0.0, 1.0])
+        ub = torch.tensor([1.0, 3.0])
+        gridsize = 5
+
+        grid = dim_grid(lb, ub, gridsize=gridsize)
+
+        # Check shape
+        self.assertEqual(grid.shape, (25, 2))
+
+        # Check values for first dimension
+        expected_x_values = torch.tensor([0.0, 0.25, 0.5, 0.75, 1.0])
+        x_values = torch.unique(grid[:, 0])
+        self.assertTrue(torch.allclose(x_values, expected_x_values))
+
+        # Check values for second dimension
+        expected_y_values = torch.tensor([1.0, 1.5, 2.0, 2.5, 3.0])
+        y_values = torch.unique(grid[:, 1])
+        self.assertTrue(torch.allclose(y_values, expected_y_values))
+
     def test_process_bounds(self):
         lb, ub, dim = _process_bounds(np.r_[0, 1], np.r_[2, 3], None)
         self.assertTrue(torch.all(lb == torch.tensor([0.0, 1.0])))


### PR DESCRIPTION
Summary: dim_grid used to use arcane numpy techniques, cleaned this up to only use pytorch functions.

Differential Revision: D71942737


