### PR TITLE
Add readonly mode for server to not modify db

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,13 @@ The canonical way of using AEPsych is to launch it in server mode (you can run `
 aepsych_server --port 5555 --ip 0.0.0.0 --db mydatabase.db
 ```
 
+You can also run the server in read-only mode, which creates a temporary copy of the database to prevent modifications to the original:
+
+```
+aepsych_server --port 5555 --ip 0.0.0.0 --db mydatabase.db --read-only
+```
+```
+
 The server accepts messages over a unix socket, and
 all messages are formatted using [JSON](https://www.json.org/json-en.html). All messages
 have the following format:


### PR DESCRIPTION
Summary:
Added an optional flag for a read-only mode for the server. When on, the database of interest will be copied to a temporary directory and worked on from there.

This flag will not work without an existing file.

Updated the database cli to use a similar method to not modify old files now too.

Differential Revision: D72327488


