### PR TITLE
Document all supported server messages

### DIFF
--- a/aepsych/server/message_handlers/handle_get_config.py
+++ b/aepsych/server/message_handlers/handle_get_config.py
@@ -41,4 +41,4 @@ def handle_get_config(server, request: dict[str, Any]) -> dict[str, Any]:
         raise RuntimeError("Message contains a section but not a property!")
 
     # If both section and property are specified, return only the relevant value from the config
-    return server.config.to_dict(deduplicate=False)[section][prop]
+    return {section: {prop: server.config.to_dict(deduplicate=False)[section][prop]}}

--- a/clients/python/Readme.md
+++ b/clients/python/Readme.md
@@ -13,7 +13,8 @@ pip install aepsych_client
 
 If you are a developer, you should also install the [main AEPsych package](https://github.com/facebookresearch/aepsych) so that you can run the tests.
 
-## Configuration
+## Basic Usage
+### Configuration
 This interface uses AEPsych's ini-based config, which gets passed as a string to the server:
 
 ```
@@ -25,7 +26,7 @@ filename = 'configs/single_lse_2d.ini'
 client.configure(config_path=filename)
 ```
 
-## Ask and tell
+### Ask and tell
 To get the next configuration from the server, we call `ask`; we report on the outcome with `tell`.
 
 ```
@@ -36,7 +37,7 @@ trial_params = client.ask()
 client.tell(config={"par1": [0], "par2": [1]}, outcome=1)
 ```
 
-## Resume functionality
+### Resume functionality
 We can run multiple interleaved experiments. When we call `configure`, we get back a strategy ID.
 The client keeps track of all these strategy IDs and we can use them to resume experiments. By
 doing this we can interleave different model runs.
@@ -58,5 +59,214 @@ client.configure(config_path=file2, config_name='config2')
 client.resume(config_name="config1)
 ```
 
-## Ending a session
+### Ending a session
 When you are done with your experiment, you should call `client.finalize()`, which will stop the server and save your data to a database.
+
+## Client API
+
+### Initialization
+
+```python
+client = AEPsychClient(ip="0.0.0.0", port=5555)
+```
+
+Creates a new AEPsych client. By default, it connects to a localhost server on port 5555.
+
+Parameters:
+- `ip` (str, optional): IP to connect to (default: "0.0.0.0")
+- `port` (int, optional): Port to connect on (default: 5555)
+- `connect` (bool): Connect as part of init? (default: True)
+- `server` (AEPsychServer, optional): An in-memory AEPsychServer object to connect to
+
+### Connection Management
+
+```python
+# Connect to a server
+client.connect(ip="0.0.0.0", port=5555)
+
+# End experiment and stop server
+response = client.finalize()
+```
+
+The `connect` method establishes a connection to an AEPsych server at the specified IP address and port. This is automatically called during initialization if `connect=True` (the default).
+
+Parameters:
+- `ip` (str): IP address of the server to connect to
+- `port` (int): Port number to connect on
+
+The `finalize` method signals to the server that the experiment is complete and stops the server. It should be called when you're done with your experiment to ensure proper cleanup and data saving.
+
+Returns:
+- Dictionary containing confirmation of termination
+
+### Configuration
+
+```python
+# Configure using a file path
+response = client.configure(config_path="configs/my_config.ini", config_name="my_experiment")
+
+# Configure using a config string
+config_str = """
+[common]
+model = GPClassificationModel
+acqf = MCLevelSetEstimation
+...
+"""
+response = client.configure(config_str=config_str, config_name="my_experiment")
+
+# Resume a previous configuration by name
+client.resume(config_name="my_experiment")
+
+# Resume a previous configuration by ID
+client.resume(config_id=0)
+```
+
+The `configure` method sets up the server with an experiment configuration. You must provide either a path to a config file or a config string.
+
+Parameters:
+- `config_path` (str, optional): Path to a config.ini file
+- `config_str` (str, optional): Config.ini encoded as a string
+- `config_name` (str, optional): A name to assign to this config internally for convenience
+
+Returns:
+- Dictionary containing the strategy ID for the configured experiment
+
+The `resume` method switches back to a previously configured experiment. This allows you to interleave multiple experiments in a single session.
+
+Parameters:
+- `config_id` (int, optional): ID of the config to resume
+- `config_name` (str, optional): Name of the config to resume (if you provided a name during configuration)
+
+Returns:
+- Dictionary containing the strategy ID that was resumed
+
+### Active Learning
+
+```python
+# Get next configuration to test
+trial_params = client.ask()
+
+# Get multiple configurations
+trial_params = client.ask(num_points=5)
+
+# Report results back to the server
+client.tell(config={"param1": [0.5], "param2": [0.3]}, outcome=1)
+
+# Report results with metadata
+client.tell(
+    config={"param1": [0.5], "param2": [0.3]},
+    outcome=1,
+    reaction_time=1.5,
+    confidence=0.8
+)
+
+# Finish the current strategy
+client.finish_strategy()
+```
+
+The `ask` method requests the next configuration(s) to test from the server. This is the core method for active learning, as it uses the model to determine the most informative points to sample next.
+
+Parameters:
+- `num_points` (int, optional): Number of points to return (default: 1)
+
+Returns:
+- Dictionary containing the suggested configuration(s) to test and whether the strategy is finished
+
+The `tell` method reports the outcome of a tested configuration back to the server. This updates the model with new data.
+
+Parameters:
+- `config` (dict): Configuration that was evaluated (keys are parameter names, values are lists)
+- `outcome` (float or dict): Outcome value(s) that were obtained
+- `model_data` (bool): Whether to include this data in the model (default: True)
+- `**metadata`: Additional metadata to record with this trial (e.g., reaction time, confidence)
+
+Returns:
+- Dictionary containing the number of trials recorded and data points added to the model
+
+The `finish_strategy` method marks the current strategy as complete.
+
+Returns:
+- Dictionary containing information about the finished strategy
+
+### Model Querying
+
+```python
+# Find the maximum of the model
+max_point = client.query(query_type="max")
+
+# Find the minimum of the model
+min_point = client.query(query_type="min")
+
+# Get model prediction at a specific point
+prediction = client.query(
+    query_type="prediction",
+    x={"param1": [0.5], "param2": [0.3]}
+)
+
+# Get inverse prediction (what x gives a specific y)
+inverse = client.query(
+    query_type="inverse",
+    y=0.75,
+    probability_space=True
+)
+
+# Query with constraints
+constrained_max = client.query(
+    query_type="max",
+    constraints={0: 0.5}  # Constrain first parameter to 0.5
+)
+```
+
+The `query` method allows you to extract information from the underlying model. It supports several query types for different purposes.
+
+Parameters:
+- `query_type` (str): Type of query to make. Options:
+  - `"max"`: Find the maximum value of the model
+  - `"min"`: Find the minimum value of the model
+  - `"prediction"`: Get model prediction at specific point(s)
+  - `"inverse"`: Find parameter values that would give a specific outcome
+- `probability_space` (bool): Whether the y value is in probability space (default: False)
+- `x` (dict, optional): Parameter configuration for prediction queries
+- `y` (float or tensor, optional): Expected y value for inverse queries
+- `constraints` (dict, optional): Equality constraints for parameters, where keys are parameter indices and values are the fixed values
+- `**kwargs`: Additional parameters to pass to the query function
+
+Returns:
+- Dictionary containing the query response, which varies based on the query type
+
+### Information Retrieval
+
+```python
+# Get experiment information
+info = client.info()
+
+# Get parameter bounds
+params = client.parameters()
+
+# Get full experiment config
+config = client.get_config()
+
+# Get specific config property
+threshold = client.get_config(section="stopping", property="min_trial_count")
+```
+
+The `info` method retrieves information about the current running experiment.
+
+Returns:
+- Dictionary containing details such as database name, experiment ID, strategy count, current strategy information, etc.
+
+The `parameters` method gets information about each parameter in the current strategy.
+
+Returns:
+- Dictionary where keys are parameter names and values are lists containing the lower and upper bounds
+
+The `get_config` method retrieves the current experiment configuration.
+
+Parameters:
+- `section` (str, optional): The section to get the property from
+- `property` (str, optional): The property to get from the section
+
+Returns:
+- Dictionary representing the experiment config or a specific property value if section and property are provided
+
+Each method returns a dictionary with relevant information about the operation performed. See the method docstrings for detailed information about the return values.

--- a/clients/python/aepsych_client/client.py
+++ b/clients/python/aepsych_client/client.py
@@ -285,5 +285,76 @@ class AEPsychClient:
 
         return self._send_recv(request)
 
+    def finish_strategy(self) -> dict[str, Any]:
+        """Finish the current strategy.
+
+        Returns:
+            Dict[str, Any]: A dictionary with these entries
+                - "finished_strategy": str, name of the finished strategy.
+                - "finished_strat_idx": int, the id of the strategy.
+        """
+        request = {"type": "finish_strategy", "message": {}}
+        return self._send_recv(request)
+
+    def get_config(
+        self, section: str | None = None, property: str | None = None
+    ) -> dict[str, Any]:
+        """Get the current experiment config.
+
+        Args:
+            section (str, optional): The section to get the property from. If provided,
+                property must also be provided.
+            property (str, optional): The property to get from the section. If provided,
+                section must also be provided.
+
+        Returns:
+            Dict[str, Any]: A dictionary representing the experiment config or a specific
+                property value if section and property are provided.
+        """
+        message = {}
+        if section is not None:
+            message["section"] = section
+        if property is not None:
+            message["property"] = property
+
+        request = {"type": "get_config", "message": message}
+        return self._send_recv(request)
+
+    def info(self) -> dict[str, Any]:
+        """Get information about the current running experiment.
+
+        Returns:
+            Dict[str, Any]: A dictionary with these entries
+                - "db_name": string, name of the database
+                - "exp_id": integer, experiment ID
+                - "strat_count": integer, number of strategies in the server.
+                - "all_strat_names": list of strings, list of the strategy names in the
+                    server.
+                - "current_strat_index": integer, the index of the current strategy.
+                - "current_strat_name": string, name of the current strategy.
+                - "current_strat_data_pts": integer, the number of data points in the
+                    current strategy.
+                - "current_strat_model": string, the name of the model in the current
+                    strategy.
+                - "current_strat_acqf": string, the acquisition function of the current
+                    stratgy.
+                - "current_strat_finished": boolean, whether the current strategy is
+                    finished.
+                - "current_strat_can_fit": boolean, whether the current strategy can fit a
+                    model.
+        """
+        request = {"type": "info", "message": {}}
+        return self._send_recv(request)
+
+    def parameters(self) -> dict[str, list[float]]:
+        """Get information about each parameter in the current strategy.
+
+        Returns:
+            Dict[str, list[float]]: A dictionary where every key is a parameter and the
+                value is a list of floats representing the lower bound and the upper bound.
+        """
+        request = {"type": "parameters", "message": {}}
+        return self._send_recv(request)
+
     def __del__(self):
         self.finalize()

--- a/clients/python/tests/test_client.py
+++ b/clients/python/tests/test_client.py
@@ -106,6 +106,41 @@ class RemoteServerTestCase(unittest.TestCase):
         self.client.resume(config_name="second_config")
         self.assertEqual(self.s.strat_id, 1)
 
+        # Test finish_strategy
+        response = self.client.finish_strategy()
+        self.assertIn("finished_strategy", response)
+        self.assertIn("finished_strat_idx", response)
+        self.assertEqual(response["finished_strategy"], self.s.strat.name)
+        self.assertEqual(response["finished_strat_idx"], self.s.strat._strat_idx)
+
+        # Test get_config
+        response = self.client.get_config()
+        self.assertIsInstance(response, dict)
+        self.assertIn("common", response)
+        self.assertIn("lb", response["common"])
+
+        # Test get_config with section and property
+        response = self.client.get_config(section="common", property="lb")
+        self.assertDictEqual(response, {"common": {"lb": "[0]"}})
+
+        # Test info
+        response = self.client.info()
+        self.assertIn("db_name", response)
+        self.assertIn("exp_id", response)
+        self.assertIn("strat_count", response)
+        self.assertIn("all_strat_names", response)
+        self.assertIn("current_strat_index", response)
+        self.assertIn("current_strat_name", response)
+        self.assertEqual(response["current_strat_name"], self.s.strat.name)
+
+        # Test parameters
+        response = self.client.parameters()
+        self.assertIsInstance(response, dict)
+        self.assertIn("x", response)
+        self.assertEqual(len(response["x"]), 2)  # Lower and upper bounds
+        self.assertEqual(response["x"][0], 0.0)  # Lower bound
+        self.assertEqual(response["x"][1], 1.0)  # Upper bound
+
         self.client.finalize()
 
 

--- a/docs/server_api_overview.md
+++ b/docs/server_api_overview.md
@@ -1,0 +1,346 @@
+---
+id: server_overview
+title: Server API Overview
+---
+
+## Server Message API
+The server can handle a variety of messages from the client. The messages are
+expected to be JSON objects with a `type` field that indicates the type of
+message alongisde a `message` field that contains the message-specific data.
+Below is an exhaustive list of the messages that the server can handle and the
+expected API for each.
+
+### setup
+Sets up an experiment with the provided configuration.
+
+**Request Format:**
+```json
+{
+  "type": "setup",
+  "message": {
+    "config_str": "...",  // Config as a string, or
+    "config_dict": {      // Config as a dictionary
+      "common": {
+        "parnames": ["param1", "param2"],
+        "outcome_types": ["continuous", "binary"],
+        "strategy_names": ["strategy1", "strategy2"],
+      },
+      "metadata": { // Metadata section is optional
+        "experiment_name": "experiment_name",
+        "experiment_description": "experiment_description",
+        "participant_id": "participant_id"
+      },
+      // Additional sections for strategies, models, etc.
+    }
+  }
+}
+```
+
+The configuration can be provided either as a string (`config_str`) or as a dictionary (`config_dict`). The configuration must include:
+
+- A `common` section with:
+  - `parnames`: List of parameter names used in the experiment
+  - `outcome_types`: List of outcome types (e.g., "continuous", "binary")
+  - `strategy_names`: List of stategy names.
+
+- An optional `metadata` section with:
+  - `experiment_name`: Name of the experiment
+  - `experiment_description`: Description of the experiment
+  - `participant_id`: ID of the participant
+
+Additional sections should be included for configuring strategies, models, acquisition functions, and other experiment components.
+
+**Response Format:**
+```json
+{
+  "strat_id": 0
+}
+```
+
+The `strat_id` field contains the ID of the newly created strategy.
+
+
+### ask
+Requests a point to be generated and returns a configuration for the next experiment trial.
+
+**Request Format:**
+```json
+{
+  "type": "ask",
+  "message": {
+    "num_points": 1  // Optional, defaults to 1
+  }
+}
+```
+
+The `num_points` parameter specifies how many parameter configurations to generate. If omitted, the server will generate a single configuration.
+
+**Response Format:**
+```json
+{
+  "config": {
+    "param1": [value1],
+    "param2": [value2],
+    ...
+  },
+  "is_finished": false,
+  "num_points": 1
+}
+```
+
+The `config` field contains parameter values for the next trial. `is_finished` indicates whether the current strategy is finished. `num_points` indicates the number of points returned.
+
+### tell
+Tells the model which input was run and what the outcome was.
+
+**Request Format:**
+```json
+{
+  "type": "tell",
+  "message": {
+    "config": {
+      "param1": value1,
+      "param2": value2,
+      ...
+    },
+    "outcome": value,  // or for multi-outcome: {"outcome1": value1, "outcome2": value2, ...}
+    "model_data": true,  // Optional, defaults to true
+    **kwargs, // Optional, any extra key-value pairs to add to the trial record
+  }
+}
+```
+
+The `config` field contains the parameter configuration used in the trial. The `outcome` field can be either a single value for single-outcome experiments or a dictionary mapping outcome names to values for multi-outcome experiments. The `model_data` parameter determines whether this data should be added to the model (true) or just recorded in the database without affecting the model (false). Any additional key-value pairs will be stored as extra data with the trial record. You can also tell the server about multiple trials at once. To do this, the parameter values and outcome values should be lists of the same length.
+
+**Response Format:**
+```json
+{
+  "trials_recorded": 1,
+  "model_data_added": 1
+}
+```
+
+The `trials_recorded` field indicates the number of trials recorded in the database. `model_data_added` indicates the number of datapoints added to the model.
+
+### exit
+Makes the server write strategies into the database and close the connection.
+
+**Request Format:**
+```json
+{
+  "type": "exit",
+  "message": {}
+}
+```
+
+This message doesn't require any parameters. It signals the server to gracefully terminate, ensuring all strategies and data are properly saved to the database before closing the connection.
+
+**Response Format:**
+```json
+{
+  "termination_type": "Terminate",
+  "success": true
+}
+```
+
+### finish_strategy
+Finishes the current strategy and returns information about the finished strategy.
+
+**Request Format:**
+```json
+{
+  "type": "finish_strategy",
+  "message": {}
+}
+```
+
+This message doesn't require any parameters. It instructs the server to mark the current strategy as finished, which may trigger the server to move to the next strategy if one is available.
+
+**Response Format:**
+```json
+{
+  "finished_strategy": "strategy_name",
+  "finished_strat_idx": 0
+}
+```
+
+The `finished_strategy` field contains the name of the finished strategy. `finished_strat_idx` contains the index of the finished strategy.
+
+### get_config
+Returns the current experiment configuration.
+
+**Request Format:**
+```json
+{
+  "type": "get_config",
+  "message": {
+    "section": "section_name",  // Optional
+    "property": "property_name"  // Optional, requires section to be specified
+  }
+}
+```
+
+The `section` parameter specifies which section of the configuration to retrieve. The `property` parameter specifies a specific property within that section to retrieve. If neither is provided, the entire configuration is returned. If `property` is specified, `section` must also be specified.
+
+**Response Format:**
+If section and property are specified:
+```json
+{
+  "section_name": {
+    "property_name": value
+  }
+}
+```
+
+If neither section nor property are specified, the entire config is returned:
+```json
+{
+  "section1": {
+    "property1": value1,
+    "property2": value2,
+    ...
+  },
+  "section2": {
+    ...
+  },
+  ...
+}
+```
+
+### info
+Returns information about the current running experiment.
+
+**Request Format:**
+```json
+{
+  "type": "info",
+  "message": {}
+}
+```
+
+This message doesn't require any parameters. It requests comprehensive information about the current state of the experiment, including database details, strategy information, and model status.
+
+**Response Format:**
+```json
+{
+  "db_name": "database_name",
+  "exp_id": 123,
+  "strat_count": 2,
+  "all_strat_names": ["strategy1", "strategy2"],
+  "current_strat_index": 1,
+  "current_strat_name": "strategy2",
+  "current_strat_data_pts": 10,
+  "current_strat_model": "model_name",
+  "current_strat_acqf": "acquisition_function_name",
+  "current_strat_finished": false,
+  "current_strat_can_fit": true
+}
+```
+
+### params
+Returns information about each parameter in the current strategy.
+
+**Request Format:**
+```json
+{
+  "type": "parameters",
+  "message": {}
+}
+```
+
+This message doesn't require any parameters. It requests information about all parameters in the current strategy, including their names and bounds.
+
+**Response Format:**
+```json
+{
+  "param1": [lower_bound1, upper_bound1],
+  "param2": [lower_bound2, upper_bound2],
+  ...
+}
+```
+
+Each key is a parameter name, and the value is a list containing the lower and upper bounds for that parameter.
+
+### query
+Queries the underlying model for various types of information.
+
+**Request Format:**
+```json
+{
+  "type": "query",
+  "message": {
+    "query_type": "max",  // Options: "max", "min", "prediction", "inverse"
+    "probability_space": false,  // Optional, defaults to false
+    "x": {  // Required for "prediction" query type
+      "param1": value1,
+      "param2": value2,
+      ...
+    },
+    "y": value,  // Required for "inverse" query type
+    "constraints": {  // Optional
+      "0": value1,  // Parameter index: value
+      "1": value2,
+      ...
+    }
+  }
+}
+```
+
+The `query_type` parameter specifies the type of query to perform:
+- `max`: Find the parameter configuration that maximizes the model output
+- `min`: Find the parameter configuration that minimizes the model output
+- `prediction`: Get the model's prediction at a specific parameter configuration
+- `inverse`: Find the parameter configuration that produces a specific output value
+
+The `probability_space` parameter determines whether the query should be performed in probability space (true) or not (false).
+
+The `x` parameter is required for the "prediction" query type and specifies the parameter configuration to get a prediction for.
+
+The `y` parameter is required for the "inverse" query type and specifies the target output value to find a matching parameter configuration for.
+
+The `constraints` parameter allows specifying equality constraints on parameters, where each key is the parameter index (0-based) and the value is the fixed value for that parameter.
+
+**Response Format:**
+```json
+{
+  "query_type": "max",
+  "probability_space": false,
+  "constraints": {
+    "0": value1,
+    "1": value2,
+    ...
+  },
+  "x": {
+    "param1": [value1],
+    "param2": [value2],
+    ...
+  },
+  "y": [value]
+}
+```
+
+The response contains the query type, whether probability space was used, any constraints applied, the parameter configuration, and the resulting y value.
+
+### resume
+Resumes a specific strategy given its ID.
+
+**Request Format:**
+```json
+{
+  "type": "resume",
+  "message": {
+    "strat_id": 1
+  }
+}
+```
+
+The `strat_id` parameter specifies the ID of the strategy to resume. Note that this is not used to switch between strategies within a single experiment. The "strategy" mentioned here refers to different experiments defined by different setup messages.
+
+**Response Format:**
+```json
+{
+  "strat_id": 1
+}
+```
+
+The `strat_id` field contains the ID of the resumed strategy.

--- a/tests/server/message_handlers/test_handle_get_config.py
+++ b/tests/server/message_handlers/test_handle_get_config.py
@@ -31,11 +31,16 @@ class HandleExitTestCase(BaseServerTestCase):
             "property": "min_asks",
         }
         response = self.s.handle_request(get_config_request)
-        self.assertEqual(response, true_config_dict["init_strat"]["min_asks"])
+        self.assertEqual(
+            response["init_strat"]["min_asks"],
+            true_config_dict["init_strat"]["min_asks"],
+        )
 
         get_config_request["message"] = {"section": "init_strat", "property": "lb"}
         response = self.s.handle_request(get_config_request)
-        self.assertEqual(response, true_config_dict["init_strat"]["lb"])
+        self.assertEqual(
+            response["init_strat"]["lb"], true_config_dict["init_strat"]["lb"]
+        )
 
         get_config_request["message"] = {"property": "min_asks"}
         with self.assertRaises(RuntimeError):

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -15,7 +15,8 @@
     ],
     "For developers": [
       "api_overview",
-      "db_overview"
+      "db_overview",
+      "server_overview"
     ],
     "Advanced topics": [
       "finish_criteria",


### PR DESCRIPTION
Summary: Add an extra page on the aepsych site that documents each message. The documentation is agnostic to client.

Differential Revision: D72355927


