### PR TITLE
Add missing acqf kwarg to logger

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -8,37 +8,40 @@ on:
   schedule:
     - cron: "0 12 * * *" # every day at 4AM west coast time
 
+env:
+  aepsych_mode: test
+
 jobs:
   lint:
     runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install ".[dev]"
           cd clients/python
           pip install .
-      
+
       - name: Lint aepsych with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      
+
       - name: Type check aepsych with mypy
         if: always()
         run: mypy --config-file mypy.ini
-      
-      - name: Lint sepsych_client with flake8  
+
+      - name: Lint sepsych_client with flake8
         if: always()
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -46,12 +49,12 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
         working-directory: clients/python
-      
+
       - name: Type check aepsych_client with mypy
         if: always()
         run: mypy --config-file mypy.ini
         working-directory: clients/python
-      
+
       - uses: omnilib/ufmt@action-v1
         if: always()
         with:
@@ -66,30 +69,29 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
         os: [macos-latest, windows-latest, macos-13]
-    
+
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install ".[dev]"
         cd  clients/python
         pip install .
-    
+
     - name: Test aepsych with unittest
       run: python -m unittest
       working-directory: tests
-    
+
     - name: Test aepsych python client with unittest
       if: always()
       run: python -m unittest
       working-directory: clients/python/tests
-      

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -12,6 +12,7 @@ from typing import Any, Generic, Protocol, runtime_checkable, TypeVar
 import torch
 from aepsych.config import Config, ConfigurableMixin
 from aepsych.models.base import AEPsychModelMixin
+from aepsych.utils_logging import logger
 from botorch.acquisition import (
     AcquisitionFunction,
     LogNoisyExpectedImprovement,
@@ -138,7 +139,7 @@ class AcqfGenerator(AEPsychGenerator):
                 if value.default == _empty and key not in extra_acqf_args:
                     if key not in config["common"]:
                         # HACK: Not actually sure why some required args can be missing
-                        warnings.warn(
+                        logger.debug(
                             f"{acqf_name} requires the {key} option but we could not find it.",
                             UserWarning,
                         )

--- a/aepsych/utils_logging.py
+++ b/aepsych/utils_logging.py
@@ -8,6 +8,7 @@
 import logging
 import logging.config
 import os
+from typing import Any
 
 logger = logging.getLogger()
 
@@ -47,7 +48,7 @@ def getLogger(level=logging.INFO, log_path: str = "logs") -> logging.Logger:
     """
     os.makedirs(log_path, exist_ok=True)
 
-    logging_config = {
+    logging_config: dict[str, Any] = {
         "version": 1,
         "disable_existing_loggers": True,
         "formatters": {"standard": {"()": ColorFormatter}},
@@ -69,5 +70,11 @@ def getLogger(level=logging.INFO, log_path: str = "logs") -> logging.Logger:
         },
     }
 
+    aepsych_mode = os.environ.get("aepsych_mode", "")
+    if aepsych_mode == "test":
+        logging_config["loggers"][""] = {}
+        logger.setLevel(logging.ERROR)
+
     logging.config.dictConfig(logging_config)
+
     return logger

--- a/aepsych/utils_logging.py
+++ b/aepsych/utils_logging.py
@@ -23,11 +23,11 @@ class ColorFormatter(logging.Formatter):
     my_format = "%(asctime)-15s [%(levelname)-7s] %(message)s"
 
     FORMATS = {
-        logging.DEBUG: reset + grey + my_format,
-        logging.INFO: reset + white + my_format,
-        logging.WARNING: reset + yellow + my_format,
-        logging.ERROR: reset + red + my_format,
-        logging.CRITICAL: reset + bold_red + my_format,
+        logging.DEBUG: grey + my_format + reset,
+        logging.INFO: white + my_format + reset,
+        logging.WARNING: yellow + my_format + reset,
+        logging.ERROR: red + my_format + reset,
+        logging.CRITICAL: bold_red + my_format + reset,
     }
 
     def format(self, record):


### PR DESCRIPTION
Summary:
When looking for acqf kwargs, missing args warnings will be sent to logger as debug. Typically not a big deal as it will be the X_baseline arg.

Future work may clean up this.

Differential Revision: D72423791


