### PR TITLE
Get rid of extra tensor casts in query utility functions

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -8,37 +8,40 @@ on:
   schedule:
     - cron: "0 12 * * *" # every day at 4AM west coast time
 
+env:
+  aepsych_mode: test
+
 jobs:
   lint:
     runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install ".[dev]"
           cd clients/python
           pip install .
-      
+
       - name: Lint aepsych with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      
+
       - name: Type check aepsych with mypy
         if: always()
         run: mypy --config-file mypy.ini
-      
-      - name: Lint sepsych_client with flake8  
+
+      - name: Lint sepsych_client with flake8
         if: always()
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -46,12 +49,12 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
         working-directory: clients/python
-      
+
       - name: Type check aepsych_client with mypy
         if: always()
         run: mypy --config-file mypy.ini
         working-directory: clients/python
-      
+
       - uses: omnilib/ufmt@action-v1
         if: always()
         with:
@@ -66,30 +69,29 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
         os: [macos-latest, windows-latest, macos-13]
-    
+
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install ".[dev]"
         cd  clients/python
         pip install .
-    
+
     - name: Test aepsych with unittest
       run: python -m unittest
       working-directory: tests
-    
+
     - name: Test aepsych python client with unittest
       if: always()
       run: python -m unittest
       working-directory: clients/python/tests
-      

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -9,7 +9,6 @@ import ast
 import configparser
 import inspect
 import json
-import logging
 import re
 import typing
 import warnings
@@ -20,6 +19,7 @@ import botorch
 import gpytorch
 import numpy as np
 import torch
+from aepsych.utils_logging import logger
 
 _T = TypeVar("_T")
 _ET = TypeVar("_ET")
@@ -247,7 +247,7 @@ class Config(configparser.ConfigParser):
             except ValueError:
                 # Check if ub/lb exists in common
                 if "ub" in self["common"] and "lb" in self["common"]:
-                    logging.warning(
+                    logger.warning(
                         "Parameter-specific bounds are incomplete, falling back to ub/lb in [common]"
                     )
                 else:

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -12,6 +12,7 @@ from typing import Any, Generic, Protocol, runtime_checkable, TypeVar
 import torch
 from aepsych.config import Config, ConfigurableMixin
 from aepsych.models.base import AEPsychModelMixin
+from aepsych.utils_logging import logger
 from botorch.acquisition import (
     AcquisitionFunction,
     LogNoisyExpectedImprovement,
@@ -138,7 +139,7 @@ class AcqfGenerator(AEPsychGenerator):
                 if value.default == _empty and key not in extra_acqf_args:
                     if key not in config["common"]:
                         # HACK: Not actually sure why some required args can be missing
-                        warnings.warn(
+                        logger.debug(
                             f"{acqf_name} requires the {key} option but we could not find it.",
                             UserWarning,
                         )

--- a/aepsych/generators/manual_generator.py
+++ b/aepsych/generators/manual_generator.py
@@ -73,7 +73,7 @@ class ManualGenerator(AEPsychGenerator):
                 RuntimeWarning,
             )
 
-        if fixed_features is not None:
+        if fixed_features is not None and len(fixed_features) != 0:
             warnings.warn(
                 f"Cannot fix features when generating from {self.__class__.__name__}"
             )

--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -124,7 +124,6 @@ class PairwiseProbitModel(PairwiseGP, AEPsychModelMixin):
         self,
         train_x: torch.Tensor,
         train_y: torch.Tensor,
-        optimizer_kwargs: dict[str, Any] | None = None,
         **kwargs,
     ) -> None:
         """Fit the model to the training data.
@@ -132,21 +131,13 @@ class PairwiseProbitModel(PairwiseGP, AEPsychModelMixin):
         Args:
             train_x (torch.Tensor): Trainin x points.
             train_y (torch.Tensor): Training y points.
-            optimizer_kwargs (dict[str, Any], optional): Keyword arguments to pass to the optimizer. Defaults to None.
         """
-        if optimizer_kwargs is not None:
-            if not "optimizer_kwargs" in optimizer_kwargs:
-                optimizer_kwargs = optimizer_kwargs.copy()
-                optimizer_kwargs.update(self.optimizer_options)
-        else:
-            optimizer_kwargs = {"options": self.optimizer_options}
-
         self.train()
         mll = PairwiseLaplaceMarginalLogLikelihood(self.likelihood, self)
         datapoints, comparisons = self._pairs_to_comparisons(train_x, train_y)
         self.set_train_data(datapoints, comparisons)
 
-        optimizer_kwargs = {} if optimizer_kwargs is None else optimizer_kwargs.copy()
+        optimizer_kwargs = self.optimizer_options.copy()
         max_fit_time = kwargs.pop("max_fit_time", self.max_fit_time)
         if max_fit_time is not None:
             if "options" not in optimizer_kwargs:

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -188,7 +188,7 @@ def get_min(
     _, _arg = get_extremum(
         model, "min", bounds, locked_dims, n_samples, max_time=max_time
     )
-    arg = torch.tensor(_arg.reshape(1, bounds.shape[1]))
+    arg = _arg.reshape(1, bounds.shape[1])
     if probability_space:
         val, _ = model.predict_probability(arg)
     else:
@@ -223,7 +223,7 @@ def get_max(
     _, _arg = get_extremum(
         model, "max", bounds, locked_dims, n_samples, max_time=max_time
     )
-    arg = torch.tensor(_arg.reshape(1, bounds.shape[1]))
+    arg = _arg.reshape(1, bounds.shape[1])
     if probability_space:
         val, _ = model.predict_probability(arg)
     else:
@@ -283,7 +283,7 @@ def inv_query(
         weights,
     )
 
-    arg = torch.tensor(_arg.reshape(1, bounds.shape[1]))
+    arg = _arg.reshape(1, bounds.shape[1])
     if probability_space:
         val, _ = model.predict_probability(arg)
     else:

--- a/aepsych/strategy/strategy.py
+++ b/aepsych/strategy/strategy.py
@@ -195,9 +195,8 @@ class Strategy(ConfigurableMixin):
             assert self.model is not None, f"{self.generator} requires a model!"
 
         if self.min_asks == self.min_total_tells == 0:
-            warnings.warn(
+            logger.warning(
                 "strategy.min_asks == strategy.min_total_tells == 0. This strategy will not generate any points!",
-                UserWarning,
             )
 
         self.name = name

--- a/aepsych/utils_logging.py
+++ b/aepsych/utils_logging.py
@@ -8,6 +8,7 @@
 import logging
 import logging.config
 import os
+from typing import Any
 
 logger = logging.getLogger()
 
@@ -47,7 +48,7 @@ def getLogger(level=logging.INFO, log_path: str = "logs") -> logging.Logger:
     """
     os.makedirs(log_path, exist_ok=True)
 
-    logging_config = {
+    logging_config: dict[str, Any] = {
         "version": 1,
         "disable_existing_loggers": True,
         "formatters": {"standard": {"()": ColorFormatter}},
@@ -69,5 +70,11 @@ def getLogger(level=logging.INFO, log_path: str = "logs") -> logging.Logger:
         },
     }
 
+    aepsych_mode = os.environ.get("aepsych_mode", "")
+    if aepsych_mode == "test":
+        logging_config["loggers"][""] = {}
+        logger.setLevel(logging.ERROR)
+
     logging.config.dictConfig(logging_config)
+
     return logger

--- a/aepsych/utils_logging.py
+++ b/aepsych/utils_logging.py
@@ -23,11 +23,11 @@ class ColorFormatter(logging.Formatter):
     my_format = "%(asctime)-15s [%(levelname)-7s] %(message)s"
 
     FORMATS = {
-        logging.DEBUG: reset + grey + my_format,
-        logging.INFO: reset + white + my_format,
-        logging.WARNING: reset + yellow + my_format,
-        logging.ERROR: reset + red + my_format,
-        logging.CRITICAL: reset + bold_red + my_format,
+        logging.DEBUG: grey + my_format + reset,
+        logging.INFO: white + my_format + reset,
+        logging.WARNING: yellow + my_format + reset,
+        logging.ERROR: red + my_format + reset,
+        logging.CRITICAL: bold_red + my_format + reset,
     }
 
     def format(self, record):

--- a/tests/generators/test_independent_optimize_acqf_generator.py
+++ b/tests/generators/test_independent_optimize_acqf_generator.py
@@ -80,9 +80,6 @@ class IndependentGPStratTest(unittest.TestCase):
                 baz_response = torch.bernoulli(f_2d(point))
                 qux_response = f_2d(point, target=torch.tensor([-0.5, -0.5]))
 
-                print(
-                    f"adding data: x = {point}, baz = {baz_response}, qux = {qux_response}"
-                )
                 strat.add_data(point, torch.tensor([[baz_response, qux_response]]))
 
     def test_diff_max_asks(self):

--- a/tests/models/test_gp_regression.py
+++ b/tests/models/test_gp_regression.py
@@ -47,7 +47,7 @@ class GPRegressionTest(unittest.TestCase):
             strategy_names = [init_strat, opt_strat]
 
             [init_strat]
-            min_asks = 10
+            min_asks = 20
             generator = SobolGenerator
 
             [opt_strat]
@@ -56,7 +56,7 @@ class GPRegressionTest(unittest.TestCase):
             model = GPRegressionModel
 
             [OptimizeAcqfGenerator]
-            acqf = qNoisyExpectedImprovement
+            acqf = qLogNoisyExpectedImprovement
 
             [GPRegressionModel]
             likelihood = GaussianLikelihood

--- a/tests/test_datafetcher.py
+++ b/tests/test_datafetcher.py
@@ -59,6 +59,7 @@ class DataFetcherTestCase(unittest.TestCase):
                   min_asks = 5
                   generator = SobolGenerator
                   model = {model_name}
+                  refit_every = 5
                """
 
     def pre_seed_config(

--- a/tests_gpu/models/test_gp_regression.py
+++ b/tests_gpu/models/test_gp_regression.py
@@ -45,7 +45,7 @@ class GPRegressionTest(unittest.TestCase):
             strategy_names = [init_strat, opt_strat]
 
             [init_strat]
-            min_asks = 10
+            min_asks = 20
             generator = SobolGenerator
 
             [opt_strat]
@@ -58,7 +58,7 @@ class GPRegressionTest(unittest.TestCase):
             max_fit_time = 1
 
             [OptimizeAcqfGenerator]
-            acqf = qNoisyExpectedImprovement
+            acqf = qLogNoisyExpectedImprovement
         """
         self.server = AEPsychServer(database_path=dbname)
         configure(self.server, config_str=config)


### PR DESCRIPTION
Summary: Queries are guaranteed to be tensors now so we don’t bother with extra tensor casts.

Differential Revision: D72431168


