### PR TITLE
Send out of generator warning to logger

### DIFF
--- a/aepsych/generators/manual_generator.py
+++ b/aepsych/generators/manual_generator.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-import warnings
 from typing import Any
 
 import torch
@@ -13,6 +12,7 @@ from aepsych.config import Config
 from aepsych.generators.base import AEPsychGenerator
 from aepsych.models.base import AEPsychModelMixin
 from aepsych.utils import _process_bounds
+from aepsych.utils_logging import logger
 from torch.quasirandom import SobolEngine
 
 
@@ -68,13 +68,12 @@ class ManualGenerator(AEPsychGenerator):
             torch.Tensor: Next set of point(s) to evaluate, [num_points x dim].
         """
         if num_points > (len(self.points) - self._idx):
-            warnings.warn(
-                "Asked for more points than are left in the generator! Giving everthing it has!",
-                RuntimeWarning,
+            logger.warning(
+                "Asked for more points than are left in the generator! Giving everything it has!",
             )
 
         if fixed_features is not None and len(fixed_features) != 0:
-            warnings.warn(
+            logger.warning(
                 f"Cannot fix features when generating from {self.__class__.__name__}"
             )
 

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -188,7 +188,7 @@ def get_min(
     _, _arg = get_extremum(
         model, "min", bounds, locked_dims, n_samples, max_time=max_time
     )
-    arg = torch.tensor(_arg.reshape(1, bounds.shape[1]))
+    arg = _arg.reshape(1, bounds.shape[1])
     if probability_space:
         val, _ = model.predict_probability(arg)
     else:
@@ -223,7 +223,7 @@ def get_max(
     _, _arg = get_extremum(
         model, "max", bounds, locked_dims, n_samples, max_time=max_time
     )
-    arg = torch.tensor(_arg.reshape(1, bounds.shape[1]))
+    arg = _arg.reshape(1, bounds.shape[1])
     if probability_space:
         val, _ = model.predict_probability(arg)
     else:
@@ -283,7 +283,7 @@ def inv_query(
         weights,
     )
 
-    arg = torch.tensor(_arg.reshape(1, bounds.shape[1]))
+    arg = _arg.reshape(1, bounds.shape[1])
     if probability_space:
         val, _ = model.predict_probability(arg)
     else:

--- a/aepsych/strategy/sequential.py
+++ b/aepsych/strategy/sequential.py
@@ -7,7 +7,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
 import numpy as np
@@ -67,9 +66,7 @@ class SequentialStrategy(ConfigurableMixin):
     def _make_next_strat(self) -> None:
         """Switch to the next strategy."""
         if (self._strat_idx + 1) >= len(self.strat_list):
-            warnings.warn(
-                "Ran out of generators, staying on final generator!", RuntimeWarning
-            )
+            logger.warning("Ran out of generators, staying on final generator!")
             return
 
         # populate new model with final data from last model

--- a/aepsych/transforms/ops/log10_plus.py
+++ b/aepsych/transforms/ops/log10_plus.py
@@ -21,7 +21,7 @@ class Log10Plus(Log10, Transform):
     def __init__(
         self,
         indices: list[int],
-        constant: float = 0.0,
+        constant: float | torch.Tensor = 0.0,
         transform_on_train: bool = True,
         transform_on_eval: bool = True,
         transform_on_fantasize: bool = True,
@@ -32,7 +32,7 @@ class Log10Plus(Log10, Transform):
 
         Args:
             indices (list[int]): The indices of the parameters to log transform.
-            constant (float): The constant to add to inputs before log transforming.
+            constant (float | torch.Tensor): The constant to add to inputs before log transforming.
                 Defaults to 0.0.
             transform_on_train (bool): A boolean indicating whether to apply the
                 transforms in train() mode. Default: True.
@@ -51,7 +51,12 @@ class Log10Plus(Log10, Transform):
             transform_on_fantasize=transform_on_fantasize,
             reverse=reverse,
         )
-        self.register_buffer("constant", torch.tensor(constant, dtype=torch.long))
+        self.register_buffer(
+            "constant",
+            torch.tensor(constant, dtype=torch.long)
+            if not isinstance(constant, torch.Tensor)
+            else constant.long(),
+        )
 
     @subset_transform
     def _transform(self, X: torch.Tensor) -> torch.Tensor:

--- a/aepsych/utils_logging.py
+++ b/aepsych/utils_logging.py
@@ -73,7 +73,7 @@ def getLogger(level=logging.INFO, log_path: str = "logs") -> logging.Logger:
     aepsych_mode = os.environ.get("aepsych_mode", "")
     if aepsych_mode == "test":
         logging_config["loggers"][""] = {}
-        logger.setLevel(logging.ERROR)
+        logger.setLevel(logging.CRITICAL)
 
     logging.config.dictConfig(logging_config)
 

--- a/tests/generators/test_manual_generator.py
+++ b/tests/generators/test_manual_generator.py
@@ -30,9 +30,12 @@ class TestManualGenerator(unittest.TestCase):
         acq3 = mod.gen()
         self.assertEqual(acq3.shape, (1, 3))
 
-        with self.assertWarns(RuntimeWarning):
+        with self.assertLogs() as log:
             acq4 = mod.gen(num_points=10)
         self.assertEqual(acq4.shape, (4, 3))
+        self.assertIn(
+            "Asked for more points than are left in the generator", log[-1][-1]
+        )
 
     def test_manual_generator(self):
         points = [[10, 10], [10, 11], [11, 10], [11, 11]]
@@ -86,8 +89,10 @@ class TestManualGenerator(unittest.TestCase):
         config.update(config_str=config_str)
         gen = ParameterTransformedGenerator.from_config(config, "ManualGenerator")
 
-        with self.assertWarnsRegex(Warning, "Cannot fix features"):
+        with self.assertLogs() as log:
             gen.gen(fixed_features={0: 10.5})
+
+        self.assertIn("Cannot fix features", log[-1][-1])
 
 
 class TestSampleAroundPointsGenerator(unittest.TestCase):

--- a/tests/models/test_gp_classification.py
+++ b/tests/models/test_gp_classification.py
@@ -853,8 +853,10 @@ class GPClassificationTest(unittest.TestCase):
             next_x = strat.gen()
             strat.add_data(next_x, [bernoulli.rvs(norm.cdf(f_1d(next_x)))])
 
-        with self.assertWarns(RuntimeWarning):
+        with self.assertLogs() as log:
             strat.gen()
+
+        self.assertIn("Ran out of generators", log[0][0].message)
 
     def test_hyperparam_consistency(self):
         # verify that creating the model `from_config` or with `__init__` has the same hyperparams

--- a/tests/server/message_handlers/test_ask_handlers.py
+++ b/tests/server/message_handlers/test_ask_handlers.py
@@ -100,13 +100,18 @@ class AskHandlerTestCase(BaseServerTestCase):
             "version": "0.01",
             "message": {"config_str": manual_dummy_config},
         }
+
         ask_request = {"type": "ask", "message": {"num_points": 10}}
 
         self.s.handle_request(setup_request)
 
-        resp = self.s.handle_request(ask_request)
+        with self.assertLogs() as log:
+            resp = self.s.handle_request(ask_request)
         self.assertEqual(len(resp["config"]["par1"]), 4)
         self.assertEqual(resp["num_points"], 4)
+        self.assertIn(
+            "Asked for more points than are left in the generator", log[-1][-1]
+        )
 
     def test_fixed_ask(self):
         config_str = """

--- a/tests/server/message_handlers/test_ask_handlers.py
+++ b/tests/server/message_handlers/test_ask_handlers.py
@@ -128,12 +128,12 @@ class AskHandlerTestCase(BaseServerTestCase):
 
         [init_strat]
         generator = SobolGenerator
-        min_total_tells = 1
+        min_total_tells = 2
 
         [opt_strat]
         generator = OptimizeAcqfGenerator
         model = GPClassificationModel
-        min_total_tells = 2
+        min_total_tells = 4
 
         [OptimizeAcqfGenerator]
         acqf = MCLevelSetEstimation

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,9 +46,7 @@ class ConfigTestCase(unittest.TestCase):
         outcome_types = [binary]
         parnames = [par1, par2]
         strategy_names = [init_strat, opt_strat]
-        model = GPClassificationModel
-        acqf = MCLevelSetEstimation
-
+        
         [par1]
         par_type = continuous
         lower_bound = 1
@@ -66,6 +64,7 @@ class ConfigTestCase(unittest.TestCase):
 
         [opt_strat]
         generator = OptimizeAcqfGenerator
+        model = GPClassificationModel
         min_asks = 20
         min_post_range = 0.01
         keep_most_recent = 10
@@ -82,6 +81,7 @@ class ConfigTestCase(unittest.TestCase):
         [OptimizeAcqfGenerator]
         restarts = 10
         samps = 1000
+        acqf = MCLevelSetEstimation
         """
         config = Config()
         config.update(config_str=config_str)
@@ -90,9 +90,9 @@ class ConfigTestCase(unittest.TestCase):
             config.get_section("MCLevelSetEstimation")
             == {"beta": "3.84", "objective": "ProbitObjective", "target": "0.75"}
         )
-        self.assertTrue(
-            config.get_section("OptimizeAcqfGenerator")
-            == {"restarts": "10", "samps": "1000"}
+        self.assertDictEqual(
+            config.get_section("OptimizeAcqfGenerator"),
+            {"restarts": "10", "samps": "1000", "acqf": "MCLevelSetEstimation"},
         )
         strat = SequentialStrategy.from_config(config)
 

--- a/tests/test_datafetcher.py
+++ b/tests/test_datafetcher.py
@@ -59,6 +59,7 @@ class DataFetcherTestCase(unittest.TestCase):
                   min_asks = 5
                   generator = SobolGenerator
                   model = {model_name}
+                  refit_every = 5
                """
 
     def pre_seed_config(

--- a/tests/test_points_allocators.py
+++ b/tests/test_points_allocators.py
@@ -67,7 +67,6 @@ class TestInducingPointAllocators(unittest.TestCase):
         config = Config()
         config.update(config_str=config_str)
         strat = Strategy.from_config(config, "init_strat")
-        print(strat.model.inducing_point_method)
         self.assertTrue(isinstance(strat.model.inducing_point_method, SobolAllocator))
 
         # check that the bounds are scaled correctly

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -103,7 +103,7 @@ class TransformsWrapperTest(unittest.TestCase):
             seed = 12345
 
             [opt_strat]
-            min_total_tells = 2
+            min_total_tells = 12
             generator = OptimizeAcqfGenerator
             model = GPRegressionModel
 
@@ -120,12 +120,16 @@ class TransformsWrapperTest(unittest.TestCase):
             "type": "tell",
             "message": {"config": {"signal1": [50], "signal2": [50]}, "outcome": 1},
         }
+        exit_request = {"type": "exit", "message": {}}
 
         server.handle_request(setup_request)
-        while not server.strat.finished:
+        tell_count = 0
+        while tell_count < 11:
             server.handle_request(ask_request)
             server.handle_request(tell_request)
+            tell_count += 1
 
+        server.handle_request(exit_request)
         # Remember transform for later
         transforms = server.strat.transforms
         server.cleanup()


### PR DESCRIPTION
Summary: When strategy is out of generator the warning message is now directly sent to logger.

Differential Revision: D72473099


