### PR TITLE
Reorder replay asks make a new strat before adding points

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -9,7 +9,7 @@ on:
     - cron: "0 12 * * *" # every day at 4AM west coast time
 
 env:
-  aepsych_mode: test
+  AEPSYCH_MODE: test
 
 jobs:
   lint:

--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -140,8 +140,7 @@ class AcqfGenerator(AEPsychGenerator):
                     if key not in config["common"]:
                         # HACK: Not actually sure why some required args can be missing
                         logger.debug(
-                            f"{acqf_name} requires the {key} option but we could not find it.",
-                            UserWarning,
+                            f"{acqf_name} requires the {key} option but we could not find it."
                         )
                         continue
 

--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -154,10 +154,10 @@ class PairwiseProbitModel(PairwiseGP, AEPsychModelMixin):
             optimizer_kwargs["options"]["maxfun"] = n_eval
             logger.info(f"fit maxfun is {n_eval}")
 
-        logger.info("Starting fit...")
+        logger.info("Starting fitting (no warm start)...")
         starttime = time.time()
         fit_gpytorch_mll(mll, optimizer_kwargs=optimizer_kwargs, **kwargs)
-        logger.info(f"Fit done, time={time.time() - starttime}")
+        logger.info(f"Fitting done, took {time.time() - starttime}")
 
     def predict(
         self,

--- a/aepsych/server/message_handlers/handle_ask.py
+++ b/aepsych/server/message_handlers/handle_ask.py
@@ -72,9 +72,9 @@ def ask(server, num_points: int = 1, **kwargs) -> dict[str, Any] | None:
     """
     if server.skip_computations:
         # Fakes points being generated and tracked by strategy to end strategies
-        server.strat._strat._count += num_points
         if server.strat._strat.finished:
             server.strat._make_next_strat()
+        server.strat._strat._count += num_points
         return None
 
     # The fixed_pars kwargs name is purposefully different to the fixed_features

--- a/aepsych/server/message_handlers/handle_exit.py
+++ b/aepsych/server/message_handlers/handle_exit.py
@@ -31,7 +31,7 @@ def handle_exit(server, request: dict[str, Any]) -> ExitResponse:
                 true if this function succeeds.
     """
     termination_type = "Normal termination"
-    logger.info("Got termination message!")
+    logger.info("got termination message!")
     server.write_strats(termination_type)
     server.exit_server_loop = True
 

--- a/aepsych/server/message_handlers/handle_tell.py
+++ b/aepsych/server/message_handlers/handle_tell.py
@@ -102,8 +102,13 @@ def flatten_tell_record(server, rec: DbReplayTable) -> dict[str, Any]:
         )[0]
     )
 
-    if rec.extra_info is not None:
-        out.update(rec.extra_info)
+    extra_data = {
+        key: value
+        for key, value in rec.message_contents["message"].items()
+        if key not in ["config", "outcome", "model_data"]
+    }
+    if len(extra_data) != 0:
+        out.update(extra_data)
 
     return out
 

--- a/aepsych/server/utils.py
+++ b/aepsych/server/utils.py
@@ -8,9 +8,7 @@
 import argparse
 import logging
 import os
-import shutil
 import sys
-import tempfile
 
 import aepsych.database.db as db
 import aepsych.utils_logging as utils_logging
@@ -85,17 +83,17 @@ def run_database(args):
         if args.summarize:
             summary = database.summarize_experiments()
             print(summary)
-            database.delete_db()
+            database.cleanup()
 
         elif "tocsv" in args and args.tocsv is not None:
             try:
                 database.to_csv(args.tocsv)
                 logger.info(f"Exported contents of {database_path} to {args.tocsv}")
-                database.delete_db()
             except Exception as error:
                 logger.error(
                     f"Failed to export contents of {database_path} with error `{error}`"
                 )
+            database.cleanup()
 
         elif "update" in args and args.update:
             logger.info(f"Updating the database {database_path}")

--- a/aepsych/strategy/strategy.py
+++ b/aepsych/strategy/strategy.py
@@ -191,7 +191,7 @@ class Strategy(ConfigurableMixin):
         if self.generator._requires_model:
             assert self.model is not None, f"{self.generator} requires a model!"
 
-        if self.min_asks == self.min_total_tells == 0:
+        if self.min_asks == self.min_total_tells == 0 and self.max_asks is None:
             logger.warning(
                 "strategy.min_asks == strategy.min_total_tells == 0. This strategy will not generate any points!",
             )

--- a/aepsych/strategy/strategy.py
+++ b/aepsych/strategy/strategy.py
@@ -94,12 +94,12 @@ class Strategy(ConfigurableMixin):
         self.is_finished = False
 
         if run_indefinitely:
-            warnings.warn(
+            logger.warning(
                 f"Strategy {name} will run indefinitely until finish() is explicitly called. Other stopping criteria will be ignored."
             )
 
         elif min_total_tells > 0 and min_asks > 0:
-            warnings.warn(
+            logger.warning(
                 "Specifying both min_total_tells and min_asks > 0 may lead to unintended behavior."
             )
 
@@ -122,9 +122,8 @@ class Strategy(ConfigurableMixin):
 
             if use_gpu_modeling:
                 if not torch.cuda.is_available():
-                    warnings.warn(
+                    logger.warning(
                         f"GPU requested for model {type(model).__name__}, but no GPU found! Using CPU instead.",
-                        UserWarning,
                     )
                     self.model_device = torch.device("cpu")
                 else:
@@ -135,16 +134,14 @@ class Strategy(ConfigurableMixin):
 
         if use_gpu_generating:
             if model is None:
-                warnings.warn(
+                logger.warning(
                     f"GPU requested for generator {type(generator).__name__} but this generator has no model to move to GPU. Using CPU instead.",
-                    UserWarning,
                 )
                 self.generator_device = torch.device("cpu")
             else:
                 if not torch.cuda.is_available():
-                    warnings.warn(
+                    logger.warning(
                         f"GPU requested for generator {type(generator).__name__}, but no GPU found! Using CPU instead.",
-                        UserWarning,
                     )
                     self.generator_device = torch.device("cpu")
                 else:
@@ -607,9 +604,8 @@ class Strategy(ConfigurableMixin):
 
         if options["model"] is not None and not options["generator"]._requires_model:
             if options["refit_every"] < options["min_asks"]:
-                warnings.warn(
+                logger.warning(
                     f"Strategy '{name}' has refit_every < min_asks even though its generator does not require a model. Consider making refit_every = min_asks to speed up point generation.",
-                    UserWarning,
                 )
 
         options["min_total_outcome_occurrences"] = config.getint(

--- a/tests/acquisition/test_mi.py
+++ b/tests/acquisition/test_mi.py
@@ -91,7 +91,7 @@ class SingleProbitMI(unittest.TestCase):
         )
         x = torch.rand(size=(10, 1))
         acqf = BernoulliMCMutualInformation(model=model, objective=ProbitObjective())
-        acq_pytorch = acqf(x)
+        acq_pytorch = acqf(x.unsqueeze(1))
 
         samps_numpy = norm.cdf(
             multivariate_normal.rvs(mean=np.ones(10) * 1.2, cov=x @ x.T, size=10000)

--- a/tests/models/test_gp_regression.py
+++ b/tests/models/test_gp_regression.py
@@ -16,6 +16,7 @@ from aepsych.server import AEPsychServer
 from aepsych.server.message_handlers.handle_ask import ask
 from aepsych.server.message_handlers.handle_setup import configure
 from aepsych.server.message_handlers.handle_tell import tell
+from aepsych.utils_logging import _set_test_warning_filters
 from gpytorch.likelihoods import GaussianLikelihood
 
 # run on single threads to keep us from deadlocking weirdly in CI
@@ -33,6 +34,7 @@ class GPRegressionTest(unittest.TestCase):
         return response
 
     def setUp(self):
+        _set_test_warning_filters()  # Needed to silence warnings from unittest
         np.random.seed(0)
         torch.manual_seed(0)
 

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -428,7 +428,10 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
             )
 
         xy = torch.stack(
-            torch.meshgrid(torch.linspace(-1, 1, 30), torch.linspace(-1, 1, 30)), dim=-1
+            torch.meshgrid(
+                torch.linspace(-1, 1, 30), torch.linspace(-1, 1, 30), indexing="ij"
+            ),
+            dim=-1,
         ).view(-1, 2)
 
         zhat, _ = strat.predict(xy)

--- a/tests/server/message_handlers/test_handle_exit.py
+++ b/tests/server/message_handlers/test_handle_exit.py
@@ -19,9 +19,11 @@ class HandleExitTestCase(BaseServerTestCase):
         self.s.socket.receive = MagicMock(return_value=request)
         self.s.dump = MagicMock()
 
-        with self.assertRaises(SystemExit) as cm:
-            self.s.serve()
+        with self.assertLogs() as log:
+            with self.assertRaises(SystemExit) as cm:
+                self.s.serve()
 
+        self.assertIn("No connection to send to!", " ".join(log.output))
         self.assertEqual(cm.exception.code, 0)
 
     def test_exit_response(self):

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -171,7 +171,6 @@ class ServerTestCase(BaseServerTestCase):
         tell_request = {
             "type": "tell",
             "message": {"config": {"x": [0.5]}, "outcome": 1},
-            "extra_info": {},
         }
         self.s.handle_request(setup_request)
         expected_x = [0, 1, 2, 3]
@@ -208,7 +207,6 @@ class ServerTestCase(BaseServerTestCase):
         tell_request = {
             "type": "tell",
             "message": {"config": {"x": [0.5]}, "outcome": 1},
-            "extra_info": {},
         }
         expected_x = [0, 1, 2, 3]
         expected_z = list(reversed(expected_x))

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -183,8 +183,8 @@ class ServerTestCase(BaseServerTestCase):
             tell_request["message"]["config"]["x"] = [expected_x[i]]
             tell_request["message"]["config"]["z"] = [expected_z[i]]
             tell_request["message"]["outcome"] = expected_y[i]
-            tell_request["extra_info"]["e1"] = 1
-            tell_request["extra_info"]["e2"] = 2
+            tell_request["message"]["e1"] = 1
+            tell_request["message"]["e2"] = 2
             i = i + 1
             self.s.handle_request(tell_request)
 
@@ -220,8 +220,8 @@ class ServerTestCase(BaseServerTestCase):
             tell_request["message"]["config"]["x"] = [expected_x[i]]
             tell_request["message"]["config"]["z"] = [expected_z[i]]
             tell_request["message"]["outcome"] = expected_y[i]
-            tell_request["extra_info"]["e1"] = 1
-            tell_request["extra_info"]["e2"] = 2
+            tell_request["message"]["e1"] = 1
+            tell_request["message"]["e2"] = 2
             i = i + 1
             self.s.handle_request(tell_request)
 
@@ -250,7 +250,6 @@ class ServerTestCase(BaseServerTestCase):
         tell_request = {
             "type": "tell",
             "message": {"config": {"x": [0.5]}, "outcome": 1},
-            "extra_info": {},
         }
         self.s.handle_request(setup_request)
         expected_x = [0, 1, 2, 3]
@@ -262,8 +261,8 @@ class ServerTestCase(BaseServerTestCase):
             tell_request["message"]["config"]["x"] = expected_x[i]
             tell_request["message"]["config"]["z"] = expected_z[i]
             tell_request["message"]["outcome"] = expected_y[i]
-            tell_request["extra_info"]["e1"] = 1
-            tell_request["extra_info"]["e2"] = 2
+            tell_request["message"]["e1"] = 1
+            tell_request["message"]["e2"] = 2
             i = i + 1
             self.s.handle_request(tell_request)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -362,8 +362,10 @@ class ConfigTestCase(unittest.TestCase):
 
         config = Config(config_str=config_str)
 
-        with self.assertWarns(UserWarning):
+        with self.assertLogs() as log:
             Strategy.from_config(config, "init_strat")
+
+        self.assertIn("Strategy 'init_strat' has refit_every < min_asks", log.output[0])
 
     def test_nested_tensor(self):
         points = [[0.25, 0.75], [0.5, 0.9]]

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -207,7 +207,7 @@ class TestSequenceGenerators(unittest.TestCase):
         lb = torch.tensor([-1.0, -1.0])
         ub = torch.tensor([1.0, 1.0])
 
-        with self.assertWarns(UserWarning):
+        with self.assertLogs() as log:
             self.strat = Strategy(
                 model=GPClassificationModel(
                     dim=2,
@@ -220,6 +220,8 @@ class TestSequenceGenerators(unittest.TestCase):
                 min_asks=1,  # should be ignored
                 run_indefinitely=True,
             )
+
+        self.assertIn("Strategy  will run indefinitely until finish()", log.output[0])
         self.strat.gen()
         self.assertFalse(self.strat.finished)
         self.strat.finish()
@@ -357,7 +359,7 @@ class TestStrategyGPU(unittest.TestCase):
         torch.cuda.is_available(), "gpu is available, can't test no gpu warning"
     )
     def test_no_gpu_model_warn(self):
-        with self.assertWarns(UserWarning):
+        with self.assertLogs() as log:
             Strategy(
                 lb=[0],
                 ub=[1],
@@ -370,11 +372,16 @@ class TestStrategyGPU(unittest.TestCase):
                 use_gpu_modeling=True,
             )
 
+        self.assertIn(
+            "GPU requested for model GPClassificationModel, but no GPU found!",
+            log.output[0],
+        )
+
     @unittest.skipIf(
         torch.cuda.is_available(), "gpu is available, can't test no gpu warning"
     )
     def test_no_gpu_generator_warn(self):
-        with self.assertWarns(UserWarning):
+        with self.assertLogs() as log:
             Strategy(
                 lb=[0],
                 ub=[1],
@@ -388,6 +395,11 @@ class TestStrategyGPU(unittest.TestCase):
                 ),
                 use_gpu_generating=True,
             )
+
+        self.assertIn(
+            "GPU requested for generator OptimizeAcqfGenerator, but no GPU found!",
+            log.output[0],
+        )
 
 
 if __name__ == "__main__":

--- a/tests_gpu/test_strategy.py
+++ b/tests_gpu/test_strategy.py
@@ -13,7 +13,7 @@ from aepsych.strategy import Strategy
 
 class TestStrategyGPU(unittest.TestCase):
     def test_gpu_no_model_generator_warn(self):
-        with self.assertWarns(UserWarning):
+        with self.assertLogs() as log:
             Strategy(
                 lb=[0.0],
                 ub=[1.0],
@@ -23,6 +23,11 @@ class TestStrategyGPU(unittest.TestCase):
                 generator=SobolGenerator(lb=[0], ub=[1]),
                 use_gpu_generating=True,
             )
+
+        self.assertIn(
+            "GPU requested for generator SobolGenerator but this generator has no model to move to GPU",
+            log.output[0],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: When skipping computation the order of operation doesn’t match a real ask message. Now it will try to make a new strategy then fake generating points.

Differential Revision: D72623652


