### PR TITLE
Ignore cleanup errors in temp file for database

### DIFF
--- a/aepsych/generators/base.py
+++ b/aepsych/generators/base.py
@@ -140,8 +140,7 @@ class AcqfGenerator(AEPsychGenerator):
                     if key not in config["common"]:
                         # HACK: Not actually sure why some required args can be missing
                         logger.debug(
-                            f"{acqf_name} requires the {key} option but we could not find it.",
-                            UserWarning,
+                            f"{acqf_name} requires the {key} option but we could not find it."
                         )
                         continue
 

--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -154,10 +154,10 @@ class PairwiseProbitModel(PairwiseGP, AEPsychModelMixin):
             optimizer_kwargs["options"]["maxfun"] = n_eval
             logger.info(f"fit maxfun is {n_eval}")
 
-        logger.info("Starting fit...")
+        logger.info("Starting fitting (no warm start)...")
         starttime = time.time()
         fit_gpytorch_mll(mll, optimizer_kwargs=optimizer_kwargs, **kwargs)
-        logger.info(f"Fit done, time={time.time() - starttime}")
+        logger.info(f"Fitting done, took {time.time() - starttime}")
 
     def predict(
         self,

--- a/aepsych/server/message_handlers/handle_exit.py
+++ b/aepsych/server/message_handlers/handle_exit.py
@@ -31,7 +31,7 @@ def handle_exit(server, request: dict[str, Any]) -> ExitResponse:
                 true if this function succeeds.
     """
     termination_type = "Normal termination"
-    logger.info("Got termination message!")
+    logger.info("got termination message!")
     server.write_strats(termination_type)
     server.exit_server_loop = True
 

--- a/aepsych/server/utils.py
+++ b/aepsych/server/utils.py
@@ -57,7 +57,7 @@ def run_database(args):
         if args.summarize or "tocsv" in args and args.tocsv is not None:
             # Make a temporary database using TemporaryDirectory for automatic cleanup
             _, db_name = os.path.split(database_path)
-            temp_dir = tempfile.TemporaryDirectory()
+            temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
             temp_db_path = os.path.join(temp_dir.name, db_name)
             shutil.copy2(database_path, temp_db_path)
             logger.info(


### PR DESCRIPTION
Summary: Cleanup errors aren't important so we ignore those errors (they'll get cleaned up by the os later if it fails).

Differential Revision: D72654484


