### PR TITLE
Make warnings throw errors if not ignored

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -33,8 +33,7 @@ jobs:
 
       - name: Lint aepsych with ruff
         run: |
-          ruff check --select=E9,F63,F7,F82
-          ruff check --exit-zero --output-format github
+          ruff check --select=E9,F63,F7,F82 --output-format github
 
       - name: Type check aepsych with mypy
         if: always()
@@ -43,8 +42,7 @@ jobs:
       - name: Lint aepsych_client with ruff
         if: always()
         run: |
-          ruff check --select=E9,F63,F7,F82
-          ruff check --exit-zero --output-format github
+          ruff check --select=E9,F63,F7,F82 --output-format github
         working-directory: clients/python
 
       - name: Type check aepsych_client with mypy

--- a/aepsych/__init__.py
+++ b/aepsych/__init__.py
@@ -7,6 +7,10 @@
 
 import sys
 
+from .utils_logging import _set_test_warning_filters
+
+_set_test_warning_filters()
+
 import torch
 from gpytorch.likelihoods import BernoulliLikelihood, GaussianLikelihood
 

--- a/aepsych/database/utils.py
+++ b/aepsych/database/utils.py
@@ -6,8 +6,6 @@
 # LICENSE file in the root directory of this source tree.
 import io
 import json
-import shutil
-import tempfile
 import warnings
 from pathlib import Path
 from typing import Sequence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,4 @@ include = [
     "tests/**/*.py",
     "tests_gpu/**/*.py"
 ]
+exclude = ["aepsych/__init__.py"]


### PR DESCRIPTION
Summary: Making warnings cause errors to make CI more reliable in finding problems.

Differential Revision: D72811244


