### PR TITLE
Fix copyright header in extensions.py

### DIFF
--- a/aepsych/extensions.py
+++ b/aepsych/extensions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) Meta, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
 # All rights reserved.
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary: There was a typo in the extensions.py copyright header.

Differential Revision: D73047875


