### PR TITLE
Add extra metadata to dataframe when extra data is included

### DIFF
--- a/aepsych/database/db.py
+++ b/aepsych/database/db.py
@@ -621,6 +621,12 @@ class Database:
                 row["participant_id"] = rec.participant_id
                 row["timestamp"] = pars[0].parent.timestamp
 
+                if include_extra_data and rec.extra_metadata is not None:
+                    try:
+                        row.update(json.loads(rec.extra_metadata))
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+
                 row.update({par.param_name: par.param_value for par in pars})
                 row.update({out.outcome_name: out.outcome_value for out in outs})
 


### PR DESCRIPTION
Summary: Add master record extra metadata when extra_data is asked for with get_data_frme.

Differential Revision: D73076136


