### PR TITLE
Include extra data to db cli exporting csv

### DIFF
--- a/aepsych/database/db.py
+++ b/aepsych/database/db.py
@@ -646,7 +646,7 @@ class Database:
 
         return pd.concat(dfs)
 
-    def to_csv(self, path: str):
+    def to_csv(self, path: str, include_extra_data: bool = False):
         """Exports the parameter and outcome data in the database to a csv file.
 
         This function can also be called from the command line using
@@ -654,6 +654,8 @@ class Database:
 
         Args:
             path (str): The filepath of the output csv.
+            include_extra_data (bool): Whether to include columns for extra data
+            from the raw table. Defaults to False.
         """
-        df = self.get_data_frame()
+        df = self.get_data_frame(include_extra_data=include_extra_data)
         df.to_csv(path, index=False)

--- a/aepsych/server/utils.py
+++ b/aepsych/server/utils.py
@@ -87,7 +87,7 @@ def run_database(args):
 
         elif "tocsv" in args and args.tocsv is not None:
             try:
-                database.to_csv(args.tocsv)
+                database.to_csv(args.tocsv, include_extra_data=True)
                 logger.info(f"Exported contents of {database_path} to {args.tocsv}")
             except Exception as error:
                 logger.error(


### PR DESCRIPTION
Summary: When creating a csv from a database from the CLI, always include extra data.

Differential Revision: D73466503


