### PR TITLE
Remove module parent from transform ops

### DIFF
--- a/aepsych/transforms/ops/fixed.py
+++ b/aepsych/transforms/ops/fixed.py
@@ -12,7 +12,7 @@ from aepsych.config import Config
 from aepsych.transforms.ops.base import StringParameterMixin, Transform
 
 
-class Fixed(Transform, StringParameterMixin, torch.nn.Module):
+class Fixed(Transform, StringParameterMixin):
     def __init__(
         self,
         indices: list[int],

--- a/aepsych/transforms/ops/round.py
+++ b/aepsych/transforms/ops/round.py
@@ -12,7 +12,7 @@ from aepsych.transforms.ops.base import Transform
 from botorch.models.transforms.input import subset_transform
 
 
-class Round(Transform, torch.nn.Module):
+class Round(Transform):
     def __init__(
         self,
         indices: list[int],


### PR DESCRIPTION
Summary: Latest version of botorch already includes it, so we don't need it anymore.

Differential Revision: D73802191


