### PR TITLE
Ensure dbs tests don't leave hanging temporary files

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -648,6 +648,8 @@ class DBUtilityTestCase(unittest.TestCase):
         np.testing.assert_equal(df.iloc[0]["trial_number"], np.nan)
         self.assertEqual(df.iloc[1]["trial_number"], 2)
 
+        extra_info_data.cleanup()
+
     def test_combine_dbs_list(self):
         """Test the combine_dbs function with a list of database paths."""
         # Get paths to existing test databases
@@ -692,6 +694,8 @@ class DBUtilityTestCase(unittest.TestCase):
             self.assertTrue(
                 "single_stimuli.db" in origin_db or "extra_info.db" in origin_db
             )
+
+        combined_db.cleanup()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Extra read only databases were leaving temporary resources hanging and not cleaning up. Fixed to ensure they are manually handled.

Differential Revision: D74211454


