### PR TITLE
Index kernel lkj prior now has the correct n

### DIFF
--- a/aepsych/factory/mixed.py
+++ b/aepsych/factory/mixed.py
@@ -103,7 +103,7 @@ class MixedMeanCovarFactory(DefaultMeanCovarFactory):
                         active_dims=(idx,),
                         ard_num_dims=1,
                         prior=gpytorch.priors.LKJCovariancePrior(
-                            n=self.discrete_param_ranks[idx],
+                            n=self.discrete_params[idx],
                             eta=1.5,
                             sd_prior=gpytorch.priors.GammaPrior(1.0, 0.15),
                         ),

--- a/tests/test_mean_covar_factories.py
+++ b/tests/test_mean_covar_factories.py
@@ -777,9 +777,6 @@ class TestMixedFactories(unittest.TestCase):
 
         [GPClassificationModel]
         mean_covar_factory = MixedMeanCovarFactory
-
-        [MixedMeanCovarFactory]
-        # discrete_kernel = index
         """
         config = Config(config_str=config_str)
         strat = SequentialStrategy.from_config(config)


### PR DESCRIPTION
Summary: The index kernel for the mixed factory uses a lkj prior which was using the wrong n (the rank instead of the number of discrete levels). This is fixed.

Differential Revision: D74374743


