### PR TITLE
Mass warning stack level cleanup

### DIFF
--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -334,7 +334,7 @@ class Config(configparser.ConfigParser):
                         f"Object {v} is deprecated and no longer supported!"
                     )
                 else:
-                    warnings.warn(f'No known object "{v}"!')
+                    warnings.warn(f'No known object "{v}"!', stacklevel=2)
 
             return fallback_type(v)
 
@@ -449,7 +449,8 @@ class Config(configparser.ConfigParser):
             warnings.warn(
                 f"Registering {obj.__name__} but already"
                 + f"have {cls.registered_names[obj.__name__]}"
-                + "registered under that name!"
+                + "registered under that name!",
+                stacklevel=2,
             )
         cls.registered_names.update({obj.__name__: obj})
 

--- a/aepsych/factory/default.py
+++ b/aepsych/factory/default.py
@@ -333,7 +333,8 @@ def _get_default_mean_function(
         if fixed_mean:
             if zero_mean:
                 warnings.warn(
-                    "Specified both `zero_mean = True` and `fixed_mean = True`. Deferring to fixed_mean!"
+                    "Specified both `zero_mean = True` and `fixed_mean = True`. Deferring to fixed_mean!",
+                    stacklevel=2,
                 )
             try:
                 target = config.getfloat("default_mean_covar_factory", "target")

--- a/aepsych/generators/optimize_acqf_generator.py
+++ b/aepsych/generators/optimize_acqf_generator.py
@@ -93,7 +93,8 @@ class OptimizeAcqfGenerator(AcqfGenerator):
 
         if isinstance(acqf, LookaheadAcquisitionFunction) and num_points > 1:
             warnings.warn(
-                f"{num_points} points were requested, but `{acqf.__class__.__name__}` can only generate one point at a time, returning only 1."
+                f"{num_points} points were requested, but `{acqf.__class__.__name__}` can only generate one point at a time, returning only 1.",
+                stacklevel=2,
             )
             num_points = 1
 

--- a/aepsych/models/base.py
+++ b/aepsych/models/base.py
@@ -182,7 +182,8 @@ class AEPsychModelMixin(GPyTorchModel, ConfigurableMixin):
         """
         if not strict:
             warnings.warn(
-                "strict set to false, but set_train_data will always follow device"
+                "strict set to false, but set_train_data will always follow device",
+                stacklevel=2,
             )
 
         if inputs is None:

--- a/aepsych/models/independent_gps.py
+++ b/aepsych/models/independent_gps.py
@@ -143,7 +143,9 @@ class IndependentGPsModel(AEPsychModelMixin):
         """
         if transformed_posterior_cls is not None:
             warnings.warn(
-                "transformed_posterior_cls is set but will be ignored.", UserWarning
+                "transformed_posterior_cls is set but will be ignored.",
+                UserWarning,
+                stacklevel=2,
             )
         means = []
         vars = []

--- a/aepsych/models/utils.py
+++ b/aepsych/models/utils.py
@@ -266,7 +266,8 @@ def inv_query(
             weights = torch.Tensor([1] * model._num_outputs)
     if probability_space:
         warnings.warn(
-            "Inverse querying with probability_space=True assumes that the model uses Probit-Bernoulli likelihood!"
+            "Inverse querying with probability_space=True assumes that the model uses Probit-Bernoulli likelihood!",
+            stacklevel=2,
         )
         posterior_transform = TargetProbabilityDistancePosteriorTransform(y, weights)
     else:

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -586,7 +586,8 @@ def facet_slices(
     if "layout" in kwargs:
         layout = kwargs.pop("layout")
         warnings.warn(
-            "The layout arg for subplots is defaulted to 'constrained', be careful when changing this"
+            "The layout arg for subplots is defaulted to 'constrained', be careful when changing this",
+            stacklevel=2,
         )
     else:
         layout = "constrained"
@@ -731,6 +732,7 @@ def plot_strat(
     warnings.warn(
         "Plotting directly from strategy is deprecated, plots should be composed manually using the Matplotlib API, AEPsych specific helper functions are available in the plotting submodule.",
         DeprecationWarning,
+        stacklevel=2,
     )
     assert (
         "binary" in strat.outcome_types
@@ -738,7 +740,8 @@ def plot_strat(
 
     if target_level is not None and not hasattr(strat.model, "monotonic_idxs"):
         warnings.warn(
-            "Threshold estimation may not be accurate for non-monotonic models."
+            "Threshold estimation may not be accurate for non-monotonic models.",
+            stacklevel=2,
         )
 
     if ax is None:
@@ -1081,6 +1084,7 @@ def plot_strat_3d(
     warnings.warn(
         "Plotting directly from strategy is deprecated, plots should be composed manually using the Matplotlib API, AEPsych specific helper functions are available in the plotting submodule.",
         DeprecationWarning,
+        stacklevel=2,
     )
     assert strat.model is not None, "Cannot plot without a model!"
 

--- a/aepsych/strategy/strategy.py
+++ b/aepsych/strategy/strategy.py
@@ -513,7 +513,11 @@ class Strategy(ConfigurableMixin):
                         "Failed to fit model! Predictions may not be accurate!"
                     )
         else:
-            warnings.warn("Cannot fit: no model has been initialized!", RuntimeWarning)
+            warnings.warn(
+                "Cannot fit: no model has been initialized!",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     def update(self) -> None:
         """Update the model."""
@@ -537,7 +541,11 @@ class Strategy(ConfigurableMixin):
                         "Failed to fit model! Predictions may not be accurate!"
                     )
         else:
-            warnings.warn("Cannot fit: no model has been initialized!", RuntimeWarning)
+            warnings.warn(
+                "Cannot fit: no model has been initialized!",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     @classmethod
     def get_config_options(

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -226,7 +226,8 @@ class ParameterTransforms(ChainedInputTransform, ConfigurableMixin):
         """
         if options is not None:
             warnings.warn(
-                "options argument is set but we will ignore it to create an entirely new options dictionary to ensure transforms are applied in the right order."
+                "options argument is set but we will ignore it to create an entirely new options dictionary to ensure transforms are applied in the right order.",
+                stacklevel=2,
             )
 
         transform_options = {}
@@ -465,7 +466,8 @@ class ParameterTransformedGenerator(ParameterTransformWrapper, ConfigurableMixin
             return self._base_obj.training  # type: ignore
         except AttributeError:
             warnings.warn(
-                f"{self._base_obj.__class__.__name__} has no attribute 'training', returning transforms' `training`"
+                f"{self._base_obj.__class__.__name__} has no attribute 'training', returning transforms' `training`",
+                stacklevel=2,
             )
             return self.transforms.training
 
@@ -478,7 +480,8 @@ class ParameterTransformedGenerator(ParameterTransformWrapper, ConfigurableMixin
             self._base_obj.train()
         except AttributeError:
             warnings.warn(
-                f"{self._base_obj.__class__.__name__} has no attribute 'train'"
+                f"{self._base_obj.__class__.__name__} has no attribute 'train'",
+                stacklevel=2,
             )
 
     def eval(self):
@@ -490,7 +493,8 @@ class ParameterTransformedGenerator(ParameterTransformWrapper, ConfigurableMixin
             self._base_obj.eval()
         except AttributeError:
             warnings.warn(
-                f"{self._base_obj.__class__.__name__} has no attribute 'eval'"
+                f"{self._base_obj.__class__.__name__} has no attribute 'eval'",
+                stacklevel=2,
             )
 
     def __reduce__(self):
@@ -752,7 +756,8 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
             return self._base_obj.training  # type: ignore
         except AttributeError:
             warnings.warn(
-                f"{self._base_obj.__class__.__name__} has no attribute 'training', returning transforms' 'training'"
+                f"{self._base_obj.__class__.__name__} has no attribute 'training', returning transforms' 'training'",
+                stacklevel=2,
             )
             return self.transforms.training
 
@@ -765,7 +770,8 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
             self._base_obj.train()
         except AttributeError:
             warnings.warn(
-                f"{self._base_obj.__class__.__name__} has no attribute 'train'"
+                f"{self._base_obj.__class__.__name__} has no attribute 'train'",
+                stacklevel=2,
             )
 
     def eval(self):
@@ -777,7 +783,8 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
             self._base_obj.eval()
         except AttributeError:
             warnings.warn(
-                f"{self._base_obj.__class__.__name__} has no attribute 'eval'"
+                f"{self._base_obj.__class__.__name__} has no attribute 'eval'",
+                stacklevel=2,
             )
 
     def __reduce__(self):


### PR DESCRIPTION
Summary: Warnings for stacklevels were often defaulted in the codebase. Now every warning should have at least a stacklevel of 2.

Differential Revision: D74767232


