### PR TITLE
Fix pairwise probit sample method compat

### DIFF
--- a/aepsych/models/pairwise_probit.py
+++ b/aepsych/models/pairwise_probit.py
@@ -12,6 +12,7 @@ import torch
 from aepsych.config import Config
 from aepsych.factory import DefaultMeanCovarFactory
 from aepsych.models.base import AEPsychModelMixin
+from aepsych.models.utils import get_max, get_min
 from aepsych.utils import _process_bounds, promote_0d
 from aepsych.utils_logging import getLogger
 from botorch.fit import fit_gpytorch_mll
@@ -230,9 +231,9 @@ class PairwiseProbitModel(PairwiseGP, AEPsychModelMixin):
         elif rereference == "x_max":
             x_ref = self.ub
         elif rereference == "f_max":
-            x_ref = torch.Tensor(self.get_max()[1])
+            x_ref = get_max(model=self, bounds=torch.stack((self.lb, self.ub)))[1]
         elif rereference == "f_min":
-            x_ref = torch.Tensor(self.get_min()[1])
+            x_ref = get_min(model=self, bounds=torch.stack((self.lb, self.ub)))[1]
         else:
             raise RuntimeError(
                 f"Unknown rereference type {rereference}! Options: x_min, x_max, f_min, f_max."

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -691,18 +691,19 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
         )
 
     @_promote_1d
-    def sample(self, x: torch.Tensor, num_samples: int) -> torch.Tensor:
+    def sample(self, x: torch.Tensor, num_samples: int, **kwargs) -> torch.Tensor:
         """Sample from underlying model given transformed x.
 
         Args:
             x (torch.Tensor): Points at which to sample, which will be transformed.
             num_samples (int): Number of samples to return.
+            **kwargs: Keyword arguments to pass to the model.sample() call.
 
         Returns:
             torch.Tensor: Posterior samples [num_samples x dim]
         """
         x = self.transforms.transform(x)
-        return self._base_obj.sample(x, num_samples)
+        return self._base_obj.sample(x, num_samples, **kwargs)
 
     def posterior(self, X: torch.Tensor, **kwargs) -> Posterior:
         """Return the model's posterior given a transformed X. Notice that this specific


### PR DESCRIPTION
Summary:
Pairwise probit has a unique sample method. It has additional arguments ("rereference") as well it requires get_min and get_max.

To fix this:
Updated model wrappers to support passing kwargs down to sample methods.
Updated sample method to use get_min and get_max helper functions as opposed to model-specific methods that no longer exists.

Differential Revision: D74921570


