### PR TITLE
`average_over_ensemble_models` decorator for acquisition functions

### DIFF
--- a/aepsych/acquisition/lookahead.py
+++ b/aepsych/acquisition/lookahead.py
@@ -14,7 +14,10 @@ from botorch.acquisition import AcquisitionFunction
 from botorch.acquisition.input_constructors import acqf_input_constructor
 from botorch.acquisition.objective import PosteriorTransform
 from botorch.models.gpytorch import GPyTorchModel
-from botorch.utils.transforms import t_batch_mode_transform
+from botorch.utils.transforms import (
+    average_over_ensemble_models,
+    t_batch_mode_transform,
+)
 from scipy.stats import norm
 from torch import Tensor
 
@@ -171,6 +174,7 @@ class LocalLookaheadAcquisitionFunction(LookaheadAcquisitionFunction):
         self.posterior_transform = posterior_transform
 
     @t_batch_mode_transform(expected_q=1)
+    @average_over_ensemble_models
     def forward(self, X: torch.Tensor) -> torch.Tensor:
         """
         Evaluate acquisition function at X.
@@ -291,6 +295,7 @@ class GlobalLookaheadAcquisitionFunction(LookaheadAcquisitionFunction):
         self.register_buffer("Xq", Xq)
 
     @t_batch_mode_transform(expected_q=1)
+    @average_over_ensemble_models
     def forward(self, X: torch.Tensor) -> torch.Tensor:
         """
         Evaluate acquisition function at X.

--- a/aepsych/acquisition/mc_posterior_variance.py
+++ b/aepsych/acquisition/mc_posterior_variance.py
@@ -15,7 +15,10 @@ from botorch.acquisition.objective import MCAcquisitionObjective
 from botorch.models.model import Model
 from botorch.sampling.base import MCSampler
 from botorch.sampling.normal import SobolQMCNormalSampler
-from botorch.utils.transforms import t_batch_mode_transform
+from botorch.utils.transforms import (
+    average_over_ensemble_models,
+    t_batch_mode_transform,
+)
 
 
 def balv_acq(obj_samps: torch.Tensor) -> torch.Tensor:
@@ -61,6 +64,7 @@ class MCPosteriorVariance(MCAcquisitionFunction):
         self.objective = objective
 
     @t_batch_mode_transform()
+    @average_over_ensemble_models
     def forward(self, X: torch.Tensor) -> torch.Tensor:
         r"""Evaluate MCPosteriorVariance on the candidate set `X`.
 

--- a/aepsych/acquisition/mutual_information.py
+++ b/aepsych/acquisition/mutual_information.py
@@ -18,7 +18,10 @@ from botorch.acquisition.objective import MCAcquisitionObjective
 from botorch.models.model import Model
 from botorch.sampling.base import MCSampler
 from botorch.sampling.normal import SobolQMCNormalSampler
-from botorch.utils.transforms import t_batch_mode_transform
+from botorch.utils.transforms import (
+    average_over_ensemble_models,
+    t_batch_mode_transform,
+)
 from torch import Tensor
 from torch.distributions.bernoulli import Bernoulli
 
@@ -82,6 +85,7 @@ class BernoulliMCMutualInformation(MCAcquisitionFunction):
         )
 
     @t_batch_mode_transform()
+    @average_over_ensemble_models
     def forward(self, X: Tensor) -> Tensor:
         r"""Evaluate mutual information on the candidate set `X`.
 


### PR DESCRIPTION
Summary:
This commit adds the `average_over_ensemble_models` decorator that separates out the acquisition value averaging over ensemble models from the `t_batch_mode_transform` decorator. While this increases the number of decorators that the `forward` method of virtually every acquisition function has, it makes the behavior much more transparent, as it is not clear that `t_batch_mode_transform` has anything to do with ensemble models.

Notably, `SampleReducingMCAcquisitionFunctions` can accommodate the ensemble averaging with a simple modification to the `sample_dim` argument of the `sample_reduction`, and thereby doesn't need the decorator. This was originally proposed in the fully Bayesian LogEI commit [here](https://github.com/pytorch/botorch/pull/2058).

Differential Revision: D75977267


