### PR TITLE
Update node version to 20 to ensure docs build

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Summary: Update node in Github Workflow to version 20 to allow docs to build.

Differential Revision: D76325521


