### PR TITLE
Remove numpy pin (#783)

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        os: [macos-latest, windows-latest, macos-13]
+        os: [macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/aepsych/config.py
+++ b/aepsych/config.py
@@ -291,7 +291,7 @@ class Config(configparser.ConfigParser):
             np.ndarray: Numpy array representation of the string.
         """
         v = ast.literal_eval(v)
-        return np.array(v, dtype=float)
+        return np.asarray(v, dtype=float)
 
     def _str_to_tensor(self, v: str) -> torch.Tensor:
         """Convert a string to a torch tensor.

--- a/aepsych/database/utils.py
+++ b/aepsych/database/utils.py
@@ -211,7 +211,7 @@ def _tell_to_record(
         # Correct for multi stimuli in old databases
         for key, value in config_dict.items():
             if isinstance(value, list):
-                value = np.array(value)
+                value = np.asarray(value)
             if value.ndim == 1:
                 value = np.expand_dims(value, axis=0)
                 config_dict[key] = value

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -150,8 +150,8 @@ def plot_points_1d(
                 y2 = pred_y[torch.argmin(torch.abs(x2 - pred_x))]
 
                 ax.plot(
-                    [np.array(x1), np.array(x2)],
-                    [np.array(y1), np.array(y2)],
+                    [np.asarray(x1), np.asarray(x2)],
+                    [np.asarray(y1), np.asarray(y2)],
                     **connect_args,  # type: ignore
                 )
                 ax.plot(
@@ -188,8 +188,8 @@ def plot_points_1d(
                     mid[1].item() if isinstance(mid[1], torch.Tensor) else mid[1],
                 )
 
-                poly_x = np.array(x_coords).squeeze()
-                poly_y = np.array(y_coords).squeeze()
+                poly_x = np.asarray(x_coords).squeeze()
+                poly_y = np.asarray(y_coords).squeeze()
                 f = np.poly1d(np.polyfit(poly_x, poly_y, 2))
                 x = np.linspace(start[0], end[0], 100)
                 return x, f(x)
@@ -204,7 +204,9 @@ def plot_points_1d(
 
                 # Create a curvey line between the hatches
                 mid_x = torch.min(pair) + (torch.abs(x1 - x2) / 2)
-                line_x, line_y = curve([x1, hatch_y], [x2, hatch_y], [mid_x, mid_y])
+                line_x, line_y = curve(
+                    [x1.numpy(), hatch_y], [x2.numpy(), hatch_y], [mid_x.numpy(), mid_y]
+                )
                 ax.plot(line_x, line_y, "-", c="gray", alpha=0.5)
                 ax.plot(
                     x1,
@@ -302,7 +304,7 @@ def plot_predict_2d(
     lb = lb.double()
     ub = ub.double()
 
-    diff = np.abs(ub - lb)
+    diff = torch.abs(ub - lb)
     edge_bumps = (diff - (diff * (1 - edge_multiplier))) / 2
     lb -= edge_bumps
     ub += edge_bumps
@@ -310,7 +312,7 @@ def plot_predict_2d(
     prediction = prediction.T
     prediction = torch.flip(prediction, dims=[0])
     mappable = ax.imshow(
-        prediction,
+        np.asarray(prediction),
         origin="upper",
         aspect=((ub[0] - lb[0]) / (ub[1] - lb[1])).item(),
         extent=extent,
@@ -519,7 +521,7 @@ def plot_contours(
     lb = lb.double()
     ub = ub.double()
 
-    diff = np.abs(ub - lb)
+    diff = torch.abs(ub - lb)
     edge_bumps = (diff - (diff * (1 - edge_multiplier))) / 2
     lb -= edge_bumps
     ub += edge_bumps
@@ -534,7 +536,7 @@ def plot_contours(
         )
 
     contours = ax.contour(
-        prediction,
+        np.asarray(prediction),
         levels=levels,
         extent=extent,
         origin="upper",
@@ -1126,7 +1128,7 @@ def plot_strat_3d(
     elif not isinstance(slice_vals, list):
         raise TypeError("slice_vals must be either an integer or a list of values")
     else:
-        slices = np.array(slice_vals)
+        slices = np.asarray(slice_vals)
 
     # make mypy happy, note that this can't be more specific
     # because of https://github.com/numpy/numpy/issues/24738
@@ -1140,7 +1142,7 @@ def plot_strat_3d(
             strat,
             parnames,
             slice_dim,
-            dim_val,
+            dim_val,  # type: ignore
             vmin,
             vmax,
             gridsize,
@@ -1170,7 +1172,7 @@ def plot_slice(
     strat: Strategy,
     parnames: list[str],
     slice_dim: int,
-    slice_val: int,
+    slice_val: float,
     vmin: float,
     vmax: float,
     gridsize: int = 30,
@@ -1184,7 +1186,7 @@ def plot_slice(
         start (Strategy): Strategy object to be plotted. Must have a dimensionality of 3.
         parnames (list[str]): list of the parameter names.
         slice_dim (int): dimension to slice on.
-        slice_val (int): value to take the slice along that dimension.
+        slice_val (float): value to take the slice along that dimension.
         vmin (float): global model minimum to use for plotting.
         vmax (float): global model maximum to use for plotting.
         gridsize (int): The number of points to sample each dimension at. Default: 30.

--- a/aepsych/server/message_handlers/handle_query.py
+++ b/aepsych/server/message_handlers/handle_query.py
@@ -120,19 +120,19 @@ def query(
         )
         response["x"] = x
         y = mean.item() if isinstance(mean, torch.Tensor) else mean[0]
-        response["y"] = np.array(y)  # mean.item()
+        response["y"] = np.asarray(y)  # mean.item()
 
     elif query_type == "inverse":
         nearest_y, nearest_loc = server.strat.inv_query(
             y, constraints, probability_space=probability_space, **kwargs
         )
-        response["y"] = np.array(nearest_y)
+        response["y"] = np.asarray(nearest_y)
         response["x"] = server._tensor_to_config(nearest_loc)
     else:
         raise RuntimeError("unknown query type!")
     # ensure all x values are arrays
     response["x"] = {
-        k: np.array([v]) if np.array(v).ndim == 0 else v
+        k: np.asarray([v]) if np.asarray(v).ndim == 0 else v
         for k, v in response["x"].items()
     }
 

--- a/aepsych/server/server.py
+++ b/aepsych/server/server.py
@@ -246,7 +246,9 @@ class AEPsychServer(object):
         # Check if the values of config are not array, if so make them so
         config_copy = {
             key: (
-                value if isinstance(value, np.ndarray) else np.array(promote_0d(value))
+                value
+                if isinstance(value, np.ndarray)
+                else np.asarray(promote_0d(value))
             )
             for key, value in config.items()
         }
@@ -273,7 +275,7 @@ class AEPsychServer(object):
         for key, value in fixed.items():
             idx = self.parnames.index(key)
             dummy[idx] = value
-        dummy = np.expand_dims(dummy, 0)
+        dummy = np.expand_dims(dummy, 0)  # type: ignore
         dummy = self.strat.transforms.str_to_indices(dummy)[0]
 
         # Turn the dummy back into a dict

--- a/aepsych/transforms/ops/log10_plus.py
+++ b/aepsych/transforms/ops/log10_plus.py
@@ -112,11 +112,11 @@ class Log10Plus(Log10, Transform):
         if "constant" not in options:
             lb = options["bounds"][0, options["indices"]]
             if lb < 0.0:
-                constant = np.abs(lb) + 1.0
+                constant = torch.abs(lb) + 1.0
             elif lb < 1.0:
-                constant = 1.0
+                constant = torch.tensor(1.0, dtype=torch.long)
             else:
-                constant = 0.0
+                constant = torch.tensor(0.0, dtype=torch.long)
 
             options["constant"] = constant
 

--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -854,7 +854,7 @@ def transform_options(
         for option, value in options.items():
             if option in _TRANSFORMABLE:
                 value = ast.literal_eval(value)
-                value = np.array(value, dtype=float)
+                value = np.asarray(value, dtype=float)
                 value = torch.tensor(value).to(torch.float64)
 
                 if option in ["ub", "lb"]:
@@ -881,8 +881,8 @@ def transform_options(
                     value = transforms.transform(value)
 
                 def _arr_to_list(iter):
-                    if hasattr(iter, "__iter__"):
-                        iter = list(iter)
+                    if isinstance(iter, np.ndarray):
+                        iter = iter.tolist()
                         iter = [_arr_to_list(element) for element in iter]
                         return iter
                     return iter

--- a/aepsych/utils.py
+++ b/aepsych/utils.py
@@ -172,7 +172,11 @@ def interpolate_monotonic(
     # basic idea is find the nearest two points to the LSE and
     # linearly interpolate between them (I think this is bisection
     # root-finding)
-    idx = np.searchsorted(y, z)
+    if isinstance(y, np.ndarray):
+        y = torch.tensor(y)
+    if isinstance(z, np.ndarray):
+        z = torch.tensor(z)
+    idx = torch.searchsorted(y, z)
     if idx == len(y):
         return float(max_x)
     elif idx == 0:
@@ -324,7 +328,7 @@ def get_jnd_1d(
     interpolate_to = post_mean + df
     return torch.tensor(
         (
-            np.array(
+            np.asarray(
                 [
                     interpolate_monotonic(mono_grid, post_mean, ito)
                     for ito in interpolate_to

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import os
 from setuptools import find_packages, setup
 
 REQUIRES = [
-    "numpy<2.0, >=1.20",
+    "numpy>=1.20",
     "matplotlib",
     "torch",
     "scipy",

--- a/tests/generators/test_manual_generator.py
+++ b/tests/generators/test_manual_generator.py
@@ -55,8 +55,8 @@ class TestManualGenerator(unittest.TestCase):
         config = Config()
         config.update(config_str=config_str)
         gen = ParameterTransformedGenerator.from_config(config, "ManualGenerator")
-        npt.assert_equal(gen.lb.numpy(), np.array([0, 0]))
-        npt.assert_equal(gen.ub.numpy(), np.array([1, 1]))
+        npt.assert_equal(gen.lb.numpy(), np.asarray([0, 0]))
+        npt.assert_equal(gen.ub.numpy(), np.asarray([1, 1]))
         self.assertFalse(gen.finished)
 
         p1 = list(gen.gen()[0])
@@ -115,8 +115,8 @@ class TestSampleAroundPointsGenerator(unittest.TestCase):
         config = Config()
         config.update(config_str=config_str)
         gen = SampleAroundPointsGenerator.from_config(config)
-        npt.assert_equal(gen.lb.numpy(), np.array([0, 0]))
-        npt.assert_equal(gen.ub.numpy(), np.array([1, 1]))
+        npt.assert_equal(gen.lb.numpy(), np.asarray([0, 0]))
+        npt.assert_equal(gen.ub.numpy(), np.asarray([1, 1]))
         self.assertEqual(gen.max_asks, len(points * samples_per_point))
         self.assertEqual(gen.seed, 123)
         self.assertFalse(gen.finished)
@@ -124,8 +124,8 @@ class TestSampleAroundPointsGenerator(unittest.TestCase):
         points = gen.gen(gen.max_asks)
         for i in range(len(window)):
             npt.assert_array_less(points[:, i], points[:, i] + window[i])
-            npt.assert_array_less(np.array([0] * len(points)), points[:, i])
-            npt.assert_array_less(points[:, i], np.array([1] * len(points)))
+            npt.assert_array_less(np.asarray([0] * len(points)), points[:, i])
+            npt.assert_array_less(points[:, i], np.asarray([1] * len(points)))
 
         self.assertTrue(gen.finished)
 
@@ -154,8 +154,8 @@ class TestSampleAroundPointsGenerator(unittest.TestCase):
         config = Config()
         config.update(config_str=config_str)
         gen = SampleAroundPointsGenerator.from_config(config)
-        npt.assert_equal(gen.lb.numpy(), np.array(lb))
-        npt.assert_equal(gen.ub.numpy(), np.array(ub))
+        npt.assert_equal(gen.lb.numpy(), np.asarray(lb))
+        npt.assert_equal(gen.ub.numpy(), np.asarray(ub))
         self.assertEqual(gen.max_asks, len(points * samples_per_point))
         self.assertEqual(gen.seed, 123)
         self.assertFalse(gen.finished)

--- a/tests/generators/test_random_generator.py
+++ b/tests/generators/test_random_generator.py
@@ -9,6 +9,7 @@ import unittest
 
 import numpy as np
 import numpy.testing as npt
+import torch
 from aepsych.config import Config
 from aepsych.generators import RandomGenerator
 
@@ -17,19 +18,19 @@ class TestRandomGenerator(unittest.TestCase):
     def test_randomgen_single(self):
         # test that RandomGenerator doesn't mess with shapes
         n = 100
-        rand = np.zeros((n, 3))
+        rand = torch.zeros((n, 3))
         mod = RandomGenerator(lb=[1, 2, 3], ub=[2, 3, 4], dim=3)
 
         for i in range(n):
             rand[i, :] = mod.gen()
 
         # check that bounds are right
-        self.assertTrue(np.all(rand[:, 0] > 1))
-        self.assertTrue(np.all(rand[:, 1] > 2))
-        self.assertTrue(np.all(rand[:, 2] > 3))
-        self.assertTrue(np.all(rand[:, 0] < 2))
-        self.assertTrue(np.all(rand[:, 1] < 3))
-        self.assertTrue(np.all(rand[:, 2] < 4))
+        self.assertTrue(torch.all(rand[:, 0] > 1))
+        self.assertTrue(torch.all(rand[:, 1] > 2))
+        self.assertTrue(torch.all(rand[:, 2] > 3))
+        self.assertTrue(torch.all(rand[:, 0] < 2))
+        self.assertTrue(torch.all(rand[:, 1] < 3))
+        self.assertTrue(torch.all(rand[:, 2] < 4))
 
     def test_randomgen_batch(self):
         # test that RandomGenerator doesn't mess with shapes
@@ -56,8 +57,8 @@ class TestRandomGenerator(unittest.TestCase):
         """
         config = Config(config_str=config_str)
         gen = RandomGenerator.from_config(config)
-        npt.assert_equal(gen.lb.numpy(), np.array(lb))
-        npt.assert_equal(gen.ub.numpy(), np.array(ub))
+        npt.assert_equal(gen.lb.numpy(), np.asarray(lb))
+        npt.assert_equal(gen.ub.numpy(), np.asarray(ub))
         self.assertEqual(gen.dim, len(lb))
 
     def test_randomgen_fixed(self):

--- a/tests/generators/test_sobol_generator.py
+++ b/tests/generators/test_sobol_generator.py
@@ -60,8 +60,8 @@ class TestSobolGenerator(unittest.TestCase):
         config = Config()
         config.update(config_str=config_str)
         gen = SobolGenerator.from_config(config)
-        npt.assert_equal(gen.lb.numpy(), np.array([0]))
-        npt.assert_equal(gen.ub.numpy(), np.array([1]))
+        npt.assert_equal(gen.lb.numpy(), np.asarray([0]))
+        npt.assert_equal(gen.ub.numpy(), np.asarray([1]))
         self.assertEqual(gen.seed, 12345)
         self.assertEqual(gen.stimuli_per_trial, 1)
 

--- a/tests/models/test_gp_classification.py
+++ b/tests/models/test_gp_classification.py
@@ -41,19 +41,12 @@ def f_1d(x, mu=0):
     """
     latent is just a gaussian bump at mu
     """
-    return np.exp(-((x - mu) ** 2))
-
-
-def f_2d(x):
-    """
-    a gaussian bump at 0 , 0
-    """
-    return np.exp(-np.linalg.norm(x, axis=-1))
+    return torch.exp(-((x - mu) ** 2))
 
 
 def f_2d_target(x, target=None):
     """
-    Distance to target
+    Distance to target, default is a guassian bump at 0, 0
     """
     if target is None:
         target = torch.tensor([0.0, 0.0])
@@ -406,7 +399,7 @@ class GPClassificationTest(unittest.TestCase):
         zhat, _ = strat.predict(x)
 
         # true max is 0, very loose test
-        self.assertTrue(np.abs(x[np.argmax(zhat.detach().numpy())]) < 0.5)
+        self.assertTrue(torch.abs(x[np.argmax(zhat.detach().numpy())]) < 0.5)
 
     def test_1d_single_probit_batched(self):
         n_init = 50
@@ -452,7 +445,7 @@ class GPClassificationTest(unittest.TestCase):
         zhat, _ = strat.predict(x)
 
         # true max is 0, very loose test
-        self.assertTrue(np.abs(x[np.argmax(zhat.detach().numpy())]) < 0.5)
+        self.assertTrue(torch.abs(x[np.argmax(zhat.detach().numpy())]) < 0.5)
 
     def test_1d_single_probit(self):
         n_init = 50
@@ -497,7 +490,7 @@ class GPClassificationTest(unittest.TestCase):
         zhat, _ = strat.predict(x)
 
         # true max is 0, very loose test
-        self.assertTrue(np.abs(x[np.argmax(zhat.detach().numpy())]) < 0.5)
+        self.assertTrue(torch.abs(x[np.argmax(zhat.detach().numpy())]) < 0.5)
 
     def test_1d_single_probit_pure_exploration(self):
         n_init = 50
@@ -647,7 +640,7 @@ class GPClassificationTest(unittest.TestCase):
         # since target is 0.75, find the point at which f_est is 0.75
         est_max = x[np.argmin((norm.cdf(zhat.detach().numpy()) - 0.75) ** 2)]
         # since true z is just x, the true max is where phi(x)=0.75,
-        self.assertTrue(np.abs(est_max - norm.ppf(0.75)) < 0.5)
+        self.assertTrue(torch.abs(est_max - norm.ppf(0.75)) < 0.5)
 
     def test_1d_jnd(self):
         n_init = 150
@@ -709,7 +702,7 @@ class GPClassificationTest(unittest.TestCase):
         )
         est_jnd_step = jnd_step[50]
         # looser test because step-jnd is hurt more by reverting to the mean
-        self.assertTrue(np.abs(est_jnd_step - 1.5) < 0.5)
+        self.assertTrue(torch.abs(est_jnd_step - 1.5) < 0.5)
 
         jnd_taylor = get_jnd(
             strat.model,
@@ -720,7 +713,7 @@ class GPClassificationTest(unittest.TestCase):
             method="taylor",
         )
         est_jnd_taylor = jnd_taylor[50]
-        self.assertTrue(np.abs(est_jnd_taylor - 1.5) < 0.25)
+        self.assertTrue(torch.abs(est_jnd_taylor - 1.5) < 0.25)
 
     def test_1d_single_lse(self):
         n_init = 50
@@ -770,7 +763,7 @@ class GPClassificationTest(unittest.TestCase):
         # since target is 0.75, find the point at which f_est is 0.75
         est_max = x[np.argmin((norm.cdf(zhat.detach().cpu().numpy()) - 0.75) ** 2)]
         # since true z is just x, the true max is where phi(x)=0.75,
-        self.assertTrue(np.abs(est_max - norm.ppf(0.75)) < 0.5)
+        self.assertTrue(torch.abs(est_max - norm.ppf(0.75)) < 0.5)
 
     def test_2d_single_probit(self):
         n_init = 150
@@ -808,7 +801,7 @@ class GPClassificationTest(unittest.TestCase):
 
         for _i in range(n_init + n_opt):
             next_x = strat.gen()
-            strat.add_data(next_x, [bernoulli.rvs(f_2d(next_x[None, :]))])
+            strat.add_data(next_x, [bernoulli.rvs(f_2d_target(next_x))])
 
         xy = np.mgrid[-1:1:30j, -1:1:30j].reshape(2, -1).T
         zhat, _ = strat.predict(torch.Tensor(xy))

--- a/tests/models/test_independent_gps.py
+++ b/tests/models/test_independent_gps.py
@@ -22,7 +22,7 @@ def f_1d(x, mu=0):
     """
     latent is just a gaussian bump at mu
     """
-    return np.exp(-((x - mu) ** 2))
+    return torch.exp(-((x - mu) ** 2))
 
 
 def f_2d(x, target=None):
@@ -284,7 +284,7 @@ class IndependentGPStratTest(unittest.TestCase):
         pred_y = strat.model.predict(x_grid)
 
         norm = torch.distributions.Normal(0, 1)
-        baz_target = f_2d(x_grid[np.argmin((norm.cdf(pred_y[0][:, 0]) - 0.75) ** 2)])
+        baz_target = f_2d(x_grid[torch.argmin((norm.cdf(pred_y[0][:, 0]) - 0.75) ** 2)])
         qux_max = x_grid[torch.argmax(pred_y[0][:, 1])]
 
         # Pretty wide check on binary, but that's the nature of it

--- a/tests/models/test_pairwise_probit.py
+++ b/tests/models/test_pairwise_probit.py
@@ -261,7 +261,7 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
 
         zhat, _ = strat.predict(x)
         # true max is 0, very loose test
-        self.assertTrue(np.abs(x[np.argmax(zhat.detach().numpy())]) < 0.5)
+        self.assertTrue(torch.abs(x[np.argmax(zhat.detach().numpy())]) < 0.5)
 
     def test_1d_pairwise_probit_pure_exploration(self):
         seed = 1
@@ -444,7 +444,7 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
     def test_sobolmodel_pairwise(self):
         # test that SobolModel correctly gets bounds
 
-        sobol_x = np.zeros((10, 3, 2))
+        sobol_x = torch.zeros((10, 3, 2))
         mod = Strategy(
             lb=[1, 2, 3],
             ub=[2, 3, 4],
@@ -459,12 +459,12 @@ class PairwiseProbitModelStrategyTest(unittest.TestCase):
         for i in range(10):
             sobol_x[i, ...] = mod.gen()
 
-        self.assertTrue(np.all(sobol_x[:, 0, :] > 1))
-        self.assertTrue(np.all(sobol_x[:, 1, :] > 2))
-        self.assertTrue(np.all(sobol_x[:, 2, :] > 3))
-        self.assertTrue(np.all(sobol_x[:, 0, :] < 2))
-        self.assertTrue(np.all(sobol_x[:, 1, :] < 3))
-        self.assertTrue(np.all(sobol_x[:, 2, :] < 4))
+        self.assertTrue(torch.all(sobol_x[:, 0, :] > 1))
+        self.assertTrue(torch.all(sobol_x[:, 1, :] > 2))
+        self.assertTrue(torch.all(sobol_x[:, 2, :] > 3))
+        self.assertTrue(torch.all(sobol_x[:, 0, :] < 2))
+        self.assertTrue(torch.all(sobol_x[:, 1, :] < 3))
+        self.assertTrue(torch.all(sobol_x[:, 2, :] < 4))
 
     def test_hyperparam_consistency(self):
         # verify that creating the model `from_config` or with `__init__` has the same hyperparams
@@ -567,7 +567,7 @@ class PairwiseProbitModelServerTest(unittest.TestCase):
 
         x = torch.linspace(-4, 4, 100)
         zhat, _ = server.strat.predict(x)
-        self.assertTrue(np.abs(x[np.argmax(zhat.detach().numpy())]) < 0.5)
+        self.assertTrue(torch.abs(x[np.argmax(zhat.detach().numpy())]) < 0.5)
 
     def test_2d_pairwise_server(self):
         seed = 1

--- a/tests/test_mean_covar_factories.py
+++ b/tests/test_mean_covar_factories.py
@@ -557,6 +557,7 @@ class TestMixedFactories(unittest.TestCase):
         locs, scale = TestMixedFactories.new_novel_det_channels_params(
             channel, scale_factor, wave_freq, target
         )
+
         return (x - locs) / scale
 
     @staticmethod
@@ -582,7 +583,7 @@ class TestMixedFactories(unittest.TestCase):
         generator = SobolGenerator(lb=[-1], ub=[1], dim=1)
         x = generator.gen(n_train)
         channel = np.random.choice(2, n_train)
-        f = TestMixedFactories.new_novel_det_channels(x.squeeze(), channel)
+        f = TestMixedFactories.new_novel_det_channels(x.squeeze().numpy(), channel)
         y = bernoulli.rvs(norm.cdf(f))
         self.xtest = generator.gen(n_test)
         self.x = torch.concatenate([x, torch.tensor(channel).unsqueeze(1)], axis=1)

--- a/tests/test_pairwise_kernel.py
+++ b/tests/test_pairwise_kernel.py
@@ -62,8 +62,8 @@ class PairwiseKernelTest(unittest.TestCase):
         )
         npt.assert_allclose(c12, pwc, atol=1e-6)
 
-        shape = np.array(c12.shape)
-        npt.assert_equal(shape, np.array([2, 2]))
+        shape = np.asarray(c12.shape)
+        npt.assert_equal(shape, np.asarray([2, 2]))
 
         x3 = torch.rand(torch.Size([3, 4]))
         x4 = torch.rand(torch.Size([6, 4]))
@@ -84,8 +84,8 @@ class PairwiseKernelTest(unittest.TestCase):
         )
         npt.assert_allclose(c34, pwc, atol=1e-6)
 
-        shape = np.array(c34.shape)
-        npt.assert_equal(shape, np.array([3, 6]))
+        shape = np.asarray(c34.shape)
+        npt.assert_equal(shape, np.asarray([3, 6]))
 
     def test_latent_diag(self):
         """
@@ -112,15 +112,15 @@ class PairwiseKernelTest(unittest.TestCase):
         x2 = torch.rand(torch.Size([2, 2, 4]))
 
         diag = self.kernel(x1, x2, diag=True)
-        shape = np.array(diag.shape)
-        npt.assert_equal(shape, np.array([2, 2]))
+        shape = np.asarray(diag.shape)
+        npt.assert_equal(shape, np.asarray([2, 2]))
 
         x1 = torch.rand(torch.Size([2, 4]))
         x2 = torch.rand(torch.Size([2, 4]))
 
         diag = self.kernel(x1, x2, diag=True)
-        shape = np.array(diag.shape)
-        npt.assert_equal(shape, np.array([2]))
+        shape = np.asarray(diag.shape)
+        npt.assert_equal(shape, np.asarray([2]))
 
 
 if __name__ == "__main__":

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -338,7 +338,7 @@ class TestClassificationPlotting(unittest.TestCase):
 
         bumped_lb = lb.double()
         bumped_ub = ub.double()
-        diff = np.abs(ub - lb)
+        diff = torch.abs(ub - lb)
         edge_bumps = (diff - (diff * (1 - edge_multiplier))) / 2
         bumped_lb -= edge_bumps
         bumped_ub += edge_bumps

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -269,7 +269,7 @@ class TestSequenceGenerators(unittest.TestCase):
         ]
 
         strat = SequentialStrategy(strat_list)
-        out = np.zeros((8, 2))
+        out = torch.zeros((8, 2))
         for i in range(8):
             next_x = strat.gen()
             strat.add_data(next_x, [1])
@@ -278,10 +278,10 @@ class TestSequenceGenerators(unittest.TestCase):
         gen1 = out[:3]
         gen2 = out[3:]
 
-        self.assertTrue(np.min(gen2) >= -10)
-        self.assertTrue(np.min(gen1) >= -1)
-        self.assertTrue(np.max(gen1) <= 1)
-        self.assertTrue(np.max(gen2) <= -8)
+        self.assertTrue(torch.min(gen2) >= -10)
+        self.assertTrue(torch.min(gen1) >= -1)
+        self.assertTrue(torch.max(gen1) <= 1)
+        self.assertTrue(torch.max(gen2) <= -8)
 
     def test_strategy_asserts(self):
         class MockModel(object):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -474,8 +474,8 @@ class TransformsLog10Test(unittest.TestCase):
         x = torch.linspace(lower_bound, upper_bound, 100)
 
         zhat, _ = strat.predict(x, probability_space=True)
-        est_max = x[np.argmin((zhat - target) ** 2)]
-        diff = np.abs((est_max / 100) - target)
+        est_max = x[torch.argmin((zhat - target) ** 2)]
+        diff = torch.abs((est_max / 100) - target)
         self.assertTrue(diff < 0.15, f"Diff = {diff}, est_max = {est_max}")
 
 
@@ -621,8 +621,8 @@ class TransformsInteger(unittest.TestCase):
         x = torch.linspace(lower_bound, upper_bound, 100)
 
         zhat, _ = strat.predict(x)
-        est_max = x[np.argmin((zhat - target) ** 2)]
-        diff = np.abs(est_max / 100 - target)
+        est_max = x[torch.argmin((zhat - target) ** 2)]
+        diff = torch.abs(est_max / 100 - target)
         self.assertTrue(diff < 0.15, f"Diff = {diff}")
 
     def test_binary(self):
@@ -809,7 +809,7 @@ class TransformCategorical(unittest.TestCase):
     def test_standalone_transform(self):
         categories = {1: ["red", "green", "blue"], 3: ["big", "small"]}
         input = torch.tensor([[0.2, 2, 4, 0, 1], [0.5, 0, 3, 0, 1], [0.9, 1, 0, 1, 0]])
-        input_cats = np.array(
+        input_cats = np.asarray(
             [
                 [0.2, "blue", 4, "big", "right"],
                 [0.5, "red", 3, "big", "right"],


### PR DESCRIPTION
Summary:

Removed numpy version pin to match botorch, had to change transforms to support new api. Also updated various locations where arrays were cast to avoid deprecation warnings.

One set of deprecation warnings remains unfixed and instead ignored, caused by old sqlalchemy version and numpy, not trivial to fix without upgrading sqlalchemy.

Differential Revision: D73263215


