### PR TITLE
Ensure db combining test cleans up test database

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -696,6 +696,7 @@ class DBUtilityTestCase(unittest.TestCase):
             )
 
         combined_db.cleanup()
+        out_path.unlink()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Test that checks the db combining utilities creates a test database unique to it and does not properly clean up. Added a cleanup at the end.

Differential Revision: D79309932


