### PR TITLE
Fix mypy for latest pytorch

### DIFF
--- a/aepsych/models/independent_gps.py
+++ b/aepsych/models/independent_gps.py
@@ -22,7 +22,10 @@ class IndependentGPsModel(AEPsychModelMixin):
         # https://github.com/pytorch/pytorch/issues/80821
         self.models: Mapping[str, AEPsychModelMixin] = model_dict  # type: ignore
         self.model_names = list(self.models.keys())
-        self._num_outputs = sum([model._num_outputs for model in model_dict.values()])
+        tmp = torch.tensor(
+            [model._num_outputs for model in model_dict.values()], dtype=torch.int
+        )
+        self._num_outputs = sum(tmp)
 
     def __getitem__(self, key):
         # Allow both integer and string indices to access model directly

--- a/aepsych/plotting.py
+++ b/aepsych/plotting.py
@@ -611,7 +611,7 @@ def facet_slices(
         **kwargs,
     )
 
-    slice_template = [
+    slice_template: list[Any] = [
         None if idx in not_axes else slice(0, prediction.shape[idx])
         for idx in range(len(lb))
     ]

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,6 @@ files = aepsych
 show_error_codes = True
 pretty = True
 ignore_missing_imports = True
-plugins = numpy.typing.mypy_plugin
 
 # TODO FIXME
 [mypy-*.database.*]


### PR DESCRIPTION
Summary: PyTorch updated to 2.8 and broke some mypy types. Double checked that there’s no actual errors and fixed mypy errors.

Differential Revision: D79823928


