### PR TITLE
Fix unity example configs acqf

### DIFF
--- a/clients/unity/Assets/StreamingAssets/configs/particleV2_manualConfig.ini
+++ b/clients/unity/Assets/StreamingAssets/configs/particleV2_manualConfig.ini
@@ -15,7 +15,6 @@ generator = PairwiseSobolGenerator
 n_trials = 20
 refit_every = 5
 generator = PairwiseOptimizeAcqfGenerator
-acqf = qNoisyExpectedImprovement
 model = PairwiseProbitModel
 
 [PairwiseProbitModel]
@@ -25,6 +24,7 @@ mean_covar_factory = default_mean_covar_factory
 [PairwiseOptimizeAcqfGenerator]
 restarts = 10
 samps = 3000
+acqf = qNoisyExpectedImprovement
 
 [qNoisyExpectedImprovement]
 objective = ProbitObjective

--- a/clients/unity/Packages/com.frl.aepsych/.Samples/Client/Scenes/Demos/Audio_1D_example.unity
+++ b/clients/unity/Packages/com.frl.aepsych/.Samples/Client/Scenes/Demos/Audio_1D_example.unity
@@ -351,8 +351,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6da7f1d8cf145a244974cf085de2b167, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   experiment: {fileID: 720461321}
 --- !u!4 &494520667
 Transform:
@@ -395,8 +395,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 66678f3fd91e1bc4c9b8b60968b5a725, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   currentStrat: 0
   server_address: localhost
   server_port: 5555
@@ -444,8 +444,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 0
   experiment_method: 0
@@ -454,7 +454,7 @@ MonoBehaviour:
     upperBound: 1.5
     name: pitch
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 0
   target: 0.5
   initialization_trials: 3
@@ -497,7 +497,6 @@ MonoBehaviour:
 
     generator = OptimizeAcqfGenerator
 
-    acqf = MCLevelSetEstimation
 
     model
     = GPClassificationModel
@@ -517,6 +516,8 @@ MonoBehaviour:
 
     samps
     = 1000
+
+    acqf = MCLevelSetEstimation
 
 
     [MCLevelSetEstimation]
@@ -541,8 +542,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 24d82a6a05e51af49a74662bb1937413, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 108
   ResponseKey1: 121
   startKey: 32
@@ -815,8 +816,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -834,8 +835,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10

--- a/clients/unity/Packages/com.frl.aepsych/.Samples/Client/Scenes/Demos/PairWise_5D_Particle_Effect.unity
+++ b/clients/unity/Packages/com.frl.aepsych/.Samples/Client/Scenes/Demos/PairWise_5D_Particle_Effect.unity
@@ -239,8 +239,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 1
   response_type: 0
   experiment_method: 1
@@ -303,8 +303,6 @@ MonoBehaviour:
 
     generator = PairwiseOptimizeAcqfGenerator
 
-    acqf
-    = qNoisyExpectedImprovement
 
     model = PairwiseProbitModel
 
@@ -323,6 +321,9 @@ MonoBehaviour:
     = 10
 
     samps = 3000
+
+    acqf
+    = qNoisyExpectedImprovement
 
 
     [qNoisyExpectedImprovement]
@@ -345,8 +346,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d19c36bbf23f46e4fbbd2198aaa949b5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 49
   ResponseKey1: 50
   startKey: 32
@@ -502,8 +503,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 66678f3fd91e1bc4c9b8b60968b5a725, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   currentStrat: 0
   server_address: localhost
   server_port: 5555
@@ -551,8 +552,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -570,8 +571,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
@@ -775,7 +776,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2416200128082496200, guid: 06c76821ecef4ae45bde3b79486fdb29, type: 3}
       propertyPath: m_Camera
-      value: 
+      value:
       objectReference: {fileID: 414714582}
     - target: {fileID: 2416200128082496200, guid: 06c76821ecef4ae45bde3b79486fdb29, type: 3}
       propertyPath: m_PlaneDistance

--- a/clients/unity/Packages/com.frl.aepsych/.Samples/Client/Scenes/Examples.unity
+++ b/clients/unity/Packages/com.frl.aepsych/.Samples/Client/Scenes/Examples.unity
@@ -151,8 +151,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 1
   experiment_method: 1
@@ -161,14 +161,14 @@ MonoBehaviour:
     upperBound: 0.85
     name: hue
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 0
   target: 0.5
   initialization_trials: 5
   optimization_trials: 5
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex1DContinuousOpt
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -184,8 +184,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6b75e003b529d3741ac62f93fb677058, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -253,8 +253,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 27468319abc5b9e4fbe24d8840c7b1dd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Dim: 0
   m_Method: 0
   m_Response: 0
@@ -334,8 +334,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 0
   experiment_method: 0
@@ -347,7 +347,7 @@ MonoBehaviour:
     upperBound: 1
     name: alpha
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 0
   target: 0.75
   initialization_trials: 10
@@ -389,8 +389,6 @@ MonoBehaviour:
     generator
     = OptimizeAcqfGenerator
 
-    acqf = MCLevelSetEstimation
-
     model = GPClassificationModel
 
 
@@ -408,6 +406,8 @@ MonoBehaviour:
     = 10
 
     samps = 1500
+
+    acqf = MCLevelSetEstimation
 
 
     [MCLevelSetEstimation]
@@ -433,8 +433,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 26337a3ad87d95b4fbac601352dbcc9e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -500,8 +500,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b0f03a3e046c0394895f4e26ce4d5c91, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -534,8 +534,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 0
   experiment_method: 1
@@ -544,7 +544,7 @@ MonoBehaviour:
     upperBound: 1
     name: gsColor
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 1
   target: 0
   initialization_trials: 6
@@ -643,8 +643,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 1
   experiment_method: 0
@@ -738,8 +738,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2a6396bacacccee4281fcc6a62ddde6e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -804,8 +804,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 1
   experiment_method: 1
@@ -820,14 +820,14 @@ MonoBehaviour:
     upperBound: 1
     name: alpha
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 0
   target: 0.5
   initialization_trials: 10
   optimization_trials: 15
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex3DContinuousOpt
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -843,8 +843,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1f74c55396e677f4e9c869035bf0aa1a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -926,8 +926,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 1
   response_type: 0
   experiment_method: 1
@@ -939,14 +939,14 @@ MonoBehaviour:
     upperBound: 1
     name: B
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 3
   target: 0.5
   initialization_trials: 10
   optimization_trials: 12
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex2DPairOptimize
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -962,8 +962,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7607e725a724bab438e52a81d8b1d854, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 49
   ResponseKey1: 50
   startKey: 32
@@ -1028,8 +1028,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 1
   response_type: 0
   experiment_method: 1
@@ -1044,14 +1044,14 @@ MonoBehaviour:
     upperBound: 1
     name: B
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 3
   target: 0.5
   initialization_trials: 12
   optimization_trials: 20
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex3DPairOptimize
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -1067,8 +1067,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: eec3274f841d8d340854ccfc62df6690, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 49
   ResponseKey1: 50
   startKey: 32
@@ -1134,8 +1134,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bc4ffcdc4e9429048994300282cf0d0a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -1168,8 +1168,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 0
   experiment_method: 0
@@ -1184,7 +1184,7 @@ MonoBehaviour:
     upperBound: 0.8
     name: alpha
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 0
   target: 0.75
   initialization_trials: 10
@@ -1385,8 +1385,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2b9dbeff5f823cc4a94bb1ddbf912c0b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 49
   ResponseKey1: 50
   startKey: 32
@@ -1418,8 +1418,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 1
   response_type: 0
   experiment_method: 2
@@ -1428,14 +1428,14 @@ MonoBehaviour:
     upperBound: 1.5
     name: width
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 2
   target: 0.5
   initialization_trials: 6
   optimization_trials: 10
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex1DPairExplore
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -1483,8 +1483,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9c13438773a3f0b44995031155c51a6a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -1519,8 +1519,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 0
   experiment_method: 1
@@ -1532,7 +1532,7 @@ MonoBehaviour:
     upperBound: 1
     name: B
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 1
   target: 0
   initialization_trials: 8
@@ -1630,8 +1630,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 66678f3fd91e1bc4c9b8b60968b5a725, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   currentStrat: 0
   server_address: localhost
   server_port: 5555
@@ -1693,8 +1693,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 1
   response_type: 0
   experiment_method: 2
@@ -1709,14 +1709,14 @@ MonoBehaviour:
     upperBound: 1
     name: value
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 2
   target: 0.5
   initialization_trials: 2
   optimization_trials: 40
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex3DPairExplore
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -1732,8 +1732,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4d40eb29d27d0e3449318ae147e2d88f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 49
   ResponseKey1: 50
   startKey: 32
@@ -1798,8 +1798,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 1
   response_type: 0
   experiment_method: 1
@@ -1808,14 +1808,14 @@ MonoBehaviour:
     upperBound: 1
     name: gsColor
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 3
   target: 0.5
   initialization_trials: 6
   optimization_trials: 6
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex1DPairOptimize
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -1831,8 +1831,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0bb1e97458cbe2f41ba49b5a5cbd488a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 49
   ResponseKey1: 50
   startKey: 32
@@ -1896,8 +1896,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: aa798068594e0244aa5b2e61727c01c9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -1931,8 +1931,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 0
   experiment_method: 1
@@ -1947,7 +1947,7 @@ MonoBehaviour:
     upperBound: 1
     name: B
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 1
   target: 0
   initialization_trials: 25
@@ -2046,8 +2046,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -2065,8 +2065,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_FirstSelected: {fileID: 0}
   m_sendNavigationEvents: 1
   m_DragThreshold: 10
@@ -2177,8 +2177,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 1
   experiment_method: 1
@@ -2190,14 +2190,14 @@ MonoBehaviour:
     upperBound: 2
     name: gravity
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 0
   target: 0.5
   initialization_trials: 8
   optimization_trials: 10
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex2DContinuousOpt
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -2213,8 +2213,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8d5405c00e184534a8282f79220dc2a8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -2405,8 +2405,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: bc07918119698034380c581eef6d08a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -2440,8 +2440,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 0
   experiment_method: 0
@@ -2556,8 +2556,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 1
   experiment_method: 0
@@ -2566,14 +2566,14 @@ MonoBehaviour:
     upperBound: 1
     name: hue
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 0
   target: 0.5
   initialization_trials: 5
   optimization_trials: 8
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex1DContinuousDetection
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -2589,8 +2589,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dd03768bf49fbaf4fb62cdfc64813144, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32
@@ -2669,8 +2669,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 1
   response_type: 0
   experiment_method: 2
@@ -2682,14 +2682,14 @@ MonoBehaviour:
     upperBound: 1
     name: value
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 2
   target: 0.5
   initialization_trials: 12
   optimization_trials: 25
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex2DPairExplore
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -2705,8 +2705,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 01a855c9dbc07b84d8cf47ae6188aa3d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 49
   ResponseKey1: 50
   startKey: 32
@@ -2756,8 +2756,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 25e9decfe19fc314da1a282b8cec8838, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   stimulus_presentation: 0
   response_type: 1
   experiment_method: 0
@@ -2769,14 +2769,14 @@ MonoBehaviour:
     upperBound: 1
     name: value
   manualConfig: {fileID: 0}
-  relativeFilePath: 
+  relativeFilePath:
   experiment_idx: 0
   target: 0.5
   initialization_trials: 6
   optimization_trials: 10
   isInitialized: 0
   isAutomatic: 1
-  fullConfigFile: 
+  fullConfigFile:
   experimentName: Ex2DContinuousDetection
   defaultFilePath: configs/default_config.ini
   isEditorVersion: 1
@@ -2792,8 +2792,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a5133cefde799d54ebb96c9b29d6d587, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   ResponseKey0: 110
   ResponseKey1: 121
   startKey: 32


### PR DESCRIPTION
Summary: Unity example configs had acqf in the strategy block as it used to be able to support. This is no longer supporter. The acqf option now belongs in the acqf generator block.

Reviewed By: tymmsc

Differential Revision: D81690112


