### PR TITLE
Delegate train_inputs/train_targets properties to base model in ParameterTransformedModel to prevent shadowing

### DIFF
--- a/aepsych/transforms/parameters.py
+++ b/aepsych/transforms/parameters.py
@@ -788,6 +788,48 @@ class ParameterTransformedModel(ParameterTransformWrapper, ConfigurableMixin):
                 stacklevel=2,
             )
 
+    @property
+    def train_inputs(self) -> tuple[torch.Tensor, ...] | None:
+        inputs = self._base_obj.train_inputs
+        if inputs is not None:
+            return tuple(self.transforms.untransform(x) for x in inputs)
+        return None
+
+    @train_inputs.setter
+    def train_inputs(self, value: tuple[torch.Tensor, ...] | None) -> None:
+        if value is not None:
+            value = tuple(self.transforms.transform(x) for x in value)
+        self._base_obj.train_inputs = value
+
+    @property
+    def _train_inputs(self) -> tuple[torch.Tensor, ...] | None:
+        inputs = self._base_obj._train_inputs
+        if inputs is not None:
+            return tuple(self.transforms.untransform(x) for x in inputs)
+        return None
+
+    @_train_inputs.setter
+    def _train_inputs(self, value: tuple[torch.Tensor, ...] | None) -> None:
+        if value is not None:
+            value = tuple(self.transforms.transform(x) for x in value)
+        self._base_obj._train_inputs = value
+
+    @property
+    def train_targets(self) -> torch.Tensor | None:
+        return self._base_obj.train_targets
+
+    @train_targets.setter
+    def train_targets(self, value: torch.Tensor | None) -> None:
+        self._base_obj.train_targets = value
+
+    @property
+    def _train_targets(self) -> torch.Tensor | None:
+        return self._base_obj._train_targets
+
+    @_train_targets.setter
+    def _train_targets(self, value: torch.Tensor | None) -> None:
+        self._base_obj._train_targets = value
+
     def __reduce__(self):
         # Helps pickle work (not dill)
         return (ParameterTransformedModel, (self._base_obj, self.transforms))


### PR DESCRIPTION
Summary: Delegate train_inputs and train_targets (including underscored variants) to the wrapped base model to prevent attribute shadowing. This fixes stale reads/writes caused by property setters writing to the wrapper’s __dict__ under dynamic inheritance in AEPsych.

Differential Revision: D90807862


