### PR TITLE
Remove mypy from actions

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -34,10 +34,11 @@ jobs:
       - name: Lint aepsych with ruff
         run: |
           ruff check --select=E9,F63,F7,F82 --output-format github
-
-      - name: Type check aepsych with mypy
-        if: always()
-        run: mypy --config-file mypy.ini
+      
+      #### REMOVED: can't upkeep right now due to upstream API changes
+      # - name: Type check aepsych with mypy
+      #   if: always()
+      #   run: mypy --config-file mypy.ini
 
       - name: Lint aepsych_client with ruff
         if: always()
@@ -45,10 +46,11 @@ jobs:
           ruff check --select=E9,F63,F7,F82 --output-format github
         working-directory: clients/python
 
-      - name: Type check aepsych_client with mypy
-        if: always()
-        run: mypy --config-file mypy.ini
-        working-directory: clients/python
+      #### REMOVED: can't upkeep right now due to upstream API changes.
+      # - name: Type check aepsych_client with mypy
+      #   if: always()
+      #   run: mypy --config-file mypy.ini
+      #   working-directory: clients/python
 
       - uses: omnilib/ufmt@action-v1
         if: always()


### PR DESCRIPTION
Summary: We can’t keep supporting mypy given some larger API changes that don’t actually break our code but messed with type checking. We need larger refactors to make this work but we can’t support it right now. So temporarily disabling mypy with note.

Differential Revision: D91599368


