### PR TITLE
Remove stale "database" subcommand from AEPsych website docs

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -119,7 +119,7 @@ class Index extends React.Component {
     `;
 
     const runServerBlock = `${pre}bash
-    aepsych_server --port 5555 --ip 0.0.0.0 database --db mydatabase.db
+    aepsych_server --port 5555 --ip 0.0.0.0 --db mydatabase.db
     `;
 
     const messageTemplateBlock = `${pre}json


### PR DESCRIPTION
Summary:
**Context:**
The AEPsych server CLI was refactored in D42038037 (Dec 2022) to remove the
`database` subcommand. The `--db` flag became a direct argument to the main
parser. However, the front page of the AEPsych docs site was never updated.

**Motivation:**
Users copying the server start command from the docs get an error because the
`database` subcommand no longer exists.

**This diff:**
- Remove the stale `database` word from the server start command on the
  AEPsych website homepage, changing from
  `aepsych_server --port 5555 --ip 0.0.0.0 database --db mydatabase.db` to
  `aepsych_server --port 5555 --ip 0.0.0.0 --db mydatabase.db`

Differential Revision: D96764511


